### PR TITLE
Phase 3 — Self-service signup + email verification

### DIFF
--- a/backend/alembic/versions/2026_04_24_1400-034_signup_tokens.py
+++ b/backend/alembic/versions/2026_04_24_1400-034_signup_tokens.py
@@ -1,0 +1,100 @@
+"""Self-service signup — verification tokens + DSGVO consent audit (Phase 3 / #94)
+
+The public ``/api/public/signup`` endpoint creates a tenant + admin user
+in an inactive state and mails a verification link. The ``signup_tokens``
+table stores the short-lived (24 h) verification token. ``signup_audit_log``
+records the AGB + Datenschutz double-opt-in (IP + UA + timestamp) per
+DSGVO Art. 7 — it's a standalone table (not extending ``time_entry_audit_log``)
+because those rows need to survive tenant deletion for legal-proof purposes.
+
+Revision ID: 034_signup_tokens
+Revises: 033_tenant_billing
+Create Date: 2026-04-24
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = '034_signup_tokens'
+down_revision = '033_tenant_billing'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # signup_tokens: one row per outstanding verification link.
+    # token is the opaque random value emailed to the user (we store a hash,
+    # not the raw token, so a DB leak doesn't grant verification privileges).
+    op.create_table(
+        'signup_tokens',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('gen_random_uuid()')),
+        sa.Column('tenant_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('token_hash', sa.String(128), nullable=False, unique=True),
+        sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('consumed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(['tenant_id'], ['tenants.id'], name='fk_signup_tokens_tenant_id'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], name='fk_signup_tokens_user_id'),
+    )
+    op.create_index('ix_signup_tokens_tenant_id', 'signup_tokens', ['tenant_id'])
+    op.create_index('ix_signup_tokens_user_id', 'signup_tokens', ['user_id'])
+    op.create_index('ix_signup_tokens_expires_at', 'signup_tokens', ['expires_at'])
+
+    # RLS: signup_tokens is scoped by tenant_id like everything else,
+    # but the public verification endpoint looks up by token_hash with
+    # superadmin context (the requester is unauthenticated).
+    op.execute("ALTER TABLE signup_tokens ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE signup_tokens FORCE ROW LEVEL SECURITY")
+    op.execute("""
+        CREATE POLICY tenant_isolation ON signup_tokens
+        USING (
+            current_setting('app.is_superadmin', true) = 'true'
+            OR tenant_id = NULLIF(current_setting('app.tenant_id', true), '')::uuid
+        )
+        WITH CHECK (
+            current_setting('app.is_superadmin', true) = 'true'
+            OR tenant_id = NULLIF(current_setting('app.tenant_id', true), '')::uuid
+        )
+    """)
+
+    # signup_audit_log: DSGVO Art. 7 double-opt-in proof. Retained across
+    # tenant deletion (see Phase 6 anonymization) so we can prove consent
+    # in a dispute years later — tenant_id nullable to survive delete.
+    op.create_table(
+        'signup_audit_log',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('gen_random_uuid()')),
+        sa.Column('tenant_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('email', sa.String(255), nullable=False),
+        sa.Column('event', sa.String(30), nullable=False),
+        # 'signup_requested' | 'email_verified' | 'resend_requested'
+        sa.Column('ip_address', sa.String(45), nullable=True),  # IPv6 max
+        sa.Column('user_agent', sa.String(500), nullable=True),
+        sa.Column('accepted_terms', sa.Boolean(), nullable=True),
+        sa.Column('accepted_privacy', sa.Boolean(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index('ix_signup_audit_log_email', 'signup_audit_log', ['email'])
+    op.create_index('ix_signup_audit_log_tenant_id', 'signup_audit_log', ['tenant_id'])
+    op.create_index('ix_signup_audit_log_created_at', 'signup_audit_log', ['created_at'])
+    # No RLS on signup_audit_log: rows are written by anonymous requesters
+    # before any tenant context exists; reads are superadmin-only (/api/superadmin).
+
+
+def downgrade() -> None:
+    op.drop_index('ix_signup_audit_log_created_at', 'signup_audit_log')
+    op.drop_index('ix_signup_audit_log_tenant_id', 'signup_audit_log')
+    op.drop_index('ix_signup_audit_log_email', 'signup_audit_log')
+    op.drop_table('signup_audit_log')
+
+    op.execute("DROP POLICY IF EXISTS tenant_isolation ON signup_tokens")
+    op.execute("ALTER TABLE signup_tokens DISABLE ROW LEVEL SECURITY")
+    op.drop_index('ix_signup_tokens_expires_at', 'signup_tokens')
+    op.drop_index('ix_signup_tokens_user_id', 'signup_tokens')
+    op.drop_index('ix_signup_tokens_tenant_id', 'signup_tokens')
+    op.drop_table('signup_tokens')

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -125,6 +125,16 @@ class Settings(BaseSettings):
     UPDATE_SERVER_URL: Optional[str] = None
     UPDATE_CHECK_INTERVAL_HOURS: int = 12
 
+    # SMTP — used by the self-service signup flow (Phase 3). If MAIL_HOST is
+    # unset, mail_service.send() logs the email body and returns True; in
+    # production (DEPLOYMENT_MODE=saas) these MUST be configured.
+    MAIL_HOST: Optional[str] = None
+    MAIL_PORT: int = 587
+    MAIL_USER: Optional[str] = None
+    MAIL_PASS: Optional[str] = None
+    MAIL_FROM: Optional[str] = None
+    MAIL_STARTTLS: bool = True
+
     @field_validator("SECRET_KEY")
     @classmethod
     def validate_secret_key(cls, v: str) -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,7 +24,7 @@ from app.config import settings
 from app.models import User, UserRole
 from app.services import auth_service, holiday_service
 from app.services.error_log_service import DBErrorHandler, cleanup_old_errors
-from app.routers import auth, admin, time_entries, absences, dashboard, holidays, reports, change_requests, company_closures, error_logs, vacation_requests, journal, import_xls, superadmin, tenant_billing
+from app.routers import auth, admin, time_entries, absences, dashboard, holidays, reports, change_requests, company_closures, error_logs, vacation_requests, journal, import_xls, superadmin, tenant_billing, public_signup
 
 # Used by the startup bootstrap to warn/abort when the initial admin still
 # uses a throwaway password. Kept at module level so git diffs that re-indent
@@ -268,6 +268,7 @@ app.include_router(journal.router)
 app.include_router(import_xls.router)
 app.include_router(superadmin.router)
 app.include_router(tenant_billing.router)
+app.include_router(public_signup.router)
 
 
 @app.middleware("http")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,6 +11,7 @@ from app.models.error_log import ErrorLog
 from app.models.vacation_request import VacationRequest, VacationRequestStatus
 from app.models.system_setting import SystemSetting
 from app.models.year_carryover import YearCarryover
+from app.models.signup_token import SignupToken, SignupAuditLog
 
 __all__ = [
     "Tenant",
@@ -32,4 +33,6 @@ __all__ = [
     "VacationRequestStatus",
     "SystemSetting",
     "YearCarryover",
+    "SignupToken",
+    "SignupAuditLog",
 ]

--- a/backend/app/models/signup_token.py
+++ b/backend/app/models/signup_token.py
@@ -1,0 +1,38 @@
+"""Signup-verification token + DSGVO consent audit (Phase 3 / Issue #94)."""
+
+from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+import uuid
+from app.database import Base
+
+
+class SignupToken(Base):
+    """Opaque verification link. We store the hash, not the raw token."""
+
+    __tablename__ = "signup_tokens"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False, index=True)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True)
+    token_hash = Column(String(128), nullable=False, unique=True)
+    expires_at = Column(DateTime(timezone=True), nullable=False, index=True)
+    consumed_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+class SignupAuditLog(Base):
+    """DSGVO Art. 7 consent proof. Survives tenant deletion for legal record."""
+
+    __tablename__ = "signup_audit_log"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id = Column(UUID(as_uuid=True), nullable=True, index=True)  # nullable — row survives tenant delete
+    email = Column(String(255), nullable=False, index=True)
+    # 'signup_requested' | 'email_verified' | 'resend_requested'
+    event = Column(String(30), nullable=False)
+    ip_address = Column(String(45), nullable=True)
+    user_agent = Column(String(500), nullable=True)
+    accepted_terms = Column(Boolean, nullable=True)
+    accepted_privacy = Column(Boolean, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)

--- a/backend/app/routers/public_signup.py
+++ b/backend/app/routers/public_signup.py
@@ -1,0 +1,125 @@
+"""Public (no-auth) self-service signup endpoints (Phase 3 / Issue #94).
+
+All routes return 404 in ``onprem`` deployment mode — the Docker +
+Native-Installer flavour doesn't have a multi-tenant landing page.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from app.core.deployment import is_saas
+from app.core.limiter import limiter
+from app.database import SessionLocal, set_superadmin_context
+from app.schemas.signup import (
+    ResendVerificationRequest,
+    SignupRequest,
+    SignupResponse,
+    VerifyResponse,
+)
+from app.services import signup_service
+from app.services.mail_service import send_verification_email
+
+
+router = APIRouter(prefix="/api/public", tags=["public-signup"])
+
+
+def _saas_only():
+    """Dependency that 404s in onprem mode."""
+    if not is_saas():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
+
+
+def _public_db():
+    """Public endpoints run without a user-session, so we open a SessionLocal
+    directly and set superadmin context so RLS doesn't bite on inserts."""
+    db = SessionLocal()
+    try:
+        set_superadmin_context(db)
+        yield db
+    finally:
+        db.close()
+
+
+def _client_meta(request: Request) -> tuple[str | None, str | None]:
+    # Behind nginx the X-Forwarded-For header carries the real IP; trust
+    # it only because the app is fronted by a reverse proxy we control.
+    xff = request.headers.get("x-forwarded-for")
+    ip = xff.split(",")[0].strip() if xff else (request.client.host if request.client else None)
+    ua = request.headers.get("user-agent")
+    # Guard against overly long UAs — column is varchar(500).
+    if ua and len(ua) > 500:
+        ua = ua[:500]
+    return ip, ua
+
+
+@router.post("/signup", response_model=SignupResponse, status_code=201)
+@limiter.limit("5/hour")
+def signup(
+    request: Request,
+    body: SignupRequest,
+    _=Depends(_saas_only),
+    db: Session = Depends(_public_db),
+) -> SignupResponse:
+    ip, ua = _client_meta(request)
+    result = signup_service.signup(
+        db,
+        practice_name=body.practice_name,
+        admin_email=body.admin_email,
+        admin_first_name=body.admin_first_name,
+        admin_last_name=body.admin_last_name,
+        admin_password=body.admin_password,
+        country=body.country,
+        ip_address=ip,
+        user_agent=ua,
+        accepted_terms=body.accept_terms,
+        accepted_privacy=body.accept_privacy,
+    )
+    # Build verification URL from the origin header; fall back to the
+    # path-only form if the request came in without Origin (e.g. curl).
+    origin = request.headers.get("origin") or ""
+    verify_url = f"{origin.rstrip('/')}/verify?token={result.verification_token}"
+    send_verification_email(
+        to=body.admin_email,
+        verification_url=verify_url,
+        practice_name=body.practice_name,
+    )
+    return SignupResponse(tenant_id=str(result.tenant_id))
+
+
+@router.get("/verify-email", response_model=VerifyResponse)
+@limiter.limit("10/minute")
+def verify_email(
+    request: Request,
+    token: str,
+    _=Depends(_saas_only),
+    db: Session = Depends(_public_db),
+) -> VerifyResponse:
+    if not token:
+        raise HTTPException(status_code=400, detail="token fehlt")
+    ip, ua = _client_meta(request)
+    tenant_id = signup_service.verify(db, raw_token=token, ip_address=ip, user_agent=ua)
+    return VerifyResponse(tenant_id=str(tenant_id))
+
+
+@router.post("/resend-verification", status_code=202)
+@limiter.limit("3/hour")
+def resend_verification(
+    request: Request,
+    body: ResendVerificationRequest,
+    _=Depends(_saas_only),
+    db: Session = Depends(_public_db),
+):
+    """Always 202, regardless of whether the email exists — prevents
+    enumeration. If the email matches an inactive admin, a new token
+    is issued and mailed."""
+    ip, ua = _client_meta(request)
+    result = signup_service.resend(db, email=body.email, ip_address=ip, user_agent=ua)
+    if result is not None:
+        origin = request.headers.get("origin") or ""
+        verify_url = f"{origin.rstrip('/')}/verify?token={result.verification_token}"
+        send_verification_email(
+            to=body.email,
+            verification_url=verify_url,
+            practice_name="PraxisZeit",  # best-effort without looking up tenant
+        )
+    return {"message": "Wenn diese Adresse registriert ist, senden wir eine neue Verifizierungsmail."}

--- a/backend/app/routers/superadmin.py
+++ b/backend/app/routers/superadmin.py
@@ -203,3 +203,17 @@ def export_tenant_arbzg_data(
         media_type="application/json",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+@router.post("/cron/trial-check")
+def cron_trial_check(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_superadmin),
+):
+    """Suspend tenants whose trial has expired AND who have no Stripe
+    subscription. Called by an external cron; exposed under superadmin
+    so only an authenticated operator can trigger it manually. The
+    Stripe-webhook in Phase 4 will be the self-healing inverse (reactivate)."""
+    from app.services.signup_service import suspend_expired_trials
+    count = suspend_expired_trials(db)
+    return {"suspended": count}

--- a/backend/app/schemas/signup.py
+++ b/backend/app/schemas/signup.py
@@ -1,0 +1,42 @@
+"""Schemas for /api/public/signup + /verify-email (Phase 3 / Issue #94)."""
+
+from pydantic import BaseModel, EmailStr, Field, field_validator
+
+
+class SignupRequest(BaseModel):
+    practice_name: str = Field(..., min_length=2, max_length=255)
+    admin_email: EmailStr
+    admin_first_name: str = Field(..., min_length=1, max_length=100)
+    admin_last_name: str = Field(..., min_length=1, max_length=100)
+    # Mirrors auth_service.hash_password policy: min 8 chars. Full strength
+    # check happens on first login; here we only block trivially short PW.
+    admin_password: str = Field(..., min_length=8, max_length=128)
+    accept_terms: bool
+    accept_privacy: bool
+    country: str = Field(..., min_length=2, max_length=2)
+
+    @field_validator("accept_terms", "accept_privacy")
+    @classmethod
+    def _must_accept(cls, v: bool) -> bool:
+        if not v:
+            raise ValueError("AGB und Datenschutz müssen akzeptiert werden")
+        return v
+
+    @field_validator("country")
+    @classmethod
+    def _upper_country(cls, v: str) -> str:
+        return v.upper()
+
+
+class SignupResponse(BaseModel):
+    tenant_id: str
+    message: str = "Bitte bestätige deine E-Mail-Adresse über den Link, den wir dir gerade gesendet haben."
+
+
+class ResendVerificationRequest(BaseModel):
+    email: EmailStr
+
+
+class VerifyResponse(BaseModel):
+    tenant_id: str
+    message: str = "E-Mail-Adresse bestätigt. Du kannst dich jetzt einloggen."

--- a/backend/app/services/mail_service.py
+++ b/backend/app/services/mail_service.py
@@ -1,0 +1,104 @@
+"""SMTP mail delivery (Phase 3 / Issue #94).
+
+Kept minimal and stdlib-only so we don't pull in FastMail/MailHog for a
+single transactional mail flow. If SMTP credentials are missing the
+service logs the email body instead of raising — letting the signup flow
+succeed locally and in CI without a relay configured. Production MUST
+set MAIL_HOST + MAIL_FROM; the ``is_configured`` helper is used by
+``/api/system/info`` callers that need to know whether real delivery
+happens.
+"""
+
+from __future__ import annotations
+
+import logging
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Optional
+
+from app.config import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+def is_configured() -> bool:
+    return bool(getattr(settings, "MAIL_HOST", None)) and bool(
+        getattr(settings, "MAIL_FROM", None)
+    )
+
+
+class MailService:
+    """Thin wrapper around smtplib. Sends one transactional mail per call."""
+
+    def __init__(
+        self,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        from_addr: Optional[str] = None,
+        starttls: Optional[bool] = None,
+    ):
+        self.host = host if host is not None else getattr(settings, "MAIL_HOST", None)
+        self.port = port if port is not None else getattr(settings, "MAIL_PORT", 587)
+        self.user = user if user is not None else getattr(settings, "MAIL_USER", None)
+        self.password = password if password is not None else getattr(settings, "MAIL_PASS", None)
+        self.from_addr = from_addr if from_addr is not None else getattr(settings, "MAIL_FROM", None)
+        self.starttls = starttls if starttls is not None else getattr(settings, "MAIL_STARTTLS", True)
+
+    def send(self, *, to: str, subject: str, body_text: str, body_html: Optional[str] = None) -> bool:
+        """Send a single email. Returns True on success (or dry-run)."""
+        if not self.host or not self.from_addr:
+            # Dry-run: log so signup tests / local dev can assert on content
+            # without a relay configured. Contains the verification URL.
+            logger.info(
+                "mail_service dry-run (no SMTP configured): to=%s subject=%r body=%s",
+                to, subject, body_text,
+            )
+            return True
+
+        msg = MIMEMultipart("alternative")
+        msg["Subject"] = subject
+        msg["From"] = self.from_addr
+        msg["To"] = to
+        msg.attach(MIMEText(body_text, "plain", "utf-8"))
+        if body_html:
+            msg.attach(MIMEText(body_html, "html", "utf-8"))
+
+        try:
+            with smtplib.SMTP(self.host, self.port, timeout=10) as smtp:
+                smtp.ehlo()
+                if self.starttls:
+                    smtp.starttls()
+                    smtp.ehlo()
+                if self.user and self.password:
+                    smtp.login(self.user, self.password)
+                smtp.send_message(msg)
+            return True
+        except Exception as exc:  # noqa: BLE001 — smtp errors are varied
+            logger.exception("mail_service: failed to send to %s: %s", to, exc)
+            return False
+
+
+def send_verification_email(to: str, verification_url: str, practice_name: str) -> bool:
+    """Composed signup-verification email. Called from the signup endpoint."""
+    subject = "Bitte E-Mail-Adresse bestätigen – PraxisZeit"
+    body_text = (
+        f"Hallo,\n\n"
+        f"vielen Dank für die Registrierung von '{practice_name}' bei PraxisZeit.\n\n"
+        f"Bitte bestätige deine E-Mail-Adresse über folgenden Link (24 Stunden gültig):\n\n"
+        f"{verification_url}\n\n"
+        f"Wenn du diese Registrierung nicht angefordert hast, kannst du diese E-Mail ignorieren.\n\n"
+        f"Viele Grüße\nDein PraxisZeit-Team"
+    )
+    body_html = (
+        f"<p>Hallo,</p>"
+        f"<p>vielen Dank für die Registrierung von <strong>{practice_name}</strong> bei PraxisZeit.</p>"
+        f"<p>Bitte bestätige deine E-Mail-Adresse über folgenden Link (24 Stunden gültig):</p>"
+        f'<p><a href="{verification_url}">{verification_url}</a></p>'
+        f"<p>Wenn du diese Registrierung nicht angefordert hast, kannst du diese E-Mail ignorieren.</p>"
+        f"<p>Viele Grüße<br>Dein PraxisZeit-Team</p>"
+    )
+    return MailService().send(to=to, subject=subject, body_text=body_text, body_html=body_html)

--- a/backend/app/services/signup_service.py
+++ b/backend/app/services/signup_service.py
@@ -1,0 +1,265 @@
+"""Self-service signup provisioning (Phase 3 / Issue #94).
+
+Flow:
+1. ``signup()`` — creates an inactive tenant + inactive admin, stores a
+   hashed verification token, writes an audit row, returns the opaque
+   token (caller mails it).
+2. ``verify()`` — consumes the token, activates admin + tenant.
+3. ``resend()`` — invalidates outstanding tokens, issues a new one.
+
+Tenant is intentionally created as ``is_active=True`` but the admin is
+``is_active=False``; that way RLS queries keyed on tenant_id don't need
+a separate ``pending_activation`` branch, while the user can't log in
+yet. A ``trial_ends_at`` 14 days in the future is set during signup.
+
+Tokens are 32-byte ``secrets.token_urlsafe`` values; we store only the
+SHA-256 hash so a DB leak doesn't expose verification URLs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.models import SignupAuditLog, SignupToken, Tenant, User, UserRole
+from app.services import auth_service
+
+
+VERIFY_TOKEN_TTL_HOURS = 24
+TRIAL_LENGTH_DAYS = 14
+
+
+@dataclass
+class SignupResult:
+    tenant_id: uuid.UUID
+    user_id: uuid.UUID
+    verification_token: str  # raw token — caller mails it, we only store the hash
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _slug_from_name(name: str, existing_slugs: set[str]) -> str:
+    """Deterministic tenant slug — lowercased, non-alnum removed, deduplicated."""
+    import re
+    base = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or "praxis"
+    base = base[:60]
+    candidate = base
+    i = 2
+    while candidate in existing_slugs:
+        suffix = f"-{i}"
+        candidate = f"{base[:60 - len(suffix)]}{suffix}"
+        i += 1
+    return candidate
+
+
+def _email_already_admin(db: Session, email: str) -> bool:
+    """An email may only be the admin of ONE active tenant at a time.
+
+    Emails belonging to inactive (pending-verification) admins are allowed
+    to re-register — we simply recycle the tenant via ``resend``-equivalent
+    semantics in a future iteration; for now we block on an existing row.
+    """
+    return (
+        db.query(User)
+        .filter(User.email == email, User.role == UserRole.ADMIN, User.is_active == True)  # noqa: E712
+        .first()
+        is not None
+    )
+
+
+def signup(
+    db: Session,
+    *,
+    practice_name: str,
+    admin_email: str,
+    admin_first_name: str,
+    admin_last_name: str,
+    admin_password: str,
+    country: str,
+    ip_address: Optional[str],
+    user_agent: Optional[str],
+    accepted_terms: bool,
+    accepted_privacy: bool,
+) -> SignupResult:
+    """Create tenant + inactive admin, return verification token."""
+    if _email_already_admin(db, admin_email):
+        # Audit the rejection too — a signal for brute-forcing existing accounts.
+        db.add(SignupAuditLog(
+            email=admin_email, event="signup_rejected_email_exists",
+            ip_address=ip_address, user_agent=user_agent,
+            accepted_terms=accepted_terms, accepted_privacy=accepted_privacy,
+        ))
+        db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="E-Mail-Adresse bereits registriert",
+        )
+
+    # Collision-avoiding slug
+    existing = {s for (s,) in db.query(Tenant.slug).all()}
+    slug = _slug_from_name(practice_name, existing)
+
+    tenant = Tenant(
+        id=uuid.uuid4(),
+        name=practice_name,
+        slug=slug,
+        is_active=True,
+        mode="multi",
+        plan="trial",
+        subscription_status="active",
+        trial_ends_at=datetime.now(timezone.utc) + timedelta(days=TRIAL_LENGTH_DAYS),
+        country=country.upper(),
+        billing_email=admin_email,
+    )
+    db.add(tenant)
+    db.flush()  # get tenant.id populated for FK
+
+    admin = User(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        username=admin_email,
+        email=admin_email,
+        password_hash=auth_service.hash_password(admin_password),
+        first_name=admin_first_name,
+        last_name=admin_last_name,
+        role=UserRole.ADMIN,
+        weekly_hours=40.0,
+        vacation_days=30,
+        work_days_per_week=5,
+        is_active=False,  # activates on verify
+    )
+    db.add(admin)
+    db.flush()
+
+    raw_token = secrets.token_urlsafe(32)
+    db.add(SignupToken(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        user_id=admin.id,
+        token_hash=_hash_token(raw_token),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=VERIFY_TOKEN_TTL_HOURS),
+    ))
+
+    db.add(SignupAuditLog(
+        tenant_id=tenant.id,
+        email=admin_email,
+        event="signup_requested",
+        ip_address=ip_address,
+        user_agent=user_agent,
+        accepted_terms=accepted_terms,
+        accepted_privacy=accepted_privacy,
+    ))
+    db.commit()
+
+    return SignupResult(
+        tenant_id=tenant.id,
+        user_id=admin.id,
+        verification_token=raw_token,
+    )
+
+
+def verify(db: Session, *, raw_token: str, ip_address: Optional[str], user_agent: Optional[str]) -> uuid.UUID:
+    """Activate the admin + return the tenant_id. Raises 410 on expired/used."""
+    token_hash = _hash_token(raw_token)
+    row: Optional[SignupToken] = (
+        db.query(SignupToken).filter(SignupToken.token_hash == token_hash).first()
+    )
+    if row is None or row.consumed_at is not None:
+        raise HTTPException(status_code=status.HTTP_410_GONE, detail="Token ungültig oder bereits verwendet")
+
+    now = datetime.now(timezone.utc)
+    # row.expires_at might come back as tz-aware from Postgres and tz-naive
+    # from SQLite (some dialects strip tz). Normalize both sides to tz-aware
+    # so the comparison works on every backend the test matrix uses.
+    expires = row.expires_at if row.expires_at.tzinfo else row.expires_at.replace(tzinfo=timezone.utc)
+    if expires < now:
+        raise HTTPException(status_code=status.HTTP_410_GONE, detail="Token abgelaufen")
+
+    user: Optional[User] = db.query(User).filter(User.id == row.user_id).first()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_410_GONE, detail="Konto existiert nicht mehr")
+
+    user.is_active = True
+    row.consumed_at = now
+    db.add(SignupAuditLog(
+        tenant_id=row.tenant_id,
+        email=user.email,
+        event="email_verified",
+        ip_address=ip_address,
+        user_agent=user_agent,
+    ))
+    db.commit()
+    return row.tenant_id
+
+
+def resend(db: Session, *, email: str, ip_address: Optional[str], user_agent: Optional[str]) -> Optional[SignupResult]:
+    """Invalidate outstanding tokens for ``email`` and issue a new one.
+
+    Returns None when no inactive admin exists for ``email`` — the public
+    endpoint returns 202 regardless so enumeration is harmless.
+    """
+    user: Optional[User] = (
+        db.query(User)
+        .filter(User.email == email, User.role == UserRole.ADMIN, User.is_active == False)  # noqa: E712
+        .first()
+    )
+    if user is None:
+        db.add(SignupAuditLog(
+            email=email, event="resend_rejected_unknown",
+            ip_address=ip_address, user_agent=user_agent,
+        ))
+        db.commit()
+        return None
+
+    # Invalidate any outstanding token so the previous link stops working.
+    (
+        db.query(SignupToken)
+        .filter(SignupToken.user_id == user.id, SignupToken.consumed_at.is_(None))
+        .update({SignupToken.consumed_at: datetime.now(timezone.utc)}, synchronize_session=False)
+    )
+    raw_token = secrets.token_urlsafe(32)
+    db.add(SignupToken(
+        id=uuid.uuid4(),
+        tenant_id=user.tenant_id,
+        user_id=user.id,
+        token_hash=_hash_token(raw_token),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=VERIFY_TOKEN_TTL_HOURS),
+    ))
+    db.add(SignupAuditLog(
+        tenant_id=user.tenant_id, email=email, event="resend_requested",
+        ip_address=ip_address, user_agent=user_agent,
+    ))
+    db.commit()
+    return SignupResult(tenant_id=user.tenant_id, user_id=user.id, verification_token=raw_token)
+
+
+def suspend_expired_trials(db: Session) -> int:
+    """Move tenants whose trial has ended AND have no Stripe subscription to
+    ``subscription_status='suspended'``. Returns the number of rows updated.
+
+    Called by the operator cron (bare endpoint under /api/superadmin) — no
+    scheduler dependency yet.
+    """
+    now = datetime.now(timezone.utc)
+    q = (
+        db.query(Tenant)
+        .filter(
+            Tenant.plan == "trial",
+            Tenant.trial_ends_at.isnot(None),
+            Tenant.trial_ends_at < now,
+            Tenant.stripe_subscription_id.is_(None),
+            Tenant.subscription_status == "active",
+        )
+    )
+    updated = q.update({Tenant.subscription_status: "suspended"}, synchronize_session=False)
+    db.commit()
+    return updated

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -49,6 +49,7 @@ def _create_test_app() -> FastAPI:
         journal,
         import_xls,
         tenant_billing,
+        public_signup,
     )
 
     app = FastAPI(title="PraxisZeit Test")
@@ -77,6 +78,7 @@ def _create_test_app() -> FastAPI:
     app.include_router(journal.router)
     app.include_router(import_xls.router)
     app.include_router(tenant_billing.router)
+    app.include_router(public_signup.router)
 
     # Health endpoint (duplicated from main.py since it is defined there directly)
     @app.get("/api/health")

--- a/backend/tests/test_signup.py
+++ b/backend/tests/test_signup.py
@@ -1,0 +1,284 @@
+"""Tests for self-service signup (Phase 3, Issue #94).
+
+Covers:
+- POST /api/public/signup happy path (tenant + inactive admin + token)
+- /verify-email activates admin and consumes token (idempotent-ish)
+- Expired / reused / unknown tokens → 410
+- Resend invalidates old tokens and issues a new one
+- DEPLOYMENT_MODE=onprem → all /api/public/* endpoints 404
+- DSGVO: audit log row per event with IP + UA + consent flags
+- Email already in use → 409
+- Trial cron suspends expired trials without Stripe subscription
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app.config import settings
+from app.database import Base, SessionLocal, get_db
+from app.models import SignupAuditLog, SignupToken, User, UserRole
+from app.models.tenant import Tenant
+from app.services import signup_service
+from tests.conftest import engine, TestingSessionLocal
+from tests.test_endpoints import test_app
+
+
+# ----- Test harness -----------------------------------------------------
+
+@pytest.fixture
+def _db_session():
+    with engine.connect() as conn:
+        conn.execute(text("PRAGMA foreign_keys = OFF"))
+        conn.commit()
+    Base.metadata.drop_all(bind=engine, checkfirst=True)
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        with engine.connect() as conn:
+            conn.execute(text("PRAGMA foreign_keys = OFF"))
+            conn.commit()
+        Base.metadata.drop_all(bind=engine, checkfirst=True)
+
+
+@pytest.fixture
+def saas_client(_db_session, monkeypatch):
+    """Client with DEPLOYMENT_MODE=saas + public endpoints pointed at the
+    in-memory SQLite session. We override the _public_db dependency to
+    yield the test session instead of opening a real SessionLocal + RLS.
+    """
+    monkeypatch.setattr(settings, "DEPLOYMENT_MODE", "saas")
+
+    from app.routers.public_signup import _public_db
+
+    def _db_override():
+        yield _db_session
+
+    test_app.dependency_overrides[_public_db] = _db_override
+    test_app.dependency_overrides[get_db] = _db_override
+    with TestClient(test_app) as client:
+        yield client
+    test_app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def onprem_client(monkeypatch):
+    monkeypatch.setattr(settings, "DEPLOYMENT_MODE", "onprem")
+    with TestClient(test_app) as client:
+        yield client
+
+
+_PAYLOAD = {
+    "practice_name": "Zahnarztpraxis Dr. Müller",
+    "admin_email": "chef@praxis-mueller.de",
+    "admin_first_name": "Anna",
+    "admin_last_name": "Müller",
+    "admin_password": "S3curePassword!",
+    "accept_terms": True,
+    "accept_privacy": True,
+    "country": "de",
+}
+
+
+# ----- onprem gating ----------------------------------------------------
+
+def test_signup_404_in_onprem(onprem_client):
+    resp = onprem_client.post("/api/public/signup", json=_PAYLOAD)
+    assert resp.status_code == 404
+
+
+def test_verify_404_in_onprem(onprem_client):
+    resp = onprem_client.get("/api/public/verify-email?token=anything")
+    assert resp.status_code == 404
+
+
+def test_resend_404_in_onprem(onprem_client):
+    resp = onprem_client.post("/api/public/resend-verification", json={"email": "x@y.de"})
+    assert resp.status_code == 404
+
+
+# ----- signup happy path ------------------------------------------------
+
+def test_signup_creates_tenant_and_inactive_admin(saas_client, _db_session):
+    with patch("app.routers.public_signup.send_verification_email", return_value=True) as mail:
+        resp = saas_client.post("/api/public/signup", json=_PAYLOAD)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert "tenant_id" in body
+
+    tenant = _db_session.query(Tenant).filter(Tenant.id == uuid.UUID(body["tenant_id"])).first()
+    assert tenant is not None
+    assert tenant.plan == "trial"
+    assert tenant.subscription_status == "active"
+    assert tenant.trial_ends_at is not None
+    assert tenant.country == "DE"
+    assert tenant.billing_email == _PAYLOAD["admin_email"]
+
+    admin = _db_session.query(User).filter(User.email == _PAYLOAD["admin_email"]).first()
+    assert admin is not None
+    assert admin.is_active is False
+    assert admin.role == UserRole.ADMIN
+
+    # Mail attempted
+    assert mail.called
+
+    # Audit row present with consent flags
+    audit = (
+        _db_session.query(SignupAuditLog)
+        .filter(SignupAuditLog.email == _PAYLOAD["admin_email"], SignupAuditLog.event == "signup_requested")
+        .first()
+    )
+    assert audit is not None
+    assert audit.accepted_terms is True
+    assert audit.accepted_privacy is True
+
+
+def test_signup_rejects_duplicate_active_admin(saas_client, _db_session):
+    # First signup + manually activate
+    with patch("app.routers.public_signup.send_verification_email", return_value=True):
+        r1 = saas_client.post("/api/public/signup", json=_PAYLOAD)
+    assert r1.status_code == 201
+    u = _db_session.query(User).filter(User.email == _PAYLOAD["admin_email"]).first()
+    u.is_active = True
+    _db_session.commit()
+
+    with patch("app.routers.public_signup.send_verification_email", return_value=True):
+        r2 = saas_client.post("/api/public/signup", json=_PAYLOAD)
+    assert r2.status_code == 409
+
+
+def test_signup_rejects_missing_consent(saas_client, _db_session):
+    payload = dict(_PAYLOAD, accept_terms=False)
+    resp = saas_client.post("/api/public/signup", json=payload)
+    assert resp.status_code == 422
+
+
+def test_signup_rejects_short_password(saas_client, _db_session):
+    payload = dict(_PAYLOAD, admin_password="short")
+    resp = saas_client.post("/api/public/signup", json=payload)
+    assert resp.status_code == 422
+
+
+# ----- verify flow ------------------------------------------------------
+
+def _create_signup(db, **overrides):
+    payload = dict(
+        practice_name="Praxis A",
+        admin_email="a@praxis-a.de",
+        admin_first_name="A",
+        admin_last_name="Alpha",
+        admin_password="S3curePassword!",
+        country="DE",
+        ip_address="127.0.0.1",
+        user_agent="pytest",
+        accepted_terms=True,
+        accepted_privacy=True,
+    )
+    payload.update(overrides)
+    return signup_service.signup(db, **payload)
+
+
+def test_verify_activates_admin(saas_client, _db_session):
+    result = _create_signup(_db_session)
+    resp = saas_client.get(f"/api/public/verify-email?token={result.verification_token}")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["tenant_id"] == str(result.tenant_id)
+
+    u = _db_session.query(User).filter(User.id == result.user_id).first()
+    assert u.is_active is True
+
+    tok = _db_session.query(SignupToken).filter(SignupToken.user_id == result.user_id).first()
+    assert tok.consumed_at is not None
+
+
+def test_verify_rejects_reused_token(saas_client, _db_session):
+    result = _create_signup(_db_session)
+    saas_client.get(f"/api/public/verify-email?token={result.verification_token}")
+    resp = saas_client.get(f"/api/public/verify-email?token={result.verification_token}")
+    assert resp.status_code == 410
+
+
+def test_verify_rejects_expired_token(saas_client, _db_session):
+    result = _create_signup(_db_session, admin_email="expired@x.de")
+    tok = _db_session.query(SignupToken).filter(SignupToken.user_id == result.user_id).first()
+    tok.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    _db_session.commit()
+    resp = saas_client.get(f"/api/public/verify-email?token={result.verification_token}")
+    assert resp.status_code == 410
+
+
+def test_verify_rejects_unknown_token(saas_client, _db_session):
+    resp = saas_client.get("/api/public/verify-email?token=totally-bogus-token")
+    assert resp.status_code == 410
+
+
+# ----- resend -----------------------------------------------------------
+
+def test_resend_issues_new_token_and_invalidates_old(saas_client, _db_session):
+    result = _create_signup(_db_session, admin_email="resend@x.de")
+    old_token = result.verification_token
+
+    with patch("app.routers.public_signup.send_verification_email", return_value=True) as mail:
+        resp = saas_client.post("/api/public/resend-verification", json={"email": "resend@x.de"})
+    assert resp.status_code == 202
+    assert mail.called
+
+    # Old token must be consumed (inactive)
+    resp2 = saas_client.get(f"/api/public/verify-email?token={old_token}")
+    assert resp2.status_code == 410
+
+
+def test_resend_returns_202_for_unknown_email(saas_client):
+    """Must NOT reveal whether the email is known (enumeration protection)."""
+    with patch("app.routers.public_signup.send_verification_email", return_value=True) as mail:
+        resp = saas_client.post(
+            "/api/public/resend-verification",
+            json={"email": "never-registered@example.com"},
+        )
+    assert resp.status_code == 202
+    assert not mail.called
+
+
+# ----- trial suspension cron -------------------------------------------
+
+def test_suspend_expired_trials(_db_session):
+    # Active trial with stripe sub → keep
+    t1 = Tenant(
+        id=uuid.uuid4(), name="T1", slug="t1", is_active=True, mode="multi",
+        plan="trial", subscription_status="active",
+        trial_ends_at=datetime.now(timezone.utc) - timedelta(days=1),
+        stripe_subscription_id="sub_already_paying",
+    )
+    # Expired trial without Stripe → suspend
+    t2 = Tenant(
+        id=uuid.uuid4(), name="T2", slug="t2", is_active=True, mode="multi",
+        plan="trial", subscription_status="active",
+        trial_ends_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    # Still within trial → keep
+    t3 = Tenant(
+        id=uuid.uuid4(), name="T3", slug="t3", is_active=True, mode="multi",
+        plan="trial", subscription_status="active",
+        trial_ends_at=datetime.now(timezone.utc) + timedelta(days=3),
+    )
+    _db_session.add_all([t1, t2, t3])
+    _db_session.commit()
+
+    count = signup_service.suspend_expired_trials(_db_session)
+    assert count == 1
+
+    _db_session.refresh(t1)
+    _db_session.refresh(t2)
+    _db_session.refresh(t3)
+    assert t1.subscription_status == "active"
+    assert t2.subscription_status == "suspended"
+    assert t3.subscription_status == "active"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import { useAuthStore } from './stores/authStore';
 import { useSystemStore } from './stores/systemStore';
 import { ToastProvider } from './contexts/ToastContext';
 import Login from './pages/Login';
+import Signup from './pages/Signup';
+import Verify from './pages/Verify';
 import Dashboard from './pages/Dashboard';
 import TimeTracking from './pages/TimeTracking';
 import AbsenceCalendarPage from './pages/AbsenceCalendarPage';
@@ -93,6 +95,8 @@ function App() {
           <Routes>
           {/* Public Routes */}
           <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
+          <Route path="/verify" element={<Verify />} />
           <Route path="/privacy" element={<Privacy />} />
 
         {/* Protected Employee Routes */}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Outlet, Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../stores/authStore';
 import { useUIStore } from '../stores/uiStore';
 import { useSystemStore } from '../stores/systemStore';
+import TrialBanner from './TrialBanner';
 import apiClient from '../api/client';
 import {
   LayoutDashboard,
@@ -357,6 +358,7 @@ export default function Layout() {
 
       {/* Main Content */}
       <main id="main-content" className="flex-1 overflow-y-auto overflow-x-hidden lg:pt-0 pt-16 pb-20 lg:pb-0 bg-background" tabIndex={-1}>
+        <TrialBanner />
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 lg:py-8">
           <Outlet />
         </div>

--- a/frontend/src/components/TrialBanner.tsx
+++ b/frontend/src/components/TrialBanner.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { Clock } from 'lucide-react';
+import apiClient from '../api/client';
+import { useAuthStore } from '../stores/authStore';
+import { useSystemStore } from '../stores/systemStore';
+
+interface BillingInfo {
+  plan: string;
+  subscription_status: string;
+  trial_ends_at: string | null;
+}
+
+/**
+ * Admin-only trial countdown. Hidden on on-prem + for non-admins. Fetches
+ * /api/tenant/billing lazily on mount; a 5xx/404 silently hides the banner.
+ */
+export default function TrialBanner() {
+  const user = useAuthStore((s) => s.user);
+  const deploymentMode = useSystemStore((s) => s.info?.deployment_mode);
+  const [billing, setBilling] = useState<BillingInfo | null>(null);
+
+  useEffect(() => {
+    if (user?.role !== 'admin' || deploymentMode !== 'saas') return;
+    apiClient
+      .get<BillingInfo>('/tenant/billing')
+      .then((r) => setBilling(r.data))
+      .catch(() => setBilling(null));
+  }, [user?.role, deploymentMode]);
+
+  if (!billing || billing.plan !== 'trial' || !billing.trial_ends_at) return null;
+
+  const ends = new Date(billing.trial_ends_at);
+  const msLeft = ends.getTime() - Date.now();
+  const daysLeft = Math.max(0, Math.ceil(msLeft / (1000 * 60 * 60 * 24)));
+
+  const urgent = daysLeft <= 3;
+  return (
+    <div
+      className={`flex items-center justify-center gap-2 text-sm px-4 py-2 ${
+        urgent ? 'bg-amber-100 text-amber-900' : 'bg-blue-50 text-blue-800'
+      }`}
+    >
+      <Clock size={14} />
+      <span>
+        Trial läuft in <strong>{daysLeft}</strong> {daysLeft === 1 ? 'Tag' : 'Tagen'} ab
+        {' '}({ends.toLocaleDateString('de-DE')}).
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import { useState, FormEvent } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useAuthStore } from '../stores/authStore';
+import { useSystemStore } from '../stores/systemStore';
 import { LogIn, FileText, Shield, Smartphone } from 'lucide-react';
 import PasswordInput from '../components/PasswordInput';
 import { getErrorMessage } from '../utils/errorMessage';
@@ -17,6 +18,7 @@ export default function Login() {
   const [modalTab, setModalTab] = useState<'cheatsheet' | 'handbuch'>('cheatsheet');
 
   const { login } = useAuthStore();
+  const deploymentMode = useSystemStore((s) => s.info?.deployment_mode);
   const navigate = useNavigate();
 
   const handleSubmit = async (e: FormEvent) => {
@@ -133,6 +135,13 @@ export default function Login() {
             )}
           </button>
         </form>
+
+        {deploymentMode === 'saas' && (
+          <div className="mt-6 text-center text-sm">
+            <span className="text-gray-600">Noch keinen Account? </span>
+            <Link to="/signup" className="text-primary hover:underline">Jetzt Praxis registrieren</Link>
+          </div>
+        )}
 
         <div className="mt-6 text-center text-sm text-gray-500">
           <p>Bei Problemen wenden Sie sich an Ihren Administrator</p>

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -1,0 +1,185 @@
+import { useState, FormEvent } from 'react';
+import { Link } from 'react-router-dom';
+import { UserPlus } from 'lucide-react';
+import apiClient from '../api/client';
+import { useSystemStore } from '../stores/systemStore';
+import PasswordInput from '../components/PasswordInput';
+import { getErrorMessage } from '../utils/errorMessage';
+
+/**
+ * /signup — Self-service practice registration. Shown only when
+ * deployment_mode=saas; on-prem installs can't reach this route because
+ * the backend returns 404 for /api/public/signup.
+ */
+export default function Signup() {
+  const deploymentMode = useSystemStore((s) => s.info?.deployment_mode);
+
+  const [practiceName, setPracticeName] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [country, setCountry] = useState('DE');
+  const [acceptTerms, setAcceptTerms] = useState(false);
+  const [acceptPrivacy, setAcceptPrivacy] = useState(false);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  if (deploymentMode === 'onprem') {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-6 bg-gray-50">
+        <div className="max-w-md bg-white rounded-xl shadow-card p-8 text-center">
+          <h1 className="text-xl font-semibold mb-2">Registrierung nicht verfügbar</h1>
+          <p className="text-sm text-gray-600 mb-4">
+            Diese Installation läuft im Lokalmodus. Eine Selbstregistrierung ist nur auf der SaaS-Plattform möglich.
+          </p>
+          <Link to="/login" className="text-primary hover:underline">Zum Login</Link>
+        </div>
+      </div>
+    );
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await apiClient.post('/public/signup', {
+        practice_name: practiceName,
+        admin_email: email,
+        admin_first_name: firstName,
+        admin_last_name: lastName,
+        admin_password: password,
+        accept_terms: acceptTerms,
+        accept_privacy: acceptPrivacy,
+        country,
+      });
+      setSubmitted(true);
+    } catch (err: any) {
+      setError(getErrorMessage(err, 'Registrierung fehlgeschlagen. Bitte versuche es erneut.'));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-6 bg-gray-50">
+        <div className="max-w-md bg-white rounded-xl shadow-card p-8 text-center">
+          <h1 className="text-xl font-semibold mb-2">Fast geschafft!</h1>
+          <p className="text-sm text-gray-600 mb-4">
+            Wir haben dir eine E-Mail mit einem Bestätigungslink gesendet.
+            Der Link ist 24 Stunden gültig.
+          </p>
+          <Link to="/login" className="text-primary hover:underline">Zum Login</Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6 bg-gray-50">
+      <form onSubmit={handleSubmit} className="w-full max-w-md bg-white rounded-xl shadow-card p-8 space-y-4">
+        <div className="flex items-center gap-2 mb-4">
+          <UserPlus className="text-primary" />
+          <h1 className="text-xl font-semibold">Praxis registrieren</h1>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Praxisname</label>
+          <input
+            type="text" required value={practiceName}
+            onChange={(e) => setPracticeName(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Vorname</label>
+            <input
+              type="text" required value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Nachname</label>
+            <input
+              type="text" required value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">E-Mail-Adresse (Admin)</label>
+          <input
+            type="email" required value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Passwort</label>
+          <PasswordInput
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={8}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+          <p className="text-xs text-gray-500 mt-1">Mindestens 8 Zeichen.</p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Land</label>
+          <select
+            value={country}
+            onChange={(e) => setCountry(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+          >
+            <option value="DE">Deutschland</option>
+            <option value="AT">Österreich</option>
+            <option value="CH">Schweiz</option>
+          </select>
+        </div>
+
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="checkbox" required checked={acceptTerms}
+            onChange={(e) => setAcceptTerms(e.target.checked)}
+            className="mt-1"
+          />
+          <span>Ich akzeptiere die <Link to="/privacy" className="text-primary hover:underline">AGB</Link>.</span>
+        </label>
+
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="checkbox" required checked={acceptPrivacy}
+            onChange={(e) => setAcceptPrivacy(e.target.checked)}
+            className="mt-1"
+          />
+          <span>Ich akzeptiere die <Link to="/privacy" className="text-primary hover:underline">Datenschutzerklärung</Link>.</span>
+        </label>
+
+        {error && <p className="text-sm text-red-600">{error}</p>}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-primary text-white py-2 rounded-lg hover:bg-primary-dark disabled:opacity-50"
+        >
+          {loading ? 'Bitte warten…' : 'Registrieren – 14 Tage kostenlos testen'}
+        </button>
+
+        <p className="text-center text-sm text-gray-600">
+          Bereits registriert? <Link to="/login" className="text-primary hover:underline">Jetzt einloggen</Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/Verify.tsx
+++ b/frontend/src/pages/Verify.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { CheckCircle2, XCircle } from 'lucide-react';
+import apiClient from '../api/client';
+import { getErrorMessage } from '../utils/errorMessage';
+
+/**
+ * /verify?token=… — Confirms the signup link sent to the admin's inbox.
+ * Consumes the token on mount and then shows success / failure.
+ */
+export default function Verify() {
+  const [params] = useSearchParams();
+  const token = params.get('token');
+  const [state, setState] = useState<'loading' | 'ok' | 'error'>('loading');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!token) {
+      setState('error');
+      setError('Der Bestätigungslink ist unvollständig.');
+      return;
+    }
+    apiClient
+      .get(`/public/verify-email?token=${encodeURIComponent(token)}`)
+      .then(() => setState('ok'))
+      .catch((err) => {
+        setState('error');
+        setError(getErrorMessage(err, 'Bestätigung fehlgeschlagen.'));
+      });
+  }, [token]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6 bg-gray-50">
+      <div className="max-w-md w-full bg-white rounded-xl shadow-card p-8 text-center">
+        {state === 'loading' && (
+          <p className="text-sm text-gray-600">Bestätige deine E-Mail-Adresse…</p>
+        )}
+        {state === 'ok' && (
+          <>
+            <CheckCircle2 className="text-success mx-auto mb-4" size={48} />
+            <h1 className="text-xl font-semibold mb-2">E-Mail bestätigt</h1>
+            <p className="text-sm text-gray-600 mb-4">
+              Dein Konto ist aktiviert. Du kannst dich jetzt einloggen.
+            </p>
+            <Link
+              to="/login"
+              className="inline-block bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary-dark"
+            >
+              Zum Login
+            </Link>
+          </>
+        )}
+        {state === 'error' && (
+          <>
+            <XCircle className="text-red-500 mx-auto mb-4" size={48} />
+            <h1 className="text-xl font-semibold mb-2">Bestätigung fehlgeschlagen</h1>
+            <p className="text-sm text-gray-600 mb-4">{error}</p>
+            <Link to="/login" className="text-primary hover:underline">Zurück zum Login</Link>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Issue #94. Self-service practice registration on the SaaS deployment with a DSGVO-compliant double-opt-in.

## Migration 034_signup_tokens

- **signup_tokens**: hashed 24 h verification token (SHA-256 — raw token never touches disk) + RLS
- **signup_audit_log**: DSGVO Art. 7 consent proof (IP + UA + accepted_terms/accepted_privacy). \`tenant_id\` nullable so rows survive the Phase-6 tenant-delete anonymization

## Backend

| Endpoint | Rate-limit | Purpose |
|---|---|---|
| POST \`/api/public/signup\` | 5/h | create tenant + inactive admin + mail verification link |
| GET  \`/api/public/verify-email?token=…\` | 10/min | activate admin, consume token |
| POST \`/api/public/resend-verification\` | 3/h | invalidate previous token + send a new one; **202 on unknown emails** (enumeration defence) |
| POST \`/api/superadmin/cron/trial-check\` | — | bare endpoint for external cron. Suspends expired trials without a Stripe subscription (Phase 4 webhook will be the reactivate path) |

All \`/api/public/*\` routes return **404 in \`onprem\` mode** (Phase 1 already hides the UI; this is defence in depth). Inbound IP is trusted from \`X-Forwarded-For\`.

\`mail_service\` is stdlib-only (smtplib). When \`MAIL_HOST\` is unset it logs the email body and returns True — signup works in CI without a relay. New env vars: \`MAIL_HOST\`, \`MAIL_PORT\`, \`MAIL_USER\`, \`MAIL_PASS\`, \`MAIL_FROM\`, \`MAIL_STARTTLS\`.

14-day trial + \`subscription_status='active'\` set on signup.

## Frontend

- \`/signup\` page — visible only when \`deployment_mode=saas\`; onprem shows a friendly "Nicht verfügbar" card
- \`/verify\` page — consumes \`?token=…\` on mount, routes to \`/login\` on success
- Login page gains "Noch keinen Account? Jetzt Praxis registrieren" link in saas mode
- \`TrialBanner\` (admin + saas only) — days-left countdown sourced from \`/api/tenant/billing\`, turns amber when ≤ 3 days

## Test plan

- [x] \`docker compose exec backend pytest tests/test_signup.py -p no:asyncio\` → 14/14
- [x] Full unit suite: 419/419 (+14 since Phase 2)
- [x] \`alembic upgrade head\` + downgrade are both clean against dev DB
- [x] Frontend \`tsc --noEmit\`: clean
- [x] Manual spec check:
  - [x] onprem mode returns 404 for all \`/api/public/*\`
  - [x] expired token → 410, reused token → 410, unknown token → 410
  - [x] missing consent → 422, short password → 422
  - [x] duplicate active email → 409
  - [x] audit log written with IP/UA/consent flags
  - [x] trial cron suspends expired trials without Stripe subscription

## What's deferred (out of scope for this PR)

- reCAPTCHA / Cloudflare Turnstile — needs external account (belongs in Phase 8 Go-Live)
- Rich HTML email template / branding
- AVV auto-generation (scheduled for Phase 6)

## Roadmap

- Closes #94
- Unblocks Phase 4 (#95 Stripe — webhook will hand off to \`trial_ends_at\` + \`subscription_status\`) and Phase 5 (#96 seat-limit enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)