### PR TITLE
fix: Admin-Jahresübersicht mit YTD-Berechnung + Carryover

### DIFF
--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -189,10 +189,9 @@ def get_yearly_absences(
         vacation_account = calculation_service.get_vacation_account(db, user, year)
         remaining_vacation_days = vacation_account['remaining_days']
 
-        # Calculate cumulative overtime for the year (up to current month)
-        today = date.today()
-        up_to_month = today.month if year == today.year else 12
-        overtime_year = calculation_service.get_overtime_account(db, user, year, up_to_month)
+        # Calculate overtime for the year (up to today for current year, full year otherwise)
+        ytd = calculation_service.get_ytd_summary(db, user, year)
+        overtime_year = ytd['overtime']
 
         results.append(EmployeeYearlyAbsences(
             user_id=str(user.id),


### PR DESCRIPTION
## Summary
- Admin-Jahresübersicht nutzt jetzt `get_ytd_summary()` statt `get_overtime_account()` für Überstunden
- **Problem**: `get_overtime_account()` berechnet Soll-Stunden für den gesamten laufenden Monat, sodass der Rest des Monats als Minusstunden erscheint
- **Fix**: `get_ytd_summary()` rechnet nur bis heute und enthält den Carryover

## Verifiziert mit Prod-Backup
Celine Sperling (80,5h Vorjahresübernahme):
- **Vorher**: 6,75h (voller März-Soll von 163h abgezogen)
- **Nachher**: 92,75h (301,5h Soll bis heute, 313,75h Ist + 80,5h Carryover)

## Test plan
- [ ] Admin-Dashboard → Jahresübersicht → Überstunden = Ist - Soll (bis heute) + Carryover
- [ ] Celine Sperling zeigt 80,5h Carryover im Überstundensaldo

🤖 Generated with [Claude Code](https://claude.com/claude-code)