### PR TITLE
Phase 0 — Tenant Isolation belt-and-suspenders (SaaS prep)

### DIFF
--- a/backend/app/routers/admin_change_requests.py
+++ b/backend/app/routers/admin_change_requests.py
@@ -33,8 +33,10 @@ def get_pending_change_request_count(
     current_user: User = Depends(require_admin),
 ):
     """Return count of pending change requests for admin badge."""
+    # F-026: explicit tenant filter (RLS is the second line of defense).
     count = db.query(ChangeRequest).filter(
-        ChangeRequest.status == ChangeRequestStatus.PENDING
+        ChangeRequest.status == ChangeRequestStatus.PENDING,
+        ChangeRequest.tenant_id == current_user.tenant_id,
     ).count()
     return {"count": count}
 
@@ -51,7 +53,10 @@ def list_all_change_requests(
     current_user: User = Depends(require_admin),
 ):
     """List all change requests (admin view)."""
-    query = db.query(ChangeRequest)
+    # F-026: explicit tenant scope before any optional filter.
+    query = db.query(ChangeRequest).filter(
+        ChangeRequest.tenant_id == current_user.tenant_id,
+    )
     if request_status:
         try:
             status_enum = ChangeRequestStatus(request_status)
@@ -75,7 +80,16 @@ def get_change_request_admin(
     current_user: User = Depends(require_admin),
 ):
     """Get a specific change request (admin view)."""
-    cr = db.query(ChangeRequest).filter(ChangeRequest.id == request_id).first()
+    # F-026: scope by tenant so a guessed UUID from another tenant 404s
+    # instead of leaking via RLS-bypass paths.
+    cr = (
+        db.query(ChangeRequest)
+        .filter(
+            ChangeRequest.id == request_id,
+            ChangeRequest.tenant_id == current_user.tenant_id,
+        )
+        .first()
+    )
     if not cr:
         raise HTTPException(status_code=404, detail="Antrag nicht gefunden")
     return _enrich_cr_response(cr, db)

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -50,7 +50,10 @@ def list_users(
     current_user: User = Depends(require_admin)
 ):
     """List users (admin only). By default only active, visible users."""
-    query = db.query(User)
+    # F-026: belt-and-suspenders — RLS already scopes by tenant, but every
+    # list endpoint must add the explicit filter so a missing GUC cannot
+    # leak cross-tenant rows.
+    query = db.query(User).filter(User.tenant_id == current_user.tenant_id)
     if not include_inactive:
         query = query.filter(User.is_active == True)
     if not include_hidden:

--- a/backend/app/routers/holidays.py
+++ b/backend/app/routers/holidays.py
@@ -24,7 +24,7 @@ def list_holidays(
     """
     year = year or today_local().year
 
-    holidays = holiday_service.get_holidays(db, year)
+    holidays = holiday_service.get_holidays(db, year, tenant_id=current_user.tenant_id)
 
     return holidays
 

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -23,11 +23,15 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/admin/reports", tags=["admin-reports"], dependencies=[Depends(require_admin)])
 
 
-def _get_active_visible_users(db: Session) -> list:
-    """Return all active, non-hidden users ordered by name."""
+def _get_active_visible_users(db: Session, tenant_id) -> list:
+    """Return all active, non-hidden users for the given tenant, ordered by name.
+
+    F-026: explicit tenant filter (RLS is the second line of defense).
+    """
     return db.query(User).filter(
+        User.tenant_id == tenant_id,
         User.is_active == True,
-        User.is_hidden == False
+        User.is_hidden == False,
     ).order_by(User.last_name, User.first_name).all()
 
 
@@ -65,7 +69,7 @@ def get_monthly_report(
         db.add(audit)
         db.commit()
 
-    users = _get_active_visible_users(db)
+    users = _get_active_visible_users(db, current_user.tenant_id)
 
     reports = []
 
@@ -139,7 +143,7 @@ def get_yearly_absences(
         db.add(audit)
         db.commit()
 
-    users = _get_active_visible_users(db)
+    users = _get_active_visible_users(db, current_user.tenant_id)
 
     results = []
 
@@ -501,7 +505,7 @@ def get_sunday_summary(
     )
     min_free_sundays = 15
 
-    users = _get_active_visible_users(db)
+    users = _get_active_visible_users(db, current_user.tenant_id)
     result = []
 
     for user in users:
@@ -550,7 +554,7 @@ def get_night_work_summary(
     Night hours: 23:00–06:00. Reports how many days each employee
     performed night work and whether they qualify as Nachtarbeitnehmer (>=48 days/year).
     """
-    users = _get_active_visible_users(db)
+    users = _get_active_visible_users(db, current_user.tenant_id)
     result = []
     threshold = 48  # §6 ArbZG: Nachtarbeitnehmer if >= 48 days/year
 
@@ -609,7 +613,7 @@ def get_compensatory_rest(
     """
     from datetime import timedelta
 
-    users = _get_active_visible_users(db)
+    users = _get_active_visible_users(db, current_user.tenant_id)
     result = []
 
     for user in users:
@@ -711,7 +715,7 @@ def get_24_week_averaging_period(
         end_date = date.today()
     start_date = end_date - timedelta(weeks=24)
 
-    users = _get_active_visible_users(db)
+    users = _get_active_visible_users(db, current_user.tenant_id)
     result = []
 
     for user in users:

--- a/backend/app/services/holiday_service.py
+++ b/backend/app/services/holiday_service.py
@@ -125,11 +125,16 @@ def sync_holidays(db: Session, year: int, state: Optional[str] = None, tenant_id
     return count
 
 
-def get_holidays(db: Session, year: int) -> List[PublicHoliday]:
-    """Get all public holidays for a given year."""
-    return db.query(PublicHoliday).filter(
-        PublicHoliday.year == year
-    ).order_by(PublicHoliday.date).all()
+def get_holidays(db: Session, year: int, tenant_id=None) -> List[PublicHoliday]:
+    """Get all public holidays for a given year, scoped to the tenant.
+
+    F-026: explicit tenant filter — RLS already scopes, but holiday rows
+    are global-looking and easy to leak if the GUC is unset for any reason.
+    """
+    query = db.query(PublicHoliday).filter(PublicHoliday.year == year)
+    if tenant_id is not None:
+        query = query.filter(PublicHoliday.tenant_id == tenant_id)
+    return query.order_by(PublicHoliday.date).all()
 
 
 def is_holiday(db: Session, check_date: date, tenant_id=None) -> bool:

--- a/backend/tests/test_cross_tenant_api.py
+++ b/backend/tests/test_cross_tenant_api.py
@@ -192,6 +192,128 @@ def test_admin_a_cannot_approve_tenant_b_change_request(_db_session, client_as_a
     assert stored.status == ChangeRequestStatus.PENDING
 
 
+@pytest.fixture(scope="function")
+def employee_a(_db_session, two_tenants):
+    return _make_user(_db_session, TENANT_A_ID, role=UserRole.EMPLOYEE, username="employee_a")
+
+
+@pytest.fixture(scope="function")
+def client_as_employee_a(_db_session, employee_a):
+    """Authenticated as a regular employee of Tenant A (non-admin endpoints)."""
+    def _override_db():
+        yield _db_session
+
+    def _current():
+        return employee_a
+
+    test_app.dependency_overrides[get_db] = _override_db
+    test_app.dependency_overrides[get_current_user] = _current
+
+    with TestClient(test_app) as client:
+        yield client
+
+    test_app.dependency_overrides.clear()
+
+
+# ─── Phase 0: belt-and-suspenders filter coverage for the 6 endpoints fixed
+#     in feat/phase0-tenant-isolation. Each test creates data in BOTH tenants
+#     and verifies that the response only ever contains Tenant A data.
+
+def test_admin_users_list_excludes_tenant_b(_db_session, client_as_admin_a, admin_a, employee_b):
+    """GET /admin/users — must not include Tenant B users."""
+    resp = client_as_admin_a.get("/api/admin/users")
+    assert resp.status_code == 200, resp.text
+    ids = {u["id"] for u in resp.json()}
+    assert str(admin_a.id) in ids
+    assert str(employee_b.id) not in ids
+
+
+def _make_pending_cr(db, user, tenant_id):
+    cr = ChangeRequest(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        tenant_id=tenant_id,
+        request_type=ChangeRequestType.CREATE,
+        status=ChangeRequestStatus.PENDING,
+        proposed_date=date.today(),
+        proposed_start_time=time(8, 0),
+        proposed_end_time=time(16, 0),
+        proposed_break_minutes=30,
+        reason="phase0",
+        entry_kind="time_entry",
+    )
+    db.add(cr)
+    db.commit()
+    return cr
+
+
+def test_admin_change_requests_list_excludes_tenant_b(
+    _db_session, client_as_admin_a, admin_a, employee_b
+):
+    """GET /admin/change-requests — must not include Tenant B CRs."""
+    cr_a = _make_pending_cr(_db_session, admin_a, TENANT_A_ID)
+    cr_b = _make_pending_cr(_db_session, employee_b, TENANT_B_ID)
+
+    resp = client_as_admin_a.get("/api/admin/change-requests")
+    assert resp.status_code == 200, resp.text
+    ids = {c["id"] for c in resp.json()}
+    assert str(cr_a.id) in ids
+    assert str(cr_b.id) not in ids
+
+
+def test_admin_change_requests_pending_count_only_own_tenant(
+    _db_session, client_as_admin_a, admin_a, employee_b
+):
+    """GET /admin/change-requests/pending-count — must count only Tenant A."""
+    _make_pending_cr(_db_session, admin_a, TENANT_A_ID)
+    _make_pending_cr(_db_session, employee_b, TENANT_B_ID)
+    _make_pending_cr(_db_session, employee_b, TENANT_B_ID)
+
+    resp = client_as_admin_a.get("/api/admin/change-requests/pending-count")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"count": 1}
+
+
+def test_admin_change_requests_get_by_id_404_for_tenant_b(
+    _db_session, client_as_admin_a, employee_b
+):
+    """GET /admin/change-requests/{id} — Tenant B CR must 404 for Tenant A admin."""
+    cr_b = _make_pending_cr(_db_session, employee_b, TENANT_B_ID)
+
+    resp = client_as_admin_a.get(f"/api/admin/change-requests/{cr_b.id}")
+    assert resp.status_code == 404, resp.text
+
+
+def test_admin_monthly_report_excludes_tenant_b_users(
+    _db_session, client_as_admin_a, admin_a, employee_b
+):
+    """GET /admin/reports/monthly — must list only Tenant A users."""
+    today = date.today()
+    resp = client_as_admin_a.get(
+        "/api/admin/reports/monthly",
+        params={"month": f"{today.year}-{today.month:02d}"},
+    )
+    assert resp.status_code == 200, resp.text
+    user_ids = {row["user_id"] for row in resp.json()}
+    assert str(employee_b.id) not in user_ids
+
+
+def test_holidays_list_excludes_tenant_b(_db_session, client_as_employee_a, two_tenants):
+    """GET /api/holidays/?year=YYYY — must not return Tenant B's holidays."""
+    from app.models.public_holiday import PublicHoliday
+    year = date.today().year
+    h_a = PublicHoliday(date=date(year, 1, 1), name="Tenant-A-Feiertag", year=year, tenant_id=TENANT_A_ID)
+    h_b = PublicHoliday(date=date(year, 5, 1), name="Tenant-B-Feiertag", year=year, tenant_id=TENANT_B_ID)
+    _db_session.add_all([h_a, h_b])
+    _db_session.commit()
+
+    resp = client_as_employee_a.get(f"/api/holidays/?year={year}")
+    assert resp.status_code == 200, resp.text
+    names = {h["name"] for h in resp.json()}
+    assert "Tenant-A-Feiertag" in names
+    assert "Tenant-B-Feiertag" not in names
+
+
 def test_admin_a_bulk_approve_ignores_tenant_b_crs(_db_session, client_as_admin_a, employee_b):
     """Bulk approve: every item for Tenant B must be reported as failed, nothing mutated."""
     cr_b = ChangeRequest(


### PR DESCRIPTION
## Summary

Phase 0 of the SaaS-Readiness roadmap (siehe Audit 2026-04-24). Fügt **expliziten `tenant_id`-Filter** an die 6 Endpoints, die bisher allein auf PostgreSQL-RLS für Mandantentrennung vertrauten.

RLS bleibt die Grundsicherung — der zusätzliche Filter ist Defense-in-Depth (CLAUDE.md F-026): wenn jemals ein `SET LOCAL app.tenant_id` vergessen oder umgangen wird, leaken die Endpoints trotzdem keine Cross-Tenant-Daten.

## Geänderte Endpoints

| Datei | Endpoint | Vorher | Nachher |
|-------|----------|--------|---------|
| `admin_users.py` | `GET /api/admin/users` | nur RLS | `+ User.tenant_id == current_user.tenant_id` |
| `admin_change_requests.py` | `GET /pending-count` | nur RLS | `+ ChangeRequest.tenant_id == ...` |
| `admin_change_requests.py` | `GET /change-requests` | nur RLS | `+ ChangeRequest.tenant_id == ...` |
| `admin_change_requests.py` | `GET /change-requests/{id}` | nur RLS | `+ ChangeRequest.tenant_id == ...` |
| `reports.py` | `_get_active_visible_users` (6 Aufrufer) | nur RLS | Signatur erweitert: `tenant_id` Pflicht-Param |
| `holiday_service.py` + `holidays.py` | `GET /api/holidays/` | nur RLS | `tenant_id` Param durchgereicht |

## Tests

`backend/tests/test_cross_tenant_api.py` — 6 neue Tests (`test_admin_users_list_excludes_tenant_b`, `test_admin_change_requests_list_excludes_tenant_b`, `test_admin_change_requests_pending_count_only_own_tenant`, `test_admin_change_requests_get_by_id_404_for_tenant_b`, `test_admin_monthly_report_excludes_tenant_b_users`, `test_holidays_list_excludes_tenant_b`) verifizieren, dass ein Admin von Tenant A keine Daten von Tenant B sieht.

Bestehende RLS-Tests (`test_tenant_rls.py`, 13 Tests gegen echtes Postgres) bleiben unverändert.

## Test plan

- [ ] `docker compose exec backend pytest tests/test_cross_tenant_api.py -v` → 13 grün (7 alte + 6 neue)
- [ ] `docker compose exec backend pytest tests/ -v` → keine Regressionen
- [ ] `docker compose exec backend pytest tests/test_tenant_rls.py -v` → 13 grün

## Related

- Audit: SaaS-Readiness 2026-04-24 (Memory)
- Roadmap-Phasen 1-8 folgen als separate Issues
- Vorläufer: Issue #73 (Multi-Tenant SaaS Umbau)

🤖 Generated with [Claude Code](https://claude.com/claude-code)