### PR TITLE
Phase 5 — Plan enforcement: seat limits + feature matrix

### DIFF
--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -286,6 +286,14 @@ def create_user(user_data: UserCreate, db: Session = Depends(get_db), current_us
     )
     check_employee_limit(active_count)
 
+    # SaaS: plan-based seat limit. Onprem Default-Tenant has plan=enterprise
+    # → unlimited, so this is effectively a no-op for on-prem installs.
+    from app.models.tenant import Tenant
+    from app.services.plan_enforcement import check_seat_limit
+    tenant = db.query(Tenant).filter(Tenant.id == current_user.tenant_id).first()
+    if tenant is not None:
+        check_seat_limit(db, tenant)
+
     new_user = User(
         username=user_data.username.lower(),
         email=user_data.email or None,
@@ -397,6 +405,13 @@ def reactivate_user(user_id: str, db: Session = Depends(get_db), current_user: U
     user = _get_user_in_tenant(db, user_id, current_user)
     if not user:
         raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
+
+    # Seat-limit enforcement: a reactivation is logically a seat add.
+    from app.models.tenant import Tenant
+    from app.services.plan_enforcement import check_seat_limit
+    tenant = db.query(Tenant).filter(Tenant.id == current_user.tenant_id).first()
+    if tenant is not None:
+        check_seat_limit(db, tenant)
 
     user.is_active = True
     user.deactivated_at = None

--- a/backend/app/routers/tenant_billing.py
+++ b/backend/app/routers/tenant_billing.py
@@ -24,6 +24,26 @@ from app.schemas.tenant import (
 router = APIRouter(prefix="/api/tenant", tags=["tenant-billing"])
 
 
+@router.get("/usage")
+def get_usage(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    """Return seat usage + plan features for the banner / billing UI."""
+    from app.services.plan_enforcement import (
+        active_seat_count, get_plan_features, seat_limit_for,
+    )
+    tenant = _get_own_tenant(db, current_user)
+    return {
+        "plan": tenant.plan,
+        "subscription_status": tenant.subscription_status,
+        "used_seats": active_seat_count(db, tenant.id),
+        "seat_limit": seat_limit_for(tenant),  # None = unlimited
+        "features": sorted(get_plan_features(tenant.plan)),
+        "trial_ends_at": tenant.trial_ends_at.isoformat() if tenant.trial_ends_at else None,
+    }
+
+
 def _get_own_tenant(db: Session, current_user: User) -> Tenant:
     """Fetch the caller's tenant. Explicit filter belt-and-suspenders:
     RLS would already scope this, but matching Phase 0 Issue #91 pattern."""

--- a/backend/app/services/plan_enforcement.py
+++ b/backend/app/services/plan_enforcement.py
@@ -1,0 +1,86 @@
+"""Plan gating: seat limits + feature flags (Phase 5 / Issue #96).
+
+Single source of truth for "what does plan X include?". The Stripe
+webhook sets ``tenant.plan``; routes call ``check_seat_limit()`` and
+``requires_feature()`` to enforce it.
+
+Plan matrix:
+    trial       5 seats    all features (so evaluators see the full UX)
+    starter     5 seats    no SSO, no advanced reporting, no custom branding
+    pro        25 seats    everything except custom branding
+    enterprise  unlimited  everything + SLA (not modelled in code)
+
+``seat_limit=None`` on the tenant row always means unlimited (overrides
+the plan default). Superadmin can override the per-tenant seat_limit to
+accommodate special deals without a plan change.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.models import User
+from app.models.tenant import Tenant
+
+
+# plan → (seat_limit, features)
+_PLAN_DEFAULTS: dict[str, tuple[int | None, set[str]]] = {
+    "trial": (5, {"reports", "change_requests", "sso", "advanced_reporting"}),
+    "starter": (5, {"reports", "change_requests"}),
+    "pro": (25, {"reports", "change_requests", "sso", "advanced_reporting"}),
+    "enterprise": (None, {"reports", "change_requests", "sso", "advanced_reporting", "custom_branding"}),
+}
+
+
+def seat_limit_for(tenant: Tenant) -> int | None:
+    """Effective seat limit: tenant.seat_limit override takes precedence
+    over the plan default. None = unlimited."""
+    if tenant.seat_limit is not None:
+        return tenant.seat_limit
+    default, _ = _PLAN_DEFAULTS.get(tenant.plan, (None, set()))
+    return default
+
+
+def get_plan_features(plan: str) -> set[str]:
+    _, features = _PLAN_DEFAULTS.get(plan, (None, set()))
+    return set(features)
+
+
+def active_seat_count(db: Session, tenant_id) -> int:
+    return (
+        db.query(User)
+        .filter(User.tenant_id == tenant_id, User.is_active == True)  # noqa: E712
+        .count()
+    )
+
+
+def check_seat_limit(db: Session, tenant: Tenant) -> None:
+    """Raise 403 when the tenant is at or above its seat limit.
+
+    Called by admin_users.create_user BEFORE db.add; keeps the race-window
+    small but we still wrap the subsequent INSERT + COMMIT — we don't need
+    a SELECT FOR UPDATE because a rare +1 over-provision is fine (the cron
+    in Phase 6 can reconcile).
+    """
+    limit = seat_limit_for(tenant)
+    if limit is None:
+        return
+    used = active_seat_count(db, tenant.id)
+    if used >= limit:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Sitzlimit erreicht ({used}/{limit}). Bitte Plan upgraden, "
+                "um weitere Mitarbeiter hinzuzufügen."
+            ),
+        )
+
+
+def require_feature(tenant: Tenant, feature: str) -> None:
+    """Raise 403 when the tenant's plan doesn't include ``feature``."""
+    if feature not in get_plan_features(tenant.plan):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Feature '{feature}' nicht im aktuellen Plan enthalten",
+        )

--- a/backend/tests/test_plan_enforcement.py
+++ b/backend/tests/test_plan_enforcement.py
@@ -1,0 +1,209 @@
+"""Tests for plan-based seat enforcement + features (Phase 5 / Issue #96)."""
+
+from __future__ import annotations
+
+import uuid
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app.database import Base, get_db
+from app.middleware.auth import get_current_user, require_admin
+from app.models import User, UserRole
+from app.models.tenant import Tenant
+from app.services import auth_service
+from app.services.plan_enforcement import (
+    check_seat_limit, get_plan_features, seat_limit_for,
+)
+from tests.conftest import engine, TestingSessionLocal
+from tests.test_endpoints import test_app
+
+
+TENANT_ID = uuid.UUID("dddddddd-0000-4000-8000-000000000501")
+
+
+@pytest.fixture
+def _db_session():
+    with engine.connect() as conn:
+        conn.execute(text("PRAGMA foreign_keys = OFF"))
+        conn.commit()
+    Base.metadata.drop_all(bind=engine, checkfirst=True)
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        with engine.connect() as conn:
+            conn.execute(text("PRAGMA foreign_keys = OFF"))
+            conn.commit()
+        Base.metadata.drop_all(bind=engine, checkfirst=True)
+
+
+def _seed_tenant(db, plan, seat_override=None):
+    t = Tenant(
+        id=TENANT_ID, name="T", slug="t-seat", is_active=True, mode="multi",
+        plan=plan, subscription_status="active", seat_limit=seat_override,
+    )
+    db.add(t)
+    db.commit()
+    return t
+
+
+def _mk_user(db, username, *, active=True, role=UserRole.EMPLOYEE):
+    u = User(
+        username=username, email=f"{username}@t.de",
+        password_hash=auth_service.hash_password("S3curePassword!"),
+        first_name=username, last_name="X", role=role,
+        weekly_hours=40, vacation_days=30, work_days_per_week=5,
+        is_active=active, tenant_id=TENANT_ID,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+# ─── pure helpers ────────────────────────────────────────────────
+
+def test_plan_defaults():
+    assert seat_limit_for(Tenant(plan="trial")) == 5
+    assert seat_limit_for(Tenant(plan="starter")) == 5
+    assert seat_limit_for(Tenant(plan="pro")) == 25
+    assert seat_limit_for(Tenant(plan="enterprise")) is None
+
+
+def test_seat_limit_override_wins():
+    assert seat_limit_for(Tenant(plan="starter", seat_limit=50)) == 50
+    assert seat_limit_for(Tenant(plan="pro", seat_limit=1)) == 1
+
+
+def test_plan_feature_matrix():
+    assert "sso" in get_plan_features("pro")
+    assert "sso" not in get_plan_features("starter")
+    assert "custom_branding" in get_plan_features("enterprise")
+    assert "custom_branding" not in get_plan_features("pro")
+
+
+# ─── check_seat_limit ────────────────────────────────────────────
+
+def test_check_seat_limit_allows_below(_db_session):
+    t = _seed_tenant(_db_session, "starter")
+    _mk_user(_db_session, "u1")
+    _mk_user(_db_session, "u2")
+    # 2/5 — must not raise
+    check_seat_limit(_db_session, t)
+
+
+def test_check_seat_limit_blocks_at_limit(_db_session):
+    t = _seed_tenant(_db_session, "starter")
+    for i in range(5):
+        _mk_user(_db_session, f"u{i}")
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc:
+        check_seat_limit(_db_session, t)
+    assert exc.value.status_code == 403
+
+
+def test_check_seat_limit_inactive_users_do_not_count(_db_session):
+    t = _seed_tenant(_db_session, "starter")
+    for i in range(5):
+        _mk_user(_db_session, f"a{i}", active=True)
+    for i in range(3):
+        _mk_user(_db_session, f"b{i}", active=False)
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException):
+        check_seat_limit(_db_session, t)
+
+
+def test_check_seat_limit_enterprise_unlimited(_db_session):
+    t = _seed_tenant(_db_session, "enterprise")
+    for i in range(50):
+        _mk_user(_db_session, f"x{i}")
+    check_seat_limit(_db_session, t)  # must not raise
+
+
+# ─── Endpoint: /api/admin/users enforces ─────────────────────────
+
+@pytest.fixture
+def admin_client(_db_session):
+    t = _seed_tenant(_db_session, "starter")
+    admin_user = _mk_user(_db_session, "admin@t.de", role=UserRole.ADMIN)
+
+    def _db(): yield _db_session
+    def _who(): return admin_user
+    test_app.dependency_overrides[get_db] = _db
+    test_app.dependency_overrides[get_current_user] = _who
+    test_app.dependency_overrides[require_admin] = _who
+    with TestClient(test_app) as c:
+        yield c, t
+    test_app.dependency_overrides.clear()
+
+
+def test_create_user_blocked_at_seat_limit(_db_session, admin_client):
+    client, t = admin_client
+    # Admin counts as 1 seat; create 4 more to hit limit 5
+    for i in range(4):
+        _mk_user(_db_session, f"emp{i}")
+    payload = {
+        "username": "too_many", "password": "S3curePassword!",
+        "first_name": "X", "last_name": "Y", "role": "employee",
+        "weekly_hours": 40, "vacation_days": 30, "work_days_per_week": 5,
+        "track_hours": True, "calendar_color": "#000000",
+        "use_daily_schedule": False,
+    }
+    resp = client.post("/api/admin/users", json=payload)
+    assert resp.status_code == 403, resp.text
+    assert "Sitzlimit" in resp.json()["detail"]
+
+
+def test_reactivate_blocked_at_seat_limit(_db_session, admin_client):
+    client, t = admin_client
+    # Admin + 4 active = 5. Plus one inactive who tries to reactivate.
+    for i in range(4):
+        _mk_user(_db_session, f"emp{i}")
+    inactive = _mk_user(_db_session, "ghost", active=False)
+
+    resp = client.post(f"/api/admin/users/{inactive.id}/reactivate")
+    assert resp.status_code == 403, resp.text
+
+
+# ─── /api/tenant/usage ────────────────────────────────────────────
+
+def test_usage_endpoint_returns_seats_and_plan(_db_session, admin_client):
+    client, _ = admin_client
+    for i in range(2):
+        _mk_user(_db_session, f"u{i}")
+    resp = client.get("/api/tenant/usage")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["plan"] == "starter"
+    assert data["seat_limit"] == 5
+    # admin + 2 employees = 3
+    assert data["used_seats"] == 3
+    assert "reports" in data["features"]
+    assert "sso" not in data["features"]  # starter
+
+
+def test_usage_endpoint_enterprise_unlimited(_db_session):
+    # Fresh tenant with plan=enterprise
+    t = Tenant(
+        id=TENANT_ID, name="E", slug="e-seat", is_active=True, mode="multi",
+        plan="enterprise", subscription_status="active",
+    )
+    _db_session.add(t)
+    _db_session.commit()
+    admin_user = _mk_user(_db_session, "admin2", role=UserRole.ADMIN)
+
+    def _db(): yield _db_session
+    def _who(): return admin_user
+    test_app.dependency_overrides[get_db] = _db
+    test_app.dependency_overrides[get_current_user] = _who
+    test_app.dependency_overrides[require_admin] = _who
+    try:
+        with TestClient(test_app) as client:
+            resp = client.get("/api/tenant/usage")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["seat_limit"] is None
+    finally:
+        test_app.dependency_overrides.clear()

--- a/frontend/src/pages/admin/Billing.tsx
+++ b/frontend/src/pages/admin/Billing.tsx
@@ -15,6 +15,13 @@ interface BillingInfo {
   country: string | null;
 }
 
+interface UsageInfo {
+  plan: string;
+  used_seats: number;
+  seat_limit: number | null;
+  features: string[];
+}
+
 interface Invoice {
   id: string;
   stripe_invoice_id: string;
@@ -28,6 +35,7 @@ interface Invoice {
 
 export default function Billing() {
   const [info, setInfo] = useState<BillingInfo | null>(null);
+  const [usage, setUsage] = useState<UsageInfo | null>(null);
   const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -39,11 +47,13 @@ export default function Billing() {
   async function refresh() {
     setLoading(true);
     try {
-      const [b, i] = await Promise.all([
+      const [b, u, i] = await Promise.all([
         apiClient.get<BillingInfo>('/tenant/billing'),
+        apiClient.get<UsageInfo>('/tenant/usage'),
         apiClient.get<Invoice[]>('/tenant/invoices'),
       ]);
       setInfo(b.data);
+      setUsage(u.data);
       setInvoices(i.data);
     } catch (err: any) {
       setError(getErrorMessage(err, 'Fehler beim Laden der Abrechnung'));
@@ -133,6 +143,31 @@ export default function Billing() {
             </button>
           )}
         </div>
+
+        {usage && (
+          <div className="pt-3 border-t border-gray-100">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-gray-600">Sitze</span>
+              <span className="font-medium">
+                {usage.used_seats}
+                {usage.seat_limit !== null && <span className="text-gray-500"> / {usage.seat_limit}</span>}
+                {usage.seat_limit === null && <span className="text-gray-500"> / ∞</span>}
+              </span>
+            </div>
+            {usage.seat_limit !== null && (
+              <div className="mt-1 h-2 bg-gray-100 rounded overflow-hidden">
+                <div
+                  className={`h-full ${
+                    usage.used_seats >= usage.seat_limit ? 'bg-red-500' :
+                    usage.used_seats >= usage.seat_limit * 0.8 ? 'bg-amber-500' :
+                    'bg-primary'
+                  }`}
+                  style={{ width: `${Math.min(100, (usage.used_seats / usage.seat_limit) * 100)}%` }}
+                />
+              </div>
+            )}
+          </div>
+        )}
       </section>
 
       {(info.plan === 'trial' || info.plan === 'starter') && (


### PR DESCRIPTION
## Summary

Issue #96. Plans now actually restrict what a tenant can do.

## Plan matrix (single source of truth)

| plan | seats | features |
|---|---|---|
| trial | 5 | reports + change_requests + sso + advanced_reporting *(full UX for eval)* |
| starter | 5 | reports + change_requests |
| pro | 25 | everything except \`custom_branding\` |
| enterprise | ∞ | everything |

\`tenant.seat_limit\` (if set by superadmin) overrides the plan default — lets you negotiate custom deals without changing the plan string.

## Enforcement

- \`POST /api/admin/users\` → \`check_seat_limit\` before the INSERT (existing on-prem license check remains for on-prem installs)
- \`POST /api/admin/users/{id}/reactivate\` → same check (reactivation is logically a seat add)
- Returns **403** "Sitzlimit erreicht (X/Y). Bitte Plan upgraden..." with the current counts so the UI can deep-link to /admin/billing.

## New endpoint

\`GET /api/tenant/usage\` (admin) → \`{plan, subscription_status, used_seats, seat_limit, features, trial_ends_at}\` — powers the billing UI's seat-usage bar and future feature-gating in the frontend.

## Frontend

\`/admin/billing\` gains a usage bar:
- "X / Y" for bounded plans, "X / ∞" for enterprise
- Turns amber at ≥80%, red at limit

## Test plan

- [x] \`docker compose exec backend pytest tests/test_plan_enforcement.py -p no:asyncio\` → 11/11
- [x] Full unit suite: 442/442 (+11 since Phase 4)
- [x] Frontend \`tsc --noEmit\`: clean
- [x] Plan matrix (trial/starter/pro/enterprise), seat override precedence, feature flags, inactive-users-don't-count, reactivation blocked at limit

## Roadmap

- Closes #96
- Unblocks Phase 6 (#97 tenant-lifecycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)