### PR TITLE
feat: Admin Eintragstyp-Auswahl (Arbeit/Krank/Fortbildung/etc.)

### DIFF
--- a/frontend/src/components/MonthlyJournal.tsx
+++ b/frontend/src/components/MonthlyJournal.tsx
@@ -52,6 +52,8 @@ interface EditState {
   startTime: string;    // "HH:mm"
   endTime: string;      // "HH:mm"
   breakMinutes: string; // string for <input> binding
+  entryType: 'work' | 'sick' | 'training' | 'overtime' | 'other';
+  absenceHours: string;
 }
 
 // ---- Helper functions -----------------------------------------------------
@@ -116,7 +118,7 @@ export default function MonthlyJournal({ userId, isAdminView }: MonthlyJournalPr
   const toast = useToast();
   const { confirmState, confirm, handleConfirm, handleCancel } = useConfirm();
   const [editingDate, setEditingDate] = useState<string | null>(null);
-  const [editState, setEditState] = useState<EditState>({ startTime: '', endTime: '', breakMinutes: '0' });
+  const [editState, setEditState] = useState<EditState>({ startTime: '', endTime: '', breakMinutes: '0', entryType: 'work', absenceHours: '8' });
   const [saving, setSaving] = useState(false);
   const [submittingDate, setSubmittingDate] = useState<string | null>(null);
   const [submitReason, setSubmitReason] = useState('');
@@ -149,11 +151,16 @@ export default function MonthlyJournal({ userId, isAdminView }: MonthlyJournalPr
 
   function startEdit(day: JournalDay) {
     const entry = day.time_entries[0] ?? null;
+    const absence = day.absences[0] ?? null;
+    const hasTimeEntry = !!entry;
+    const hasAbsence = !hasTimeEntry && !!absence;
     setEditingDate(day.date);
     setEditState({
       startTime: entry?.start_time ?? '',
       endTime: entry?.end_time ?? '',
       breakMinutes: String(entry?.break_minutes ?? 0),
+      entryType: hasAbsence ? (absence.type as EditState['entryType']) : 'work',
+      absenceHours: hasAbsence ? String(absence.hours) : '8',
     });
   }
 
@@ -163,26 +170,37 @@ export default function MonthlyJournal({ userId, isAdminView }: MonthlyJournalPr
   }
 
   async function handleAdminSave(day: JournalDay) {
-    const start = editState.startTime;
-    const end = editState.endTime;
-    if (!start || !end) {
-      toast.error('Von und Bis sind Pflichtfelder');
-      return;
-    }
     setSaving(true);
     try {
-      const payload = {
-        start_time: start,
-        end_time: end,
-        break_minutes: Math.min(parseInt(editState.breakMinutes, 10) || 0, 480),
-      };
-      const existing = day.time_entries[0];
-      if (existing) {
-        await apiClient.put(`/admin/time-entries/${existing.id}`, payload);
+      if (editState.entryType === 'work') {
+        const start = editState.startTime;
+        const end = editState.endTime;
+        if (!start || !end) {
+          toast.error('Von und Bis sind Pflichtfelder');
+          setSaving(false);
+          return;
+        }
+        const payload = {
+          start_time: start,
+          end_time: end,
+          break_minutes: Math.min(parseInt(editState.breakMinutes, 10) || 0, 480),
+        };
+        const existing = day.time_entries[0];
+        if (existing) {
+          await apiClient.put(`/admin/time-entries/${existing.id}`, payload);
+        } else {
+          await apiClient.post(`/admin/users/${userId}/time-entries`, {
+            date: day.date,
+            ...payload,
+          });
+        }
       } else {
-        await apiClient.post(`/admin/users/${userId}/time-entries`, {
+        // Absence entry
+        await apiClient.post('/absences', {
+          user_id: userId,
           date: day.date,
-          ...payload,
+          type: editState.entryType,
+          hours: parseFloat(editState.absenceHours) || 0,
         });
       }
       toast.success('Gespeichert');
@@ -367,36 +385,65 @@ export default function MonthlyJournal({ userId, isAdminView }: MonthlyJournalPr
                           {format(dateObj, 'EEE', { locale: de })}
                         </td>
                         <td className={`px-3 py-2 ${TYPE_COLORS[day.type]}`}>
-                          {day.is_holiday && day.holiday_name
-                            ? day.holiday_name
-                            : TYPE_LABELS[day.type] ?? day.type}
-                          {multiEntry && (
-                            <span className="ml-1 text-xs text-gray-400">
-                              ({day.time_entries.length}×)
-                            </span>
+                          {editingDate === day.date && isAdminView && !day.time_entries.length && !day.absences.length ? (
+                            <select
+                              value={editState.entryType}
+                              onChange={(e) => setEditState(s => ({ ...s, entryType: e.target.value as EditState['entryType'] }))}
+                              className="border border-gray-300 rounded px-1 py-0.5 text-sm"
+                            >
+                              <option value="work">Arbeit</option>
+                              <option value="sick">Krank</option>
+                              <option value="training">Fortbildung</option>
+                              <option value="overtime">ÜSt-Ausgleich</option>
+                              <option value="other">Sonstiges</option>
+                            </select>
+                          ) : (
+                            <>
+                              {day.is_holiday && day.holiday_name
+                                ? day.holiday_name
+                                : TYPE_LABELS[day.type] ?? day.type}
+                              {multiEntry && (
+                                <span className="ml-1 text-xs text-gray-400">
+                                  ({day.time_entries.length}×)
+                                </span>
+                              )}
+                            </>
                           )}
                         </td>
                         <td className="px-3 py-2 hidden md:table-cell text-gray-600 whitespace-nowrap">
                           {isGray ? '–' : editingDate === day.date ? (
-                            <div className="flex items-center gap-1">
+                            editState.entryType === 'work' ? (
+                              <div className="flex items-center gap-1">
+                                <input
+                                  type="time"
+                                  value={editState.startTime}
+                                  onChange={(e) => setEditState(s => ({ ...s, startTime: e.target.value }))}
+                                  className="w-[5.5rem] border border-gray-300 rounded px-1 py-0.5 text-sm"
+                                />
+                                <span className="text-gray-400">–</span>
+                                <input
+                                  type="time"
+                                  value={editState.endTime}
+                                  onChange={(e) => setEditState(s => ({ ...s, endTime: e.target.value }))}
+                                  className="w-[5.5rem] border border-gray-300 rounded px-1 py-0.5 text-sm"
+                                />
+                              </div>
+                            ) : (
                               <input
-                                type="time"
-                                value={editState.startTime}
-                                onChange={(e) => setEditState(s => ({ ...s, startTime: e.target.value }))}
-                                className="w-[5.5rem] border border-gray-300 rounded px-1 py-0.5 text-sm"
+                                type="number"
+                                step="0.5"
+                                min={0}
+                                max={24}
+                                value={editState.absenceHours}
+                                onChange={(e) => setEditState(s => ({ ...s, absenceHours: e.target.value }))}
+                                className="w-20 border border-gray-300 rounded px-1 py-0.5 text-sm"
+                                placeholder="Stunden"
                               />
-                              <span className="text-gray-400">–</span>
-                              <input
-                                type="time"
-                                value={editState.endTime}
-                                onChange={(e) => setEditState(s => ({ ...s, endTime: e.target.value }))}
-                                className="w-[5.5rem] border border-gray-300 rounded px-1 py-0.5 text-sm"
-                              />
-                            </div>
+                            )
                           ) : vonBis}
                         </td>
                         <td className="px-3 py-2 hidden md:table-cell text-right text-gray-500">
-                          {isGray ? '' : editingDate === day.date ? (
+                          {isGray ? '' : editingDate === day.date && editState.entryType === 'work' ? (
                             <input
                               type="number"
                               inputMode="numeric"
@@ -406,7 +453,7 @@ export default function MonthlyJournal({ userId, isAdminView }: MonthlyJournalPr
                               onChange={(e) => setEditState(s => ({ ...s, breakMinutes: e.target.value }))}
                               className="w-16 border border-gray-300 rounded px-1 py-0.5 text-sm text-right"
                             />
-                          ) : pause}
+                          ) : editingDate === day.date ? '' : pause}
                         </td>
                         <td className="px-3 py-2 text-right text-gray-700">
                           {isGray ? '' : formatHoursSimple(day.actual_hours)}

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -88,6 +88,8 @@ export default function AdminDashboard() {
     end_time: '17:00',
     break_minutes: 0,
     note: '',
+    entry_type: 'work' as 'work' | 'sick' | 'training' | 'overtime' | 'other',
+    absence_hours: 8,
   });
   const [auditLog, setAuditLog] = useState<any[]>([]);
   const [auditLoading, setAuditLoading] = useState(false);
@@ -220,18 +222,45 @@ export default function AdminDashboard() {
       end_time: entry.end_time.substring(0, 5),
       break_minutes: entry.break_minutes,
       note: entry.note || '',
+      entry_type: 'work',
+      absence_hours: 8,
     });
   };
 
   const handleAdminSaveEntry = async () => {
     if (!selectedEmployee) return;
     try {
-      if (editingEntryId) {
-        await apiClient.put(`/admin/time-entries/${editingEntryId}`, entryForm);
-        toast.success('Eintrag aktualisiert');
+      if (entryForm.entry_type === 'work') {
+        // Normal time entry
+        if (editingEntryId) {
+          await apiClient.put(`/admin/time-entries/${editingEntryId}`, {
+            date: entryForm.date,
+            start_time: entryForm.start_time,
+            end_time: entryForm.end_time,
+            break_minutes: entryForm.break_minutes,
+            note: entryForm.note,
+          });
+          toast.success('Eintrag aktualisiert');
+        } else {
+          await apiClient.post(`/admin/users/${selectedEmployee.user_id}/time-entries`, {
+            date: entryForm.date,
+            start_time: entryForm.start_time,
+            end_time: entryForm.end_time,
+            break_minutes: entryForm.break_minutes,
+            note: entryForm.note,
+          });
+          toast.success('Eintrag erstellt');
+        }
       } else {
-        await apiClient.post(`/admin/users/${selectedEmployee.user_id}/time-entries`, entryForm);
-        toast.success('Eintrag erstellt');
+        // Absence entry (sick, training, overtime comp, other)
+        await apiClient.post('/absences', {
+          user_id: selectedEmployee.user_id,
+          date: entryForm.date,
+          type: entryForm.entry_type,
+          hours: entryForm.absence_hours,
+          note: entryForm.note || null,
+        });
+        toast.success('Abwesenheit erstellt');
       }
       setEditingEntryId(null);
       setShowNewEntryForm(false);
@@ -240,6 +269,11 @@ export default function AdminDashboard() {
         params: { user_id: selectedEmployee.user_id, month: currentMonth }
       });
       setEmployeeTimeEntries(entriesResponse.data);
+      // Refresh absences
+      const absencesResponse = await apiClient.get('/absences', {
+        params: { user_id: selectedEmployee.user_id, year: currentMonth.split('-')[0] }
+      });
+      setEmployeeAbsences(absencesResponse.data);
       fetchAuditForUser(selectedEmployee.user_id);
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Speichern'));
@@ -1021,6 +1055,8 @@ export default function AdminDashboard() {
                             end_time: '17:00',
                             break_minutes: 0,
                             note: '',
+                            entry_type: 'work',
+                            absence_hours: 8,
                           });
                         }}
                         className="text-sm bg-primary hover:bg-primary-dark text-white px-3 py-1 rounded-lg flex items-center space-x-1 transition"
@@ -1034,6 +1070,20 @@ export default function AdminDashboard() {
                     {(editingEntryId || showNewEntryForm) && (
                       <div className="px-4 py-3 bg-blue-50 border-b border-blue-200">
                         <div className="grid grid-cols-2 md:grid-cols-5 gap-2 text-sm">
+                          {!editingEntryId && (
+                            <select
+                              value={entryForm.entry_type}
+                              onChange={(e) => setEntryForm({ ...entryForm, entry_type: e.target.value as any })}
+                              aria-label="Eintragstyp"
+                              className="px-2 py-1 border border-gray-300 rounded text-sm col-span-2 md:col-span-1"
+                            >
+                              <option value="work">Arbeit</option>
+                              <option value="sick">Krank</option>
+                              <option value="training">Fortbildung</option>
+                              <option value="overtime">Überstundenausgleich</option>
+                              <option value="other">Sonstiges</option>
+                            </select>
+                          )}
                           <input
                             type="date"
                             value={entryForm.date}
@@ -1041,29 +1091,45 @@ export default function AdminDashboard() {
                             aria-label="Datum"
                             className="px-2 py-1 border border-gray-300 rounded text-sm"
                           />
-                          <input
-                            type="time"
-                            value={entryForm.start_time}
-                            onChange={(e) => setEntryForm({ ...entryForm, start_time: e.target.value })}
-                            aria-label="Von (Uhrzeit)"
-                            className="px-2 py-1 border border-gray-300 rounded text-sm"
-                          />
-                          <input
-                            type="time"
-                            value={entryForm.end_time}
-                            onChange={(e) => setEntryForm({ ...entryForm, end_time: e.target.value })}
-                            aria-label="Bis (Uhrzeit)"
-                            className="px-2 py-1 border border-gray-300 rounded text-sm"
-                          />
-                          <input
-                            type="number"
-                            min="0"
-                            value={entryForm.break_minutes}
-                            onChange={(e) => setEntryForm({ ...entryForm, break_minutes: parseInt(e.target.value) || 0 })}
-                            placeholder="Pause (Min.)"
-                            aria-label="Pause in Minuten"
-                            className="px-2 py-1 border border-gray-300 rounded text-sm"
-                          />
+                          {(entryForm.entry_type === 'work' || editingEntryId) ? (
+                            <>
+                              <input
+                                type="time"
+                                value={entryForm.start_time}
+                                onChange={(e) => setEntryForm({ ...entryForm, start_time: e.target.value })}
+                                aria-label="Von (Uhrzeit)"
+                                className="px-2 py-1 border border-gray-300 rounded text-sm"
+                              />
+                              <input
+                                type="time"
+                                value={entryForm.end_time}
+                                onChange={(e) => setEntryForm({ ...entryForm, end_time: e.target.value })}
+                                aria-label="Bis (Uhrzeit)"
+                                className="px-2 py-1 border border-gray-300 rounded text-sm"
+                              />
+                              <input
+                                type="number"
+                                min="0"
+                                value={entryForm.break_minutes}
+                                onChange={(e) => setEntryForm({ ...entryForm, break_minutes: parseInt(e.target.value) || 0 })}
+                                placeholder="Pause (Min.)"
+                                aria-label="Pause in Minuten"
+                                className="px-2 py-1 border border-gray-300 rounded text-sm"
+                              />
+                            </>
+                          ) : (
+                            <input
+                              type="number"
+                              step="0.5"
+                              min="0"
+                              max="24"
+                              value={entryForm.absence_hours}
+                              onChange={(e) => setEntryForm({ ...entryForm, absence_hours: parseFloat(e.target.value) || 0 })}
+                              placeholder="Stunden"
+                              aria-label="Stunden"
+                              className="px-2 py-1 border border-gray-300 rounded text-sm"
+                            />
+                          )}
                           <input
                             type="text"
                             value={entryForm.note}


### PR DESCRIPTION
## Summary
- **AdminDashboard**: Neuer Eintrag-Formular hat Typ-Selector (Arbeit, Krank, Fortbildung, Überstundenausgleich, Sonstiges). Erstellt TimeEntry oder Absence je nach Typ.
- **MonthlyJournal**: Admin kann bei leeren Tagen den Eintragstyp wählen. Bei Abwesenheitstypen wird Stunden-Feld statt Von/Bis angezeigt.
- Employee Abwesenheitsseite unterstützt bereits alle Typen.

## Test plan
- [ ] AdminDashboard → MA auswählen → Neuer Eintrag → Typ = Krank → Stunden eingeben → erstellt Absence
- [ ] AdminDashboard → Neuer Eintrag → Typ = Arbeit → Von/Bis/Pause → erstellt TimeEntry
- [ ] MonthlyJournal → leerer Tag → Plus-Button → Typ-Selector → Fortbildung → Stunden → speichert Absence
- [ ] Bestehende TimeEntry-Bearbeitung funktioniert weiterhin

🤖 Generated with [Claude Code](https://claude.com/claude-code)