### PR TITLE
fix: Admin-Jahresübersicht Überstunden bis heute statt Jahresende

### DIFF
--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -189,8 +189,10 @@ def get_yearly_absences(
         vacation_account = calculation_service.get_vacation_account(db, user, year)
         remaining_vacation_days = vacation_account['remaining_days']
 
-        # Calculate cumulative overtime for the year (up to December)
-        overtime_year = calculation_service.get_overtime_account(db, user, year, 12)
+        # Calculate cumulative overtime for the year (up to current month)
+        today = date.today()
+        up_to_month = today.month if year == today.year else 12
+        overtime_year = calculation_service.get_overtime_account(db, user, year, up_to_month)
 
         results.append(EmployeeYearlyAbsences(
             user_id=str(user.id),


### PR DESCRIPTION
## Summary
- Admin-Dashboard Jahresübersicht berechnete Überstunden mit `up_to_month=12` (ganzes Jahr), jetzt wird `today.month` verwendet wenn `year == aktuelles Jahr`

## Test plan
- [ ] Admin-Dashboard öffnen → Jahresübersicht → Überstunden entsprechen Stand heute, nicht Jahresende

🤖 Generated with [Claude Code](https://claude.com/claude-code)