### PR TITLE
feat(ux): Passwort-Anzeigen-Toggle für alle Passwort-Felder

### DIFF
--- a/frontend/src/components/PasswordInput.tsx
+++ b/frontend/src/components/PasswordInput.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import { Eye, EyeOff } from 'lucide-react'
+
+interface PasswordInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  className?: string
+}
+
+export default function PasswordInput({ className = '', ...props }: PasswordInputProps) {
+  const [visible, setVisible] = useState(false)
+
+  return (
+    <div className="relative">
+      <input
+        {...props}
+        type={visible ? 'text' : 'password'}
+        className={`${className} pr-10`}
+      />
+      <button
+        type="button"
+        onClick={() => setVisible(v => !v)}
+        className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-400 hover:text-gray-600 focus:outline-none"
+        tabIndex={-1}
+        aria-label={visible ? 'Passwort verbergen' : 'Passwort anzeigen'}
+      >
+        {visible ? <EyeOff size={18} /> : <Eye size={18} />}
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -2,6 +2,7 @@ import { useState, FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../stores/authStore';
 import { LogIn, FileText } from 'lucide-react';
+import PasswordInput from '../components/PasswordInput';
 
 export default function Login() {
   const [username, setUsername] = useState('');
@@ -64,9 +65,8 @@ export default function Login() {
             <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
               Passwort
             </label>
-            <input
+            <PasswordInput
               id="password"
-              type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useAuthStore } from '../stores/authStore';
 import apiClient from '../api/client';
 import { Lock, Save, Palette } from 'lucide-react';
+import PasswordInput from '../components/PasswordInput';
 
 // 12 beautiful pastel colors for calendar
 const PASTEL_COLORS = [
@@ -214,8 +215,7 @@ export default function Profile() {
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 Aktuelles Passwort
               </label>
-              <input
-                type="password"
+              <PasswordInput
                 value={passwordData.current_password}
                 onChange={(e) =>
                   setPasswordData({ ...passwordData, current_password: e.target.value })
@@ -227,8 +227,7 @@ export default function Profile() {
 
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Neues Passwort</label>
-              <input
-                type="password"
+              <PasswordInput
                 value={passwordData.new_password}
                 onChange={(e) => setPasswordData({ ...passwordData, new_password: e.target.value })}
                 required
@@ -241,8 +240,7 @@ export default function Profile() {
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 Passwort bestätigen
               </label>
-              <input
-                type="password"
+              <PasswordInput
                 value={passwordData.confirm_password}
                 onChange={(e) =>
                   setPasswordData({ ...passwordData, confirm_password: e.target.value })

--- a/frontend/src/pages/admin/Users.tsx
+++ b/frontend/src/pages/admin/Users.tsx
@@ -6,6 +6,7 @@ import { useToast } from '../../contexts/ToastContext';
 import { useConfirm } from '../../hooks/useConfirm';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import LoadingSpinner from '../../components/LoadingSpinner';
+import PasswordInput from '../../components/PasswordInput';
 import Badge from '../../components/Badge';
 
 interface User {
@@ -463,9 +464,8 @@ export default function Users() {
               {!editingId && (
                 <div>
                   <label htmlFor="f-password" className="block text-sm font-medium text-gray-700 mb-1">Passwort *</label>
-                  <input
+                  <PasswordInput
                     id="f-password"
-                    type="password"
                     value={formData.password}
                     onChange={(e) => setFormData({ ...formData, password: e.target.value })}
                     required
@@ -1225,8 +1225,7 @@ export default function Users() {
                 <p className="text-sm text-gray-600 mb-3">
                   Neues Passwort für <strong>{setPasswordModal.userName}</strong>:
                 </p>
-                <input
-                  type="password"
+                <PasswordInput
                   value={newPassword}
                   onChange={(e) => setNewPassword(e.target.value)}
                   placeholder="Neues Passwort (mind. 8 Zeichen)"


### PR DESCRIPTION
## Summary

- Neue `PasswordInput`-Komponente mit Eye/EyeOff-Icon (lucide-react)
- Toggle schaltet zwischen `type="password"` und `type="text"` um
- `tabIndex={-1}` am Button – stört Tab-Navigation nicht

## Betroffene Felder (6 total)

| Seite | Feld |
|-------|------|
| Login | Passwort |
| Profil | Aktuelles Passwort, Neues Passwort, Passwort bestätigen |
| Admin → Benutzer | Passwort (anlegen), Passwort setzen (Modal) |

## Test plan

- [ ] Login-Seite: Auge-Icon sichtbar, Toggle funktioniert
- [ ] Profil → Passwort ändern: alle 3 Felder togglebar
- [ ] Admin → Benutzer anlegen: Passwort-Feld togglebar
- [ ] Admin → Passwort setzen Modal: Feld togglebar
- [ ] Tab-Navigation überspringt den Toggle-Button

🤖 Generated with [Claude Code](https://claude.com/claude-code)