### PR TITLE
feat: YTD-Jahresübersicht + Vorjahresübernahme (#54, #55)

### DIFF
--- a/backend/alembic/versions/2026_03_15_1400-026_add_year_carryovers.py
+++ b/backend/alembic/versions/2026_03_15_1400-026_add_year_carryovers.py
@@ -1,0 +1,35 @@
+"""Add year_carryovers table for overtime and vacation carryover from previous year
+
+Revision ID: 026_add_year_carryovers
+Revises: 025_add_profile_picture
+Create Date: 2026-03-15
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '026_add_year_carryovers'
+down_revision = '025_add_profile_picture'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'year_carryovers',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text('gen_random_uuid()')),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False, index=True),
+        sa.Column('year', sa.Integer(), nullable=False),
+        sa.Column('overtime_hours', sa.Numeric(8, 2), nullable=False, server_default='0'),
+        sa.Column('vacation_days', sa.Numeric(4, 1), nullable=False, server_default='0'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint('user_id', 'year', name='uq_year_carryover_user_year'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('year_carryovers')

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.company_closure import CompanyClosure
 from app.models.error_log import ErrorLog
 from app.models.vacation_request import VacationRequest, VacationRequestStatus
 from app.models.system_setting import SystemSetting
+from app.models.year_carryover import YearCarryover
 
 __all__ = [
     "User",
@@ -27,4 +28,5 @@ __all__ = [
     "VacationRequest",
     "VacationRequestStatus",
     "SystemSetting",
+    "YearCarryover",
 ]

--- a/backend/app/models/year_carryover.py
+++ b/backend/app/models/year_carryover.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Numeric, Integer, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+import uuid
+from app.database import Base
+
+
+class YearCarryover(Base):
+    """Stores overtime hours and vacation days carried over from the previous year."""
+
+    __tablename__ = "year_carryovers"
+    __table_args__ = (
+        UniqueConstraint('user_id', 'year', name='uq_year_carryover_user_year'),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    year = Column(Integer, nullable=False)  # The year these carryovers apply TO
+    overtime_hours = Column(Numeric(8, 2), nullable=False, default=0)  # Overtime hours from previous year
+    vacation_days = Column(Numeric(4, 1), nullable=False, default=0)  # Vacation days from previous year
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    def __repr__(self):
+        return f"<YearCarryover(user_id={self.user_id}, year={self.year}, overtime={self.overtime_hours}h, vacation={self.vacation_days}d)>"

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -5,12 +5,13 @@ from sqlalchemy import extract, func
 from typing import List, Optional
 from datetime import date, datetime, timezone, timedelta
 from app.database import get_db
-from app.models import User, TimeEntry, Absence, WorkingHoursChange, ChangeRequest, ChangeRequestStatus, ChangeRequestType, TimeEntryAuditLog, UserRole, PublicHoliday, AbsenceType
+from app.models import User, TimeEntry, Absence, WorkingHoursChange, ChangeRequest, ChangeRequestStatus, ChangeRequestType, TimeEntryAuditLog, UserRole, PublicHoliday, AbsenceType, YearCarryover
 from app.models.vacation_request import VacationRequest, VacationRequestStatus
 from app.models.system_setting import SystemSetting
 from app.middleware.auth import require_admin
 from app.schemas.user import UserCreate, UserUpdate, UserResponse, UserCreateResponse, AdminSetPassword, UserListResponse
 from app.schemas.working_hours_change import WorkingHoursChangeCreate, WorkingHoursChangeResponse
+from app.schemas.year_carryover import YearCarryoverCreate, YearCarryoverResponse
 from app.schemas.change_request import ChangeRequestResponse, ChangeRequestReview
 from app.schemas.time_entry import TimeEntryCreate, TimeEntryResponse, TimeEntryUpdate
 from app.schemas.time_entry_audit_log import AuditLogResponse
@@ -1120,3 +1121,62 @@ def review_vacation_request(
     db.commit()
     db.refresh(vr)
     return _enrich_vr_response(vr, db)
+
+
+# ──────────────────── Year Carryover ────────────────────
+
+
+@router.get("/users/{user_id}/carryovers", response_model=List[YearCarryoverResponse])
+def list_carryovers(
+    user_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    """List all year carryovers for a user."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
+
+    carryovers = db.query(YearCarryover).filter(
+        YearCarryover.user_id == user_id
+    ).order_by(YearCarryover.year.desc()).all()
+
+    return carryovers
+
+
+@router.put("/users/{user_id}/carryovers/{year}", response_model=YearCarryoverResponse)
+def upsert_carryover(
+    user_id: str,
+    year: int,
+    data: YearCarryoverCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    """Create or update year carryover (overtime hours & vacation days from previous year)."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
+
+    if year < 2000 or year > 2100:
+        raise HTTPException(status_code=400, detail="Ungültiges Jahr")
+
+    carryover = db.query(YearCarryover).filter(
+        YearCarryover.user_id == user_id,
+        YearCarryover.year == year,
+    ).first()
+
+    if carryover:
+        carryover.overtime_hours = data.overtime_hours
+        carryover.vacation_days = data.vacation_days
+    else:
+        carryover = YearCarryover(
+            user_id=user_id,
+            year=year,
+            overtime_hours=data.overtime_hours,
+            vacation_days=data.vacation_days,
+        )
+        db.add(carryover)
+
+    db.commit()
+    db.refresh(carryover)
+    return carryover

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from app.database import get_db
 from app.models import User, TimeEntry, UserRole
 from app.middleware.auth import get_current_user
-from app.schemas.reports import MonthlyDashboard, OvertimeAccount, OvertimeHistory, VacationAccount
+from app.schemas.reports import MonthlyDashboard, OvertimeAccount, OvertimeHistory, VacationAccount, YtdOvertime
 from app.services import calculation_service
 from sqlalchemy import extract
 
@@ -96,6 +96,27 @@ def get_overtime_account(
     return OvertimeAccount(
         current_balance=current_balance,
         history=history
+    )
+
+
+@router.get("/ytd-overtime", response_model=YtdOvertime)
+def get_ytd_overtime(
+    year: Optional[int] = Query(None, description="Year (default: current year)"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    """
+    Get year-to-date overtime summary.
+    Calculates target and actual hours from Jan 1 to today.
+    """
+    now = datetime.now()
+    year = year or now.year
+
+    summary = calculation_service.get_ytd_summary(db, current_user, year)
+
+    return YtdOvertime(
+        year=year,
+        **summary
     )
 
 

--- a/backend/app/schemas/reports.py
+++ b/backend/app/schemas/reports.py
@@ -29,6 +29,15 @@ class OvertimeAccount(BaseModel):
     history: List[OvertimeHistory]
 
 
+class YtdOvertime(BaseModel):
+    """Year-to-date overtime summary (Jan 1 to today)."""
+    year: int
+    target_hours: float
+    actual_hours: float
+    overtime: float
+    carryover_hours: float = 0.0
+
+
 class VacationAccount(BaseModel):
     """Vacation account for a year."""
     year: int

--- a/backend/app/schemas/year_carryover.py
+++ b/backend/app/schemas/year_carryover.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, Field, field_serializer
+from uuid import UUID
+from datetime import datetime
+from typing import Optional
+
+
+class YearCarryoverCreate(BaseModel):
+    """Create or update year carryover for a user."""
+    overtime_hours: float = Field(default=0, ge=-9999, le=9999)
+    vacation_days: float = Field(default=0, ge=-50, le=50)
+
+
+class YearCarryoverResponse(BaseModel):
+    """Year carryover response."""
+    id: UUID
+    user_id: UUID
+    year: int
+    overtime_hours: float
+    vacation_days: float
+    created_at: datetime
+    updated_at: datetime
+
+    @field_serializer('id', 'user_id')
+    def serialize_uuid(self, value: UUID) -> str:
+        return str(value)
+
+    class Config:
+        from_attributes = True

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -4,7 +4,7 @@ from calendar import monthrange
 from typing import Dict
 from sqlalchemy.orm import Session
 from sqlalchemy import func, extract
-from app.models import User, TimeEntry, Absence, PublicHoliday, AbsenceType, WorkingHoursChange
+from app.models import User, TimeEntry, Absence, PublicHoliday, AbsenceType, WorkingHoursChange, YearCarryover
 
 
 def get_weekly_hours_for_date(db: Session, user: User, target_date: date) -> Decimal:
@@ -323,8 +323,16 @@ def get_overtime_account(db: Session, user: User, up_to_year: int, up_to_month: 
                 break
         return result
 
+    # --- year carryovers (overtime from previous years) ---
+    carryovers = db.query(YearCarryover).filter(
+        YearCarryover.user_id == user.id,
+        YearCarryover.year >= first_entry.date.year,
+        YearCarryover.year <= up_to_year,
+    ).all()
+    carryover_total = sum((Decimal(str(c.overtime_hours)) for c in carryovers), start=Decimal('0'))
+
     # --- iterate months and compute balance in memory ---
-    total_balance = Decimal('0.00')
+    total_balance = carryover_total
     current_year, current_month = first_entry.date.year, first_entry.date.month
 
     while (current_year < up_to_year) or (current_year == up_to_year and current_month <= up_to_month):
@@ -353,6 +361,100 @@ def get_overtime_account(db: Session, user: User, up_to_year: int, up_to_month: 
             current_month += 1
 
     return total_balance.quantize(Decimal('0.01'))
+
+
+def get_ytd_summary(db: Session, user: User, year: int = None) -> Dict:
+    """
+    Calculate year-to-date summary from Jan 1 to today.
+
+    Sums daily targets and actual hours for all working days from Jan 1
+    of the given year up to and including today.
+
+    Args:
+        db: Database session
+        user: User object
+        year: Year (default: current year)
+
+    Returns:
+        Dict with target_hours, actual_hours, overtime
+    """
+    if not user.track_hours:
+        return {"target_hours": 0.0, "actual_hours": 0.0, "overtime": 0.0}
+
+    today = date.today()
+    if year is None:
+        year = today.year
+
+    # End date: today if current year, else Dec 31
+    end = today if year == today.year else date(year, 12, 31)
+    start = date(year, 1, 1)
+
+    if start > end:
+        return {"target_hours": 0.0, "actual_hours": 0.0, "overtime": 0.0}
+
+    # Fetch holidays in range
+    holidays = db.query(PublicHoliday).filter(
+        PublicHoliday.date >= start,
+        PublicHoliday.date <= end,
+    ).all()
+    holiday_dates: set = {h.date for h in holidays}
+
+    # Fetch absences in range (exclude TRAINING - same as get_monthly_target)
+    absences = db.query(Absence).filter(
+        Absence.user_id == user.id,
+        Absence.date >= start,
+        Absence.date <= end,
+        Absence.type != AbsenceType.TRAINING,
+    ).all()
+    absence_dates: set = {a.date for a in absences}
+
+    # Fetch working hours changes
+    wh_changes = db.query(WorkingHoursChange).filter(
+        WorkingHoursChange.user_id == user.id,
+    ).order_by(WorkingHoursChange.effective_from).all()
+
+    def _weekly_hours_for_date(d: date) -> Decimal:
+        result = Decimal(str(user.weekly_hours))
+        for change in wh_changes:
+            if change.effective_from <= d:
+                result = Decimal(str(change.weekly_hours))
+            else:
+                break
+        return result
+
+    # Sum daily targets
+    total_target = Decimal('0')
+    current = start
+    while current <= end:
+        if current.weekday() < 5 and current not in holiday_dates and current not in absence_dates:
+            weekly_hours = _weekly_hours_for_date(current)
+            daily_target = get_daily_target_for_date(user, current, weekly_hours)
+            total_target += daily_target
+        current += timedelta(days=1)
+
+    # Sum actual hours
+    entries = db.query(TimeEntry).filter(
+        TimeEntry.user_id == user.id,
+        TimeEntry.date >= start,
+        TimeEntry.date <= end,
+    ).all()
+    total_actual = sum((Decimal(str(e.net_hours)) for e in entries), start=Decimal('0'))
+
+    # Include overtime carryover for this year
+    carryover = db.query(YearCarryover).filter(
+        YearCarryover.user_id == user.id,
+        YearCarryover.year == year,
+    ).first()
+    carryover_hours = Decimal(str(carryover.overtime_hours)) if carryover else Decimal('0')
+
+    overtime = total_actual - total_target + carryover_hours
+
+    return {
+        "target_hours": float(total_target.quantize(Decimal('0.01'))),
+        "actual_hours": float(total_actual.quantize(Decimal('0.01'))),
+        "overtime": float(overtime.quantize(Decimal('0.01'))),
+        "carryover_hours": float(carryover_hours.quantize(Decimal('0.01'))),
+    }
 
 
 def get_vacation_account(db: Session, user: User, year: int) -> Dict:
@@ -398,6 +500,14 @@ def get_vacation_account(db: Session, user: User, year: int) -> Dict:
         months_worked = Decimal(str(lwd.month - 1)) + Decimal(str(days_worked)) / Decimal(str(days_in_month))
         budget_days_last = (Decimal(str(user.vacation_days)) * months_worked / Decimal('12')).quantize(Decimal('0.1'))
         budget_days = min(budget_days, budget_days_last)
+    # Add carryover vacation days from previous year
+    carryover = db.query(YearCarryover).filter(
+        YearCarryover.user_id == user.id,
+        YearCarryover.year == year,
+    ).first()
+    carryover_days = Decimal(str(carryover.vacation_days)) if carryover else Decimal('0')
+    budget_days += carryover_days
+
     budget_hours = budget_days * daily_target
 
     # Calculate used vacation hours

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -52,6 +52,14 @@ interface YearlyAbsenceSummary {
   total_days: number;
 }
 
+interface YtdOvertime {
+  year: number;
+  target_hours: number;
+  actual_hours: number;
+  overtime: number;
+  carryover_hours: number;
+}
+
 interface NextVacation {
   date: string;
   end_date?: string;
@@ -94,6 +102,7 @@ export default function Dashboard() {
   const [overtimeAccount, setOvertimeAccount] = useState<OvertimeAccount | null>(null);
   const [vacationAccount, setVacationAccount] = useState<VacationAccount | null>(null);
   const [yearlyAbsences, setYearlyAbsences] = useState<YearlyAbsenceSummary | null>(null);
+  const [ytdOvertime, setYtdOvertime] = useState<YtdOvertime | null>(null);
   const [teamAbsences, setTeamAbsences] = useState<TeamAbsence[]>([]);
   const [nextVacation, setNextVacation] = useState<NextVacation | null>(null);
   const [loading, setLoading] = useState(true);
@@ -103,13 +112,14 @@ export default function Dashboard() {
     const fetchData = async () => {
       try {
         const currentYear = new Date().getFullYear();
-        const [dashboardRes, overtimeRes, vacationRes, teamAbsencesRes, absencesRes, nextVacationRes] = await Promise.all([
+        const [dashboardRes, overtimeRes, vacationRes, teamAbsencesRes, absencesRes, nextVacationRes, ytdRes] = await Promise.all([
           apiClient.get('/dashboard'),
           apiClient.get('/dashboard/overtime'),
           apiClient.get('/dashboard/vacation'),
           apiClient.get('/absences/team/upcoming'),
           apiClient.get('/absences', { params: { year: currentYear } }),
           apiClient.get('/absences/next-vacation'),
+          apiClient.get('/dashboard/ytd-overtime'),
         ]);
 
         setDashboardData(dashboardRes.data);
@@ -117,6 +127,7 @@ export default function Dashboard() {
         setVacationAccount(vacationRes.data);
         setTeamAbsences(teamAbsencesRes.data);
         setNextVacation(nextVacationRes.data);
+        setYtdOvertime(ytdRes.data);
 
         // Calculate yearly absence summary
         const absences: AbsenceEntry[] = absencesRes.data;
@@ -378,36 +389,74 @@ export default function Dashboard() {
 
       {showDetails && (
         <>
-          {/* Yearly Absence Overview */}
-          {trackHours && yearlyAbsences && (
+          {/* Yearly Overview */}
+          {trackHours && (yearlyAbsences || ytdOvertime) && (
             <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-8">
               <h2 className="text-xl font-bold text-gray-900 mb-6">Jahresübersicht {new Date().getFullYear()}</h2>
-              <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-                <div className="text-center">
-                  <div className="text-3xl font-bold text-blue-600">{yearlyAbsences.vacation_days.toFixed(1)}</div>
-                  <div className="text-sm text-gray-600 mt-1">Urlaub</div>
+
+              {/* YTD Overtime Summary */}
+              {ytdOvertime && (
+                <div className="mb-6 p-4 bg-gray-50 rounded-lg">
+                  <h3 className="text-sm font-medium text-gray-600 mb-3">Stunden 01.01. bis heute</h3>
+                  <div className={`grid ${ytdOvertime.carryover_hours !== 0 ? 'grid-cols-2 md:grid-cols-4' : 'grid-cols-3'} gap-4`}>
+                    <div className="text-center">
+                      <div className="text-2xl font-bold text-gray-700">{ytdOvertime.target_hours.toFixed(1)}h</div>
+                      <div className="text-sm text-gray-500 mt-1">Soll</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-2xl font-bold text-gray-700">{ytdOvertime.actual_hours.toFixed(1)}h</div>
+                      <div className="text-sm text-gray-500 mt-1">Ist</div>
+                    </div>
+                    {ytdOvertime.carryover_hours !== 0 && (
+                      <div className="text-center">
+                        <div className={`text-2xl font-bold ${ytdOvertime.carryover_hours >= 0 ? 'text-blue-600' : 'text-orange-600'}`}>
+                          {ytdOvertime.carryover_hours >= 0 ? '+' : ''}{ytdOvertime.carryover_hours.toFixed(1)}h
+                        </div>
+                        <div className="text-sm text-gray-500 mt-1">Übertrag Vorjahr</div>
+                      </div>
+                    )}
+                    <div className="text-center">
+                      <div className={`text-2xl font-bold ${ytdOvertime.overtime >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                        {ytdOvertime.overtime >= 0 ? '+' : ''}{ytdOvertime.overtime.toFixed(1)}h
+                      </div>
+                      <div className="text-sm text-gray-500 mt-1">Überstunden</div>
+                    </div>
+                  </div>
                 </div>
-                <div className="text-center">
-                  <div className="text-3xl font-bold text-red-600">{yearlyAbsences.sick_days.toFixed(1)}</div>
-                  <div className="text-sm text-gray-600 mt-1">Krank</div>
+              )}
+
+              {/* Absence Summary */}
+              {yearlyAbsences && (
+                <div>
+                  <h3 className="text-sm font-medium text-gray-600 mb-3">Abwesenheiten</h3>
+                  <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-blue-600">{yearlyAbsences.vacation_days.toFixed(1)}</div>
+                      <div className="text-sm text-gray-600 mt-1">Urlaub</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-red-600">{yearlyAbsences.sick_days.toFixed(1)}</div>
+                      <div className="text-sm text-gray-600 mt-1">Krank</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-orange-600">{yearlyAbsences.training_days.toFixed(1)}</div>
+                      <div className="text-sm text-gray-600 mt-1">Fortbildung</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-purple-600">{yearlyAbsences.overtime_days.toFixed(1)}</div>
+                      <div className="text-sm text-gray-600 mt-1">Überstunden&shy;ausgleich</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-gray-600">{yearlyAbsences.other_days.toFixed(1)}</div>
+                      <div className="text-sm text-gray-600 mt-1">Sonstiges</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-gray-900">{yearlyAbsences.total_days.toFixed(1)}</div>
+                      <div className="text-sm text-gray-600 mt-1">Gesamt</div>
+                    </div>
+                  </div>
                 </div>
-                <div className="text-center">
-                  <div className="text-3xl font-bold text-orange-600">{yearlyAbsences.training_days.toFixed(1)}</div>
-                  <div className="text-sm text-gray-600 mt-1">Fortbildung</div>
-                </div>
-                <div className="text-center">
-                  <div className="text-3xl font-bold text-purple-600">{yearlyAbsences.overtime_days.toFixed(1)}</div>
-                  <div className="text-sm text-gray-600 mt-1">Überstunden&shy;ausgleich</div>
-                </div>
-                <div className="text-center">
-                  <div className="text-3xl font-bold text-gray-600">{yearlyAbsences.other_days.toFixed(1)}</div>
-                  <div className="text-sm text-gray-600 mt-1">Sonstiges</div>
-                </div>
-                <div className="text-center">
-                  <div className="text-3xl font-bold text-gray-900">{yearlyAbsences.total_days.toFixed(1)}</div>
-                  <div className="text-sm text-gray-600 mt-1">Gesamt</div>
-                </div>
-              </div>
+              )}
             </div>
           )}
 

--- a/frontend/src/pages/admin/Users.tsx
+++ b/frontend/src/pages/admin/Users.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import FocusTrap from 'focus-trap-react';
 import apiClient from '../../api/client';
-import { Plus, Edit2, Key, UserX, UserCheck, Save, X, Clock, Trash2, ArrowUp, ArrowDown, Search, Eye, EyeOff, UserMinus, BookOpen } from 'lucide-react';
+import { Plus, Edit2, Key, UserX, UserCheck, Save, X, Clock, Trash2, ArrowUp, ArrowDown, Search, Eye, EyeOff, UserMinus, BookOpen, ArrowLeftRight } from 'lucide-react';
 import { useToast } from '../../contexts/ToastContext';
 import { useConfirm } from '../../hooks/useConfirm';
 import ConfirmDialog from '../../components/ConfirmDialog';
@@ -52,6 +52,16 @@ interface WorkingHoursChange {
   weekly_hours: number;
   note?: string;
   created_at: string;
+}
+
+interface YearCarryover {
+  id: string;
+  user_id: string;
+  year: number;
+  overtime_hours: number;
+  vacation_days: number;
+  created_at: string;
+  updated_at: string;
 }
 
 /** Verbleibende Grace-Period-Tage (0 = abgelaufen / kein deactivated_at). */
@@ -105,6 +115,14 @@ export default function Users() {
   const [suggestedVacation, setSuggestedVacation] = useState<number | null>(null);
   const [setPasswordModal, setSetPasswordModal] = useState<{ userId: string; userName: string } | null>(null);
   const [newPassword, setNewPassword] = useState('');
+  const [showCarryoverModal, setShowCarryoverModal] = useState(false);
+  const [carryoverUser, setCarryoverUser] = useState<User | null>(null);
+  const [carryovers, setCarryovers] = useState<YearCarryover[]>([]);
+  const [carryoverFormData, setCarryoverFormData] = useState({
+    year: new Date().getFullYear(),
+    overtime_hours: 0,
+    vacation_days: 0,
+  });
   const { confirmState, confirm, handleConfirm, handleCancel } = useConfirm();
 
   // Sorting & Filtering
@@ -226,6 +244,62 @@ export default function Users() {
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Setzen des Passworts'));
     }
+  };
+
+  const handleOpenCarryover = async (user: User) => {
+    setCarryoverUser(user);
+    setCarryoverFormData({
+      year: new Date().getFullYear(),
+      overtime_hours: 0,
+      vacation_days: 0,
+    });
+    try {
+      const res = await apiClient.get(`/admin/users/${user.id}/carryovers`);
+      setCarryovers(res.data);
+
+      // Pre-fill form with current year's carryover if it exists
+      const currentYear = new Date().getFullYear();
+      const existing = res.data.find((c: YearCarryover) => c.year === currentYear);
+      if (existing) {
+        setCarryoverFormData({
+          year: currentYear,
+          overtime_hours: existing.overtime_hours,
+          vacation_days: existing.vacation_days,
+        });
+      }
+    } catch {
+      setCarryovers([]);
+    }
+    setShowCarryoverModal(true);
+  };
+
+  const handleCarryoverSubmit = async () => {
+    if (!carryoverUser) return;
+    try {
+      await apiClient.put(
+        `/admin/users/${carryoverUser.id}/carryovers/${carryoverFormData.year}`,
+        {
+          overtime_hours: carryoverFormData.overtime_hours,
+          vacation_days: carryoverFormData.vacation_days,
+        }
+      );
+      toast.success(`Übernahme für ${carryoverFormData.year} gespeichert`);
+      // Refresh list
+      const res = await apiClient.get(`/admin/users/${carryoverUser.id}/carryovers`);
+      setCarryovers(res.data);
+      fetchUsers(); // Refresh vacation info
+    } catch (error: any) {
+      toast.error(getErrorMessage(error, 'Fehler beim Speichern'));
+    }
+  };
+
+  const handleCarryoverYearChange = (year: number) => {
+    const existing = carryovers.find(c => c.year === year);
+    setCarryoverFormData({
+      year,
+      overtime_hours: existing?.overtime_hours ?? 0,
+      vacation_days: existing?.vacation_days ?? 0,
+    });
   };
 
   const handleDeactivate = (userId: string, name: string) => {
@@ -969,6 +1043,13 @@ export default function Users() {
                         <Clock size={16} />
                       </button>
                       <button
+                        onClick={() => handleOpenCarryover(user)}
+                        className="text-teal-600 hover:text-teal-800"
+                        title="Vorjahresübernahme"
+                      >
+                        <ArrowLeftRight size={16} />
+                      </button>
+                      <button
                         onClick={() => handleSetPassword(user.id, `${user.first_name} ${user.last_name}`)}
                         className="text-orange-600 hover:text-orange-800"
                         title="Passwort setzen"
@@ -1142,6 +1223,14 @@ export default function Users() {
                       title="Stundenverlauf"
                     >
                       <Clock size={16} />
+                    </button>
+                    <button
+                      onClick={() => handleOpenCarryover(user)}
+                      className="p-2 bg-teal-50 text-teal-600 rounded-lg hover:bg-teal-100 transition"
+                      aria-label="Vorjahresübernahme"
+                      title="Vorjahresübernahme"
+                    >
+                      <ArrowLeftRight size={16} />
                     </button>
                     <button
                       onClick={() => handleSetPassword(user.id, `${user.first_name} ${user.last_name}`)}
@@ -1442,6 +1531,124 @@ export default function Users() {
                 className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 px-4 py-2 rounded-lg transition"
               >
                 Abbrechen
+              </button>
+            </div>
+          </FocusTrap>
+        </div>
+      )}
+
+      {/* Carryover Modal */}
+      {showCarryoverModal && carryoverUser && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <FocusTrap focusTrapOptions={{ allowOutsideClick: true, onDeactivate: () => setShowCarryoverModal(false), initialFocus: false }}>
+            <div className="bg-white rounded-xl shadow-lg max-w-lg w-full p-6 max-h-[90vh] overflow-y-auto">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Vorjahresübernahme: {carryoverUser.first_name} {carryoverUser.last_name}
+                </h3>
+                <button
+                  onClick={() => setShowCarryoverModal(false)}
+                  className="text-gray-400 hover:text-gray-600"
+                >
+                  <X size={20} />
+                </button>
+              </div>
+
+              <p className="text-sm text-gray-600 mb-4">
+                Überstunden und Resturlaub aus dem Vorjahr übernehmen. Die Werte werden auf das Stundenkonto bzw. den Jahresurlaub angerechnet.
+              </p>
+
+              {/* Year selector */}
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-1">Jahr</label>
+                <select
+                  value={carryoverFormData.year}
+                  onChange={(e) => handleCarryoverYearChange(parseInt(e.target.value))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
+                >
+                  {Array.from({ length: 5 }, (_, i) => new Date().getFullYear() - 2 + i).map(y => (
+                    <option key={y} value={y}>{y}</option>
+                  ))}
+                </select>
+                <p className="text-xs text-gray-500 mt-1">
+                  Werte gelten als Übernahme <strong>in</strong> das gewählte Jahr
+                </p>
+              </div>
+
+              {/* Overtime hours */}
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-1">Überstunden aus Vorjahr (Stunden)</label>
+                <input
+                  type="number"
+                  step="0.5"
+                  value={carryoverFormData.overtime_hours}
+                  onChange={(e) => setCarryoverFormData({ ...carryoverFormData, overtime_hours: parseFloat(e.target.value) || 0 })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  Positive Werte = Überstunden-Guthaben, negative = Minusstunden
+                </p>
+              </div>
+
+              {/* Vacation days */}
+              <div className="mb-6">
+                <label className="block text-sm font-medium text-gray-700 mb-1">Resturlaub aus Vorjahr (Tage)</label>
+                <input
+                  type="number"
+                  step="0.5"
+                  value={carryoverFormData.vacation_days}
+                  onChange={(e) => setCarryoverFormData({ ...carryoverFormData, vacation_days: parseFloat(e.target.value) || 0 })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  Wird zum Jahresurlaub {carryoverFormData.year} addiert
+                </p>
+              </div>
+
+              <button
+                onClick={handleCarryoverSubmit}
+                className="w-full bg-primary hover:bg-primary-dark text-white px-4 py-3 rounded-lg flex items-center justify-center space-x-2 transition mb-3"
+              >
+                <Save size={18} />
+                <span>Speichern</span>
+              </button>
+
+              {/* Existing carryovers table */}
+              {carryovers.length > 0 && (
+                <div className="mt-4 border-t border-gray-200 pt-4">
+                  <h4 className="text-sm font-medium text-gray-700 mb-2">Gespeicherte Übernahmen</h4>
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-gray-500 border-b">
+                        <th className="py-1 pr-4">Jahr</th>
+                        <th className="py-1 pr-4">Überstunden</th>
+                        <th className="py-1">Resturlaub</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {carryovers.map(c => (
+                        <tr
+                          key={c.id}
+                          className={`border-b border-gray-100 cursor-pointer hover:bg-gray-50 ${c.year === carryoverFormData.year ? 'bg-blue-50' : ''}`}
+                          onClick={() => handleCarryoverYearChange(c.year)}
+                        >
+                          <td className="py-1.5 pr-4 font-medium">{c.year}</td>
+                          <td className={`py-1.5 pr-4 ${c.overtime_hours >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                            {c.overtime_hours >= 0 ? '+' : ''}{c.overtime_hours.toFixed(1)}h
+                          </td>
+                          <td className="py-1.5">{c.vacation_days.toFixed(1)} Tage</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+
+              <button
+                onClick={() => setShowCarryoverModal(false)}
+                className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 px-4 py-2 rounded-lg transition mt-3"
+              >
+                Schließen
               </button>
             </div>
           </FocusTrap>


### PR DESCRIPTION
## Summary
- **#54 Jahresübersicht**: Neuer `/api/dashboard/ytd-overtime` Endpoint berechnet Soll-/Ist-Stunden und Überstunden vom 01.01. bis heute. Dashboard zeigt Soll, Ist und Überstunden in der Jahresübersicht an.
- **#55 Vorjahresübernahme**: Neues `YearCarryover`-Modell (Migration 026) für jahresspezifische Übernahme von Überstunden und Resturlaub. Admin-Benutzerverwaltung mit Modal für CRUD. Carryover fließt automatisch in Überstundenkonto und Urlaubsbudget ein.

## Changes
- Backend: `YearCarryover` model, migration 026, schemas, admin endpoints (GET/PUT carryovers)
- Backend: `get_ytd_summary()` in calculation_service, `/api/dashboard/ytd-overtime` endpoint
- Backend: `get_overtime_account()`, `get_vacation_account()` berücksichtigen Carryover
- Frontend: Dashboard Jahresübersicht mit YTD Soll/Ist/Überstunden + Carryover-Anzeige
- Frontend: Admin Users Modal für Vorjahresübernahme (Überstunden + Resturlaub pro Jahr)

## Test plan
- [ ] `alembic upgrade head` — Migration 026 erstellt `year_carryovers` Tabelle
- [ ] Dashboard: Jahresübersicht zeigt Soll/Ist/Überstunden korrekt
- [ ] Admin: Vorjahresübernahme-Modal öffnen, Werte eingeben, speichern
- [ ] Carryover-Überstunden erscheinen im Überstundenkonto
- [ ] Carryover-Urlaubstage erhöhen das Jahres-Urlaubsbudget
- [ ] Dashboard zeigt "Übertrag Vorjahr" wenn Carryover vorhanden

Closes #54, Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)