### PR TITLE
fix: Carryover als Startbilanz + Jahresabschluss

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1180,3 +1180,30 @@ def upsert_carryover(
     db.commit()
     db.refresh(carryover)
     return carryover
+
+
+@router.post("/year-closing/{year}")
+def create_year_closing(
+    year: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    """
+    Create year-end closing: calculates overtime balance and remaining vacation
+    for all active users at Dec 31 and creates carryover records for year+1.
+    """
+    if year < 2000 or year > 2100:
+        raise HTTPException(status_code=400, detail="Ungültiges Jahr")
+
+    users = db.query(User).filter(
+        User.is_active == True,
+        User.track_hours == True,
+    ).all()
+
+    results = calculation_service.create_year_closing(db, year, users)
+
+    return {
+        "year": year,
+        "next_year": year + 1,
+        "employees": results,
+    }

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -251,10 +251,11 @@ def get_monthly_balance(db: Session, user: User, year: int, month: int) -> Decim
 
 def get_overtime_account(db: Session, user: User, up_to_year: int, up_to_month: int) -> Decimal:
     """
-    Calculate cumulative overtime account from employment start up to specified month.
+    Calculate cumulative overtime account up to specified month.
 
-    Optimised: fetches all time entries, absences, holidays, and working-hours changes
-    in a single batch (4 queries total) instead of 3+ queries per month.
+    If a YearCarryover exists, uses it as the starting balance and only
+    iterates months from that year forward (avoids double-counting).
+    Otherwise falls back to calculating from the first time entry.
 
     Args:
         db: Database session
@@ -270,23 +271,40 @@ def get_overtime_account(db: Session, user: User, up_to_year: int, up_to_month: 
 
     up_to_date = date(up_to_year, up_to_month, monthrange(up_to_year, up_to_month)[1])
 
+    # --- determine starting point ---
+    # Find the most recent carryover at or before up_to_year
+    latest_carryover = db.query(YearCarryover).filter(
+        YearCarryover.user_id == user.id,
+        YearCarryover.year <= up_to_year,
+    ).order_by(YearCarryover.year.desc()).first()
+
+    if latest_carryover:
+        # Start from Jan of the carryover year with the carryover value
+        start_year = latest_carryover.year
+        start_month = 1
+        initial_balance = Decimal(str(latest_carryover.overtime_hours))
+        start_date = date(start_year, 1, 1)
+    else:
+        # No carryover: start from first time entry
+        first_entry = db.query(TimeEntry).filter(
+            TimeEntry.user_id == user.id
+        ).order_by(TimeEntry.date).first()
+
+        if not first_entry:
+            return Decimal('0.00')
+
+        start_year = first_entry.date.year
+        start_month = first_entry.date.month
+        initial_balance = Decimal('0.00')
+        start_date = date(start_year, start_month, 1)
+
     # --- single-pass bulk fetches ---
-    first_entry = db.query(TimeEntry).filter(
-        TimeEntry.user_id == user.id
-    ).order_by(TimeEntry.date).first()
-
-    if not first_entry:
-        return Decimal('0.00')
-
-    start_date = date(first_entry.date.year, first_entry.date.month, 1)
-
     # All time entries in range (group by month in memory)
     entries = db.query(TimeEntry).filter(
         TimeEntry.user_id == user.id,
         TimeEntry.date >= start_date,
         TimeEntry.date <= up_to_date,
     ).all()
-    # month_key → sum of net_hours
     actual_by_month: Dict[tuple, Decimal] = {}
     for e in entries:
         key = (e.date.year, e.date.month)
@@ -323,17 +341,9 @@ def get_overtime_account(db: Session, user: User, up_to_year: int, up_to_month: 
                 break
         return result
 
-    # --- year carryovers (overtime from previous years) ---
-    carryovers = db.query(YearCarryover).filter(
-        YearCarryover.user_id == user.id,
-        YearCarryover.year >= first_entry.date.year,
-        YearCarryover.year <= up_to_year,
-    ).all()
-    carryover_total = sum((Decimal(str(c.overtime_hours)) for c in carryovers), start=Decimal('0'))
-
     # --- iterate months and compute balance in memory ---
-    total_balance = carryover_total
-    current_year, current_month = first_entry.date.year, first_entry.date.month
+    total_balance = initial_balance
+    current_year, current_month = start_year, start_month
 
     while (current_year < up_to_year) or (current_year == up_to_year and current_month <= up_to_month):
         key = (current_year, current_month)
@@ -554,3 +564,60 @@ def count_workdays(db: Session, start: date, end: date) -> int:
             count += 1
         cur += timedelta(days=1)
     return count
+
+
+def create_year_closing(db: Session, year: int, users: list) -> list:
+    """
+    Create year-end closing for all given users.
+
+    For each user, calculates the cumulative overtime balance at Dec 31
+    and the remaining vacation days, then creates/updates a YearCarryover
+    record for year+1.
+
+    Args:
+        db: Database session
+        year: The year being closed (carryovers are created for year+1)
+        users: List of User objects
+
+    Returns:
+        List of dicts with user info and carryover values
+    """
+    next_year = year + 1
+    results = []
+
+    for user in users:
+        # Calculate overtime balance at end of year
+        overtime_balance = get_overtime_account(db, user, year, 12)
+
+        # Calculate remaining vacation days
+        vacation_account = get_vacation_account(db, user, year)
+        remaining_vacation = Decimal(str(vacation_account['remaining_days']))
+
+        # Create or update carryover for next year
+        carryover = db.query(YearCarryover).filter(
+            YearCarryover.user_id == user.id,
+            YearCarryover.year == next_year,
+        ).first()
+
+        if carryover:
+            carryover.overtime_hours = overtime_balance
+            carryover.vacation_days = remaining_vacation
+        else:
+            carryover = YearCarryover(
+                user_id=user.id,
+                year=next_year,
+                overtime_hours=overtime_balance,
+                vacation_days=remaining_vacation,
+            )
+            db.add(carryover)
+
+        results.append({
+            "user_id": str(user.id),
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "overtime_hours": float(overtime_balance),
+            "vacation_days": float(remaining_vacation.quantize(Decimal('0.1'))),
+        })
+
+    db.commit()
+    return results

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -3,7 +3,7 @@ import { format } from 'date-fns';
 import { Link } from 'react-router-dom';
 import FocusTrap from 'focus-trap-react';
 import apiClient from '../../api/client';
-import { Users, Clock, TrendingUp, X, Calendar, FileText, ChevronRight, Mail, Briefcase, ArrowUp, ArrowDown, Search, Plus, Edit2, Trash2, Save, ScrollText } from 'lucide-react';
+import { Users, Clock, TrendingUp, X, Calendar, FileText, ChevronRight, Mail, Briefcase, ArrowUp, ArrowDown, Search, Plus, Edit2, Trash2, Save, ScrollText, BookCheck } from 'lucide-react';
 import { useToast } from '../../contexts/ToastContext';
 import { useConfirm } from '../../hooks/useConfirm';
 import ConfirmDialog from '../../components/ConfirmDialog';
@@ -131,6 +131,25 @@ export default function AdminDashboard() {
     } finally {
       setYearlyLoading(false);
     }
+  };
+
+  const handleYearClosing = () => {
+    confirm({
+      title: `Jahresabschluss ${currentYear}`,
+      message: `Überstunden-Saldo und Resturlaub aller aktiven Mitarbeiter werden berechnet und als Übernahme in ${currentYear + 1} gespeichert. Bestehende Übernahmen für ${currentYear + 1} werden überschrieben.\n\nFortfahren?`,
+      confirmLabel: 'Jahresabschluss erstellen',
+      variant: 'warning',
+      onConfirm: async () => {
+        try {
+          const res = await apiClient.post(`/admin/year-closing/${currentYear}`);
+          const count = res.data.employees?.length || 0;
+          toast.success(`Jahresabschluss ${currentYear} erstellt: ${count} Mitarbeiter übernommen nach ${currentYear + 1}`);
+          fetchYearlyAbsences();
+        } catch (error: any) {
+          toast.error(getErrorMessage(error, 'Fehler beim Jahresabschluss'));
+        }
+      },
+    });
   };
 
   const fetchEmployeeDetails = async (employee: EmployeeReport) => {
@@ -597,6 +616,14 @@ export default function AdminDashboard() {
               aria-label="Jahr"
               className="px-4 py-2 border border-gray-300 rounded-lg"
             />
+            <button
+              onClick={handleYearClosing}
+              className="bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-lg flex items-center space-x-2 transition"
+              title={`Jahresabschluss ${currentYear} erstellen`}
+            >
+              <BookCheck size={20} />
+              <span className="hidden sm:inline">Jahresabschluss</span>
+            </button>
             <Link
               to="/admin/reports"
               className="bg-primary hover:bg-primary-dark text-white px-4 py-2 rounded-lg flex items-center space-x-2 transition"


### PR DESCRIPTION
## Summary
- **Carryover-Fix**: `get_overtime_account()` nutzt den neuesten `YearCarryover` als Startbilanz und iteriert nur ab diesem Jahr — kein Doppelzählen mehr bei Jahresabschlüssen
- **Jahresabschluss**: Neuer `POST /api/admin/year-closing/{year}` Endpoint berechnet Überstundensaldo + Resturlaub aller aktiven MA und erstellt Carryovers für das Folgejahr
- **Admin-UI**: Jahresabschluss-Button in der Jahresübersicht (mit Bestätigungsdialog)

## Test plan
- [ ] Admin-Dashboard → Jahresübersicht → Überstunden enthalten Vorjahresübernahme
- [ ] Jahresabschluss-Button → Bestätigung → Carryovers für Folgejahr werden erstellt
- [ ] Erneuter Jahresabschluss überschreibt bestehende Carryovers (kein Doppeln)
- [ ] Mitarbeiter-Dashboard → Überstundenkonto korrekt mit Carryover

🤖 Generated with [Claude Code](https://claude.com/claude-code)