### PR TITLE
Phase 7 — Per-tenant metrics + superadmin overview + Slack alerts

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -149,6 +149,9 @@ class Settings(BaseSettings):
     # Grace period before a canceled subscription flips to 'suspended'.
     STRIPE_CANCEL_GRACE_DAYS: int = 30
 
+    # Optional — operator alerts (Phase 7). Unset → alerts are logged only.
+    SLACK_WEBHOOK_URL: Optional[str] = None
+
     @field_validator("SECRET_KEY")
     @classmethod
     def validate_secret_key(cls, v: str) -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -274,6 +274,24 @@ app.include_router(billing.webhook_router)
 
 
 @app.middleware("http")
+async def tenant_metrics_middleware(request: Request, call_next):
+    """Increment per-tenant HTTP counter before handing off to the route.
+    Only adds a label lookup per request — cheap enough for the hot path."""
+    tid = None
+    auth = request.headers.get("authorization", "")
+    if auth.lower().startswith("bearer "):
+        try:
+            from app.services.auth_service import decode_token
+            payload = decode_token(auth.split(" ", 1)[1]) or {}
+            tid = payload.get("tid")
+        except Exception:  # noqa: BLE001
+            tid = None
+    from app.services.tenant_metrics import record_request
+    record_request(tid, request.method)
+    return await call_next(request)
+
+
+@app.middleware("http")
 async def capture_errors_middleware(request: Request, call_next):
     """Capture 5xx errors and log them to the error_logs table."""
     try:

--- a/backend/app/routers/public_signup.py
+++ b/backend/app/routers/public_signup.py
@@ -83,6 +83,11 @@ def signup(
         verification_url=verify_url,
         practice_name=body.practice_name,
     )
+    try:
+        from app.services.alerting import alert_new_signup
+        alert_new_signup(body.practice_name, body.admin_email)
+    except Exception:  # noqa: BLE001 — alerts never block signup
+        pass
     return SignupResponse(tenant_id=str(result.tenant_id))
 
 

--- a/backend/app/routers/superadmin.py
+++ b/backend/app/routers/superadmin.py
@@ -205,6 +205,84 @@ def export_tenant_arbzg_data(
     )
 
 
+@router.get("/tenants-overview")
+def tenants_overview(
+    page: int = Query(1, ge=1),
+    per_page: int = Query(25, ge=1, le=200),
+    status_filter: str | None = Query(None, pattern="^(active|trial|past_due|suspended|canceled)$"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_superadmin),
+):
+    """Paginated tenant listing for the Superadmin Dashboard (Phase 7).
+
+    Returns plan, status, trial-days-remaining, active-seats, MRR-contribution.
+    """
+    from app.services.metrics_refresh import _PLAN_MONTHLY_CENTS
+    set_superadmin_context(db)
+    q = db.query(Tenant)
+    if status_filter == "trial":
+        q = q.filter(Tenant.plan == "trial")
+    elif status_filter in {"active", "past_due", "suspended", "canceled"}:
+        q = q.filter(Tenant.subscription_status == status_filter)
+
+    total = q.count()
+    rows = q.order_by(Tenant.created_at.desc()).offset((page - 1) * per_page).limit(per_page).all()
+
+    now = datetime.now(timezone.utc)
+    out = []
+    for t in rows:
+        seats = (
+            db.query(User)
+            .filter(User.tenant_id == t.id, User.is_active == True)  # noqa: E712
+            .count()
+        )
+        trial_days_left = None
+        if t.plan == "trial" and t.trial_ends_at:
+            ends = t.trial_ends_at if t.trial_ends_at.tzinfo else t.trial_ends_at.replace(tzinfo=timezone.utc)
+            trial_days_left = max(0, (ends - now).days)
+        mrr_contrib = 0
+        if t.plan in _PLAN_MONTHLY_CENTS and t.subscription_status == "active":
+            mrr_contrib = _PLAN_MONTHLY_CENTS[t.plan] * max(1, seats)
+        out.append({
+            "id": str(t.id),
+            "name": t.name,
+            "slug": t.slug,
+            "plan": t.plan,
+            "subscription_status": t.subscription_status,
+            "seats": seats,
+            "seat_limit": t.seat_limit,
+            "trial_ends_at": t.trial_ends_at.isoformat() if t.trial_ends_at else None,
+            "trial_days_left": trial_days_left,
+            "mrr_cents": mrr_contrib,
+            "created_at": t.created_at.isoformat() if t.created_at else None,
+            "deletion_requested_at": t.deletion_requested_at.isoformat() if t.deletion_requested_at else None,
+            "anonymized_at": t.anonymized_at.isoformat() if t.anonymized_at else None,
+        })
+    return {"total": total, "page": page, "per_page": per_page, "tenants": out}
+
+
+@router.get("/metrics/mrr")
+def mrr_details(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_superadmin),
+):
+    """Detailed MRR breakdown for dashboard KPIs."""
+    from app.services.metrics_refresh import compute_mrr_details
+    set_superadmin_context(db)
+    return compute_mrr_details(db)
+
+
+@router.post("/cron/metrics-refresh")
+def cron_metrics_refresh(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_superadmin),
+):
+    """Recompute per-tenant Prometheus gauges + billing KPIs."""
+    from app.services.metrics_refresh import refresh_all
+    set_superadmin_context(db)
+    return refresh_all(db)
+
+
 @router.post("/cron/trial-check")
 def cron_trial_check(
     db: Session = Depends(get_db),

--- a/backend/app/services/alerting.py
+++ b/backend/app/services/alerting.py
@@ -1,0 +1,62 @@
+"""Operator alerts (Slack webhook, optional — Phase 7 / Issue #98).
+
+Fire-and-forget JSON POST to the configured Slack-incoming-webhook URL.
+When ``SLACK_WEBHOOK_URL`` is unset, each call is a no-op so CI / local
+work without a Slack workspace.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from typing import Optional
+
+from app.config import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+def is_configured() -> bool:
+    return bool(getattr(settings, "SLACK_WEBHOOK_URL", None))
+
+
+def alert(text: str, *, channel: Optional[str] = None) -> bool:
+    """Post ``text`` to Slack. Returns True on success / dry-run."""
+    url = getattr(settings, "SLACK_WEBHOOK_URL", None)
+    if not url:
+        logger.info("alerting (no Slack webhook configured): %s", text)
+        return True
+
+    payload: dict = {"text": text}
+    if channel:
+        payload["channel"] = channel
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return 200 <= resp.status < 300
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("alerting: Slack webhook failed: %s", exc)
+        return False
+
+
+# ───────────────── Convenience wrappers ─────────────────
+
+def alert_new_signup(tenant_name: str, admin_email: str) -> None:
+    alert(f":tada: Neuer Signup: *{tenant_name}* ({admin_email})")
+
+
+def alert_plan_upgrade(tenant_name: str, new_plan: str) -> None:
+    alert(f":rocket: Plan-Upgrade: *{tenant_name}* → {new_plan}")
+
+
+def alert_past_due(tenant_name: str, days: int) -> None:
+    alert(f":warning: Zahlung überfällig ({days} Tage): *{tenant_name}*")
+
+
+def alert_deletion_requested(tenant_name: str) -> None:
+    alert(f":wastebasket: Löschantrag: *{tenant_name}*")

--- a/backend/app/services/lifecycle_service.py
+++ b/backend/app/services/lifecycle_service.py
@@ -74,6 +74,11 @@ def request_deletion(db: Session, tenant: Tenant, by_user: User) -> datetime:
     tenant.deletion_requested_at = now
     tenant.deletion_requested_by = by_user.id
     db.commit()
+    try:
+        from app.services.alerting import alert_deletion_requested
+        alert_deletion_requested(tenant.name)
+    except Exception:  # noqa: BLE001
+        pass
     return now + timedelta(days=DELETE_GRACE_DAYS)
 
 

--- a/backend/app/services/metrics_refresh.py
+++ b/backend/app/services/metrics_refresh.py
@@ -1,0 +1,121 @@
+"""Background refresh of per-tenant gauges + billing KPIs
+(Phase 7 / Issue #98).
+
+These gauges can't be point-in-time updated by request handlers (DAU,
+employee count, storage are SELECT COUNT queries). The operator cron
+invokes /api/superadmin/cron/metrics-refresh once per day/hour.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Callable
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models import User
+from app.models.tenant import Tenant
+from app.services.tenant_metrics import (
+    praxiszeit_active_tenants,
+    praxiszeit_mrr_cents,
+    praxiszeit_tenant_dau,
+    praxiszeit_tenant_employees,
+    praxiszeit_tenant_storage_bytes,
+    praxiszeit_trial_tenants,
+)
+
+
+# Monthly price in cents per plan. Kept in-code (not DB) because we
+# always want the RESOURCE price, not whatever discount a single tenant
+# negotiated — MRR should reflect steady-state revenue.
+_PLAN_MONTHLY_CENTS: dict[str, int] = {
+    "starter": 1900,   # €19 / seat / month
+    "pro": 3900,       # €39 / seat / month
+    "enterprise": 0,   # per-contract, don't double-count in public MRR
+}
+
+
+def refresh_all(db: Session) -> dict[str, float]:
+    """Recompute every tenant-labelled gauge + aggregate KPIs. Returns a
+    summary dict for logging."""
+    tenants = db.query(Tenant).filter(Tenant.is_active == True).all()  # noqa: E712
+
+    # Per-tenant employee counts
+    for t in tenants:
+        count = (
+            db.query(User)
+            .filter(User.tenant_id == t.id, User.is_active == True)  # noqa: E712
+            .count()
+        )
+        praxiszeit_tenant_employees.labels(tenant_id=str(t.id)).set(count)
+
+    # DAU: users who appeared in any TimeEntry in the last 24 h.
+    from app.models import TimeEntry
+    since = datetime.now(timezone.utc) - timedelta(hours=24)
+    since_date = since.date()
+    dau_rows = (
+        db.query(TimeEntry.tenant_id, func.count(func.distinct(TimeEntry.user_id)))
+        .filter(TimeEntry.date >= since_date)
+        .group_by(TimeEntry.tenant_id)
+        .all()
+    )
+    dau_by_tid = {str(tid): count for tid, count in dau_rows}
+    for t in tenants:
+        praxiszeit_tenant_dau.labels(tenant_id=str(t.id)).set(dau_by_tid.get(str(t.id), 0))
+
+    # Storage: row count × guesstimate 200 bytes/row. Cheap proxy; good
+    # enough for a dashboard trend line. Don't JOIN pg_total_relation_size
+    # because that requires superuser perms inside Postgres.
+    for t in tenants:
+        te = db.query(TimeEntry).filter(TimeEntry.tenant_id == t.id).count()
+        praxiszeit_tenant_storage_bytes.labels(tenant_id=str(t.id)).set(te * 200)
+
+    # Aggregates
+    active_tenants = [t for t in tenants if t.subscription_status == "active"]
+    trial_tenants = [t for t in tenants if t.plan == "trial"]
+    praxiszeit_active_tenants.set(len(active_tenants))
+    praxiszeit_trial_tenants.set(len(trial_tenants))
+
+    # MRR: sum of monthly prices × seats for active non-trial tenants.
+    mrr = 0
+    for t in active_tenants:
+        if t.plan == "trial" or t.plan == "enterprise":
+            continue
+        seats = (
+            db.query(User)
+            .filter(User.tenant_id == t.id, User.is_active == True)  # noqa: E712
+            .count()
+        )
+        mrr += _PLAN_MONTHLY_CENTS.get(t.plan, 0) * max(1, seats)
+    praxiszeit_mrr_cents.set(mrr)
+
+    return {
+        "tenants": len(tenants),
+        "active_tenants": len(active_tenants),
+        "trial_tenants": len(trial_tenants),
+        "mrr_cents": mrr,
+    }
+
+
+def compute_mrr_details(db: Session) -> dict:
+    """Return a more detailed MRR breakdown for the superadmin dashboard."""
+    by_plan = {"starter": 0, "pro": 0, "enterprise": 0}
+    for t in db.query(Tenant).filter(
+        Tenant.is_active == True,  # noqa: E712
+        Tenant.subscription_status == "active",
+    ).all():
+        if t.plan in by_plan:
+            seats = (
+                db.query(User)
+                .filter(User.tenant_id == t.id, User.is_active == True)  # noqa: E712
+                .count()
+            )
+            by_plan[t.plan] += _PLAN_MONTHLY_CENTS.get(t.plan, 0) * max(1, seats)
+
+    mrr_cents = by_plan["starter"] + by_plan["pro"]
+    return {
+        "mrr_cents": mrr_cents,
+        "arr_cents": mrr_cents * 12,
+        "by_plan": by_plan,
+    }

--- a/backend/app/services/stripe_service.py
+++ b/backend/app/services/stripe_service.py
@@ -220,6 +220,11 @@ def handle_event(db: Session, event) -> dict:
         tenant.subscription_status = "active"
         if plan:
             tenant.plan = plan
+            try:
+                from app.services.alerting import alert_plan_upgrade
+                alert_plan_upgrade(tenant.name, plan)
+            except Exception:  # noqa: BLE001
+                pass
         action = "subscription_activated"
 
     elif etype == "customer.subscription.updated":

--- a/backend/app/services/tenant_metrics.py
+++ b/backend/app/services/tenant_metrics.py
@@ -1,0 +1,67 @@
+"""Per-tenant Prometheus metrics (Phase 7 / Issue #98).
+
+Exposed as the standard Prometheus metric objects so the existing
+``prometheus_fastapi_instrumentator`` endpoint picks them up without
+any additional wiring.
+
+We use labels {tenant_id} sparingly — Prometheus cardinality guidance
+is to keep label values in the low thousands. Since each PraxisZeit
+tenant is a paying customer, that's inherently bounded.
+"""
+
+from prometheus_client import Counter, Gauge
+
+
+# Per-tenant API request counter. Labelled by tenant_id + route template
+# (the instrumentator already groups paths, we add the tenant dimension
+# via a middleware below).
+praxiszeit_tenant_api_requests_total = Counter(
+    "praxiszeit_tenant_api_requests_total",
+    "HTTP requests handled by API, per tenant.",
+    ["tenant_id", "method"],
+)
+
+praxiszeit_tenant_dau = Gauge(
+    "praxiszeit_tenant_dau",
+    "Daily active users per tenant (unique users in the last 24 h).",
+    ["tenant_id"],
+)
+
+praxiszeit_tenant_employees = Gauge(
+    "praxiszeit_tenant_employees",
+    "Active employees per tenant right now.",
+    ["tenant_id"],
+)
+
+praxiszeit_tenant_storage_bytes = Gauge(
+    "praxiszeit_tenant_storage_bytes",
+    "Approximate storage used per tenant (bytes).",
+    ["tenant_id"],
+)
+
+# Billing KPIs — tenant-agnostic but updated by the same refresh job.
+praxiszeit_mrr_cents = Gauge(
+    "praxiszeit_mrr_cents",
+    "Monthly recurring revenue in cents across all active subscriptions.",
+)
+
+praxiszeit_active_tenants = Gauge(
+    "praxiszeit_active_tenants",
+    "Number of tenants with subscription_status='active'.",
+)
+
+praxiszeit_trial_tenants = Gauge(
+    "praxiszeit_trial_tenants",
+    "Number of tenants currently on the trial plan.",
+)
+
+
+def record_request(tenant_id: str | None, method: str) -> None:
+    """Increment the per-tenant request counter. ``None`` tenant_id means
+    the request was unauthenticated (public signup, health, webhook);
+    we record it under the literal ``"none"`` label so the metric is
+    still queryable."""
+    praxiszeit_tenant_api_requests_total.labels(
+        tenant_id=tenant_id or "none",
+        method=method,
+    ).inc()

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -51,6 +51,7 @@ def _create_test_app() -> FastAPI:
         tenant_billing,
         public_signup,
         billing,
+        superadmin,
     )
 
     app = FastAPI(title="PraxisZeit Test")
@@ -82,6 +83,7 @@ def _create_test_app() -> FastAPI:
     app.include_router(public_signup.router)
     app.include_router(billing.router)
     app.include_router(billing.webhook_router)
+    app.include_router(superadmin.router)
 
     # Health endpoint (duplicated from main.py since it is defined there directly)
     @app.get("/api/health")

--- a/backend/tests/test_metrics_and_alerts.py
+++ b/backend/tests/test_metrics_and_alerts.py
@@ -1,0 +1,206 @@
+"""Phase 7 tests — per-tenant metrics, MRR calc, alerts, superadmin
+tenant-overview endpoint."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, time, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app.config import settings
+from app.database import Base, get_db
+from app.middleware.auth import get_current_user, require_superadmin
+from app.models import TimeEntry, User, UserRole
+from app.models.tenant import Tenant
+from app.services import alerting, auth_service
+from app.services.metrics_refresh import compute_mrr_details, refresh_all
+from app.services.tenant_metrics import (
+    praxiszeit_active_tenants,
+    praxiszeit_mrr_cents,
+    praxiszeit_tenant_dau,
+    praxiszeit_tenant_employees,
+)
+from tests.conftest import engine, TestingSessionLocal
+from tests.test_endpoints import test_app
+
+
+TID_A = uuid.UUID("01020304-0000-4000-8000-000000000701")
+TID_B = uuid.UUID("01020304-0000-4000-8000-000000000702")
+
+
+@pytest.fixture
+def _db_session():
+    with engine.connect() as conn:
+        conn.execute(text("PRAGMA foreign_keys = OFF"))
+        conn.commit()
+    Base.metadata.drop_all(bind=engine, checkfirst=True)
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        with engine.connect() as conn:
+            conn.execute(text("PRAGMA foreign_keys = OFF"))
+            conn.commit()
+        Base.metadata.drop_all(bind=engine, checkfirst=True)
+
+
+def _seed_universe(db):
+    # One starter tenant with 5 active seats, one pro with 10, one trial with 3
+    starter = Tenant(
+        id=TID_A, name="Starter AG", slug="starter", is_active=True, mode="multi",
+        plan="starter", subscription_status="active",
+    )
+    pro = Tenant(
+        id=TID_B, name="Pro GmbH", slug="pro", is_active=True, mode="multi",
+        plan="pro", subscription_status="active",
+    )
+    db.add_all([starter, pro])
+    db.commit()
+
+    for i in range(5):
+        db.add(User(
+            username=f"s{i}", email=f"s{i}@a.de",
+            password_hash=auth_service.hash_password("S3cure!Password"),
+            first_name="S", last_name="X", role=UserRole.EMPLOYEE,
+            weekly_hours=40, vacation_days=30, work_days_per_week=5,
+            is_active=True, tenant_id=TID_A,
+        ))
+    for i in range(10):
+        db.add(User(
+            username=f"p{i}", email=f"p{i}@b.de",
+            password_hash=auth_service.hash_password("S3cure!Password"),
+            first_name="P", last_name="X", role=UserRole.EMPLOYEE,
+            weekly_hours=40, vacation_days=30, work_days_per_week=5,
+            is_active=True, tenant_id=TID_B,
+        ))
+    db.commit()
+    return starter, pro
+
+
+# ─── MRR calc ─────────────────────────────────────────────────────
+
+def test_mrr_details_sums_active_plans(_db_session):
+    _seed_universe(_db_session)
+    out = compute_mrr_details(_db_session)
+    # starter: 5 seats × €19/mo = €95 = 9500 cents
+    # pro:    10 seats × €39/mo = €390 = 39000 cents
+    assert out["by_plan"]["starter"] == 9500
+    assert out["by_plan"]["pro"] == 39000
+    assert out["mrr_cents"] == 9500 + 39000
+    assert out["arr_cents"] == (9500 + 39000) * 12
+
+
+def test_mrr_excludes_past_due_tenants(_db_session):
+    starter, pro = _seed_universe(_db_session)
+    pro.subscription_status = "past_due"
+    _db_session.commit()
+    out = compute_mrr_details(_db_session)
+    assert out["by_plan"]["pro"] == 0
+    assert out["mrr_cents"] == 9500
+
+
+# ─── refresh_all sets gauges ─────────────────────────────────────
+
+def test_refresh_all_updates_gauges(_db_session):
+    _seed_universe(_db_session)
+    summary = refresh_all(_db_session)
+    assert summary["tenants"] == 2
+    assert summary["active_tenants"] == 2
+    assert praxiszeit_active_tenants._value.get() == 2
+    # Per-tenant gauge — direct lookup
+    assert praxiszeit_tenant_employees.labels(tenant_id=str(TID_A))._value.get() == 5
+    assert praxiszeit_tenant_employees.labels(tenant_id=str(TID_B))._value.get() == 10
+
+
+def test_dau_counts_recent_time_entries(_db_session):
+    starter, _ = _seed_universe(_db_session)
+    users = _db_session.query(User).filter(User.tenant_id == TID_A).all()
+    today = date.today()
+    # 2 distinct users logged time today → DAU=2 for starter
+    for u in users[:2]:
+        _db_session.add(TimeEntry(
+            user_id=u.id, tenant_id=TID_A, date=today,
+            start_time=time(9, 0), end_time=time(17, 0), break_minutes=30,
+        ))
+    _db_session.commit()
+    refresh_all(_db_session)
+    assert praxiszeit_tenant_dau.labels(tenant_id=str(TID_A))._value.get() == 2
+
+
+# ─── Alerts ──────────────────────────────────────────────────────
+
+def test_alert_logs_when_slack_unset(caplog, monkeypatch):
+    monkeypatch.setattr(settings, "SLACK_WEBHOOK_URL", None)
+    with caplog.at_level("INFO"):
+        assert alerting.alert("hello") is True
+    assert "alerting (no Slack" in caplog.text
+
+
+def test_alert_posts_to_slack_when_configured(monkeypatch):
+    monkeypatch.setattr(settings, "SLACK_WEBHOOK_URL", "https://hooks.slack.example/x")
+    mock_resp = type("R", (), {"status": 200, "__enter__": lambda s: s, "__exit__": lambda *a: None})()
+    with patch("urllib.request.urlopen", return_value=mock_resp) as u:
+        assert alerting.alert("hi") is True
+    assert u.called
+
+
+# ─── Superadmin tenant-overview endpoint ─────────────────────────
+
+@pytest.fixture
+def superadmin_client(_db_session):
+    _seed_universe(_db_session)
+    superadmin = User(
+        id=uuid.uuid4(),
+        username="sa", email="sa@x",
+        password_hash=auth_service.hash_password("S3curePassword!"),
+        first_name="Super", last_name="Admin",
+        role=UserRole.ADMIN,  # role isn't the gate; tenant_id IS NULL is
+        weekly_hours=40, vacation_days=30, work_days_per_week=5,
+        is_active=True, tenant_id=None,
+    )
+    _db_session.add(superadmin)
+    _db_session.commit()
+
+    def _db(): yield _db_session
+    def _who(): return superadmin
+    test_app.dependency_overrides[get_db] = _db
+    test_app.dependency_overrides[get_current_user] = _who
+    test_app.dependency_overrides[require_superadmin] = _who
+    with TestClient(test_app) as c:
+        yield c
+    test_app.dependency_overrides.clear()
+
+
+def test_tenants_overview_returns_paginated_list(superadmin_client):
+    # SQLite has no SET LOCAL → patch the RLS context helper out for the call.
+    with patch("app.routers.superadmin.set_superadmin_context"):
+        resp = superadmin_client.get("/api/superadmin/tenants-overview")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["total"] == 2
+    names = {t["name"] for t in data["tenants"]}
+    assert names == {"Starter AG", "Pro GmbH"}
+    pro = next(t for t in data["tenants"] if t["plan"] == "pro")
+    assert pro["mrr_cents"] == 10 * 3900
+
+
+def test_tenants_overview_filter_by_plan(superadmin_client):
+    with patch("app.routers.superadmin.set_superadmin_context"):
+        resp = superadmin_client.get("/api/superadmin/tenants-overview?status_filter=trial")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+
+def test_superadmin_mrr_endpoint(superadmin_client):
+    with patch("app.routers.superadmin.set_superadmin_context"):
+        resp = superadmin_client.get("/api/superadmin/metrics/mrr")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["mrr_cents"] == 9500 + 39000
+    assert data["arr_cents"] == (9500 + 39000) * 12

--- a/docs/ops/RUNBOOK-tenant-restore.md
+++ b/docs/ops/RUNBOOK-tenant-restore.md
@@ -1,0 +1,65 @@
+# Runbook: Tenant-Restore aus Daily-PG-Dump
+
+Dieses Dokument beschreibt, wie Daten eines einzelnen Tenants aus dem
+täglichen PostgreSQL-Dump wiederhergestellt werden, ohne den gesamten
+Cluster zurückzurollen.
+
+## Voraussetzungen
+
+- Zugriff auf das Backup-Verzeichnis (per Policy: 30 Tage Aufbewahrung,
+  verschlüsselt).
+- `psql` + `pg_dump` auf dem Restore-Host (Version ≥ 16).
+- Kenntnis der betroffenen `tenant_id` (UUID).
+
+## Fall 1 — Einzelner Tenant hat versehentlich Daten gelöscht
+
+1. **Scratch-DB erstellen**:
+   ```bash
+   createdb -U praxiszeit_migrations praxiszeit_restore_$(date +%s)
+   ```
+2. **Kompletten Dump einspielen**:
+   ```bash
+   pg_restore --no-owner -d praxiszeit_restore_XXXX /backups/praxiszeit_YYYYMMDD.dump
+   ```
+3. **Nur betroffene Zeilen exportieren**:
+   ```bash
+   TENANT="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+   # Time entries
+   pg_dump --data-only \
+     --table=time_entries \
+     --table=absences \
+     --table=change_requests \
+     --where="tenant_id='${TENANT}'" \
+     praxiszeit_restore_XXXX > tenant_slice.sql
+   ```
+   (`--where` benötigt `pg_dump` ≥ 17; alternativ per `COPY (SELECT ... WHERE tenant_id=...) TO`.)
+4. **Diff gegen Live-DB**: vor `psql -f` in eine Staging-Kopie der
+   Live-DB einspielen und dort verifizieren.
+5. **Apply auf Live**: nur dann, wenn Schritt 4 erfolgreich war.
+
+## Fall 2 — Tenant komplett verloren (Account irrtümlich anonymisiert)
+
+Die Migration 036 + `lifecycle_service.anonymize_tenant` scrubt PII,
+aber behält die Zeilen. Wenn die 30-Tage-Grace umgangen wurde:
+
+1. Scratch-DB wie oben.
+2. Daten direkt für die `tenant_id` abfragen und per `COPY` rüber­ziehen.
+3. User-Spalten (`username`, `email`, `first_name`, `last_name`, `password_hash`)
+   zurückspielen. Tenant-Spalten (`name`, `company_name`, …) analog.
+
+## Monitoring / Verification
+
+- `praxiszeit_tenant_employees{tenant_id="…"}` muss in Grafana wieder die
+  erwartete Zahl zeigen.
+- `praxiszeit_tenant_dau` kehrt am Folgetag zurück (DAU-Fenster = 24 h).
+
+## Backup-Policy (Ist-Zustand)
+
+- Täglich 02:00 UTC: `pg_dump -Fc` auf gleichem Host, `rsync` auf externe
+  Backup-Maschine.
+- Retention: 30 Tage rolling.
+- Off-Site-Kopie: wöchentlich, verschlüsselt (GPG).
+
+> Wenn Backups nicht konfiguriert sind, sofort Phase 7 Ops-Task aufsetzen
+> – **das Produkt ist nicht SaaS-tauglich ohne Restore-Pfad.**

--- a/monitoring/grafana/dashboards/tenants-overview.json
+++ b/monitoring/grafana/dashboards/tenants-overview.json
@@ -1,0 +1,86 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "graphTooltip": 0,
+  "id": null,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {"defaults": {"unit": "short"}},
+      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"colorMode": "value", "graphMode": "area"},
+      "title": "Active Tenants",
+      "type": "stat",
+      "targets": [{"expr": "praxiszeit_active_tenants", "refId": "A"}]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {"defaults": {"unit": "short"}},
+      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 0},
+      "id": 2,
+      "options": {"colorMode": "value", "graphMode": "area"},
+      "title": "Trial Tenants",
+      "type": "stat",
+      "targets": [{"expr": "praxiszeit_trial_tenants", "refId": "A"}]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {"unit": "eur", "decimals": 2}
+      },
+      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 0},
+      "id": 3,
+      "options": {"colorMode": "value", "graphMode": "area"},
+      "title": "MRR (Monthly Recurring Revenue)",
+      "type": "stat",
+      "targets": [
+        {"expr": "praxiszeit_mrr_cents / 100", "refId": "A"}
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 6},
+      "id": 4,
+      "title": "Active Employees per Tenant",
+      "type": "timeseries",
+      "targets": [
+        {"expr": "praxiszeit_tenant_employees", "refId": "A", "legendFormat": "{{tenant_id}}"}
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 16},
+      "id": 5,
+      "title": "Daily Active Users per Tenant",
+      "type": "timeseries",
+      "targets": [
+        {"expr": "praxiszeit_tenant_dau", "refId": "A", "legendFormat": "{{tenant_id}}"}
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 26},
+      "id": 6,
+      "title": "API Requests per Tenant (5m rate)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (tenant_id) (rate(praxiszeit_tenant_api_requests_total[5m]))",
+          "refId": "A",
+          "legendFormat": "{{tenant_id}}"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["praxiszeit", "saas", "tenants"],
+  "templating": {"list": []},
+  "time": {"from": "now-24h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "PraxisZeit – Tenants Overview",
+  "uid": "praxiszeit-tenants",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary

Issue #98. Operator observability without any new deps.

## Per-tenant Prometheus metrics

All exposed via the existing \`prometheus_fastapi_instrumentator\` \`/metrics\` endpoint:

| metric | type | labels | description |
|---|---|---|---|
| \`praxiszeit_tenant_api_requests_total\` | Counter | \`tenant_id, method\` | incremented by new middleware that decodes the JWT \`tid\` once per request |
| \`praxiszeit_tenant_dau\` | Gauge | \`tenant_id\` | unique users with a TimeEntry in the last 24 h |
| \`praxiszeit_tenant_employees\` | Gauge | \`tenant_id\` | active employees |
| \`praxiszeit_tenant_storage_bytes\` | Gauge | \`tenant_id\` | proxy: row count × 200 B |
| \`praxiszeit_mrr_cents\` | Gauge | — | MRR across active non-trial subs |
| \`praxiszeit_active_tenants\` / \`praxiszeit_trial_tenants\` | Gauge | — | aggregate counts |

Gauges are recomputed by \`POST /api/superadmin/cron/metrics-refresh\` (operator cron — hourly or daily is fine).

## Superadmin endpoints

- \`GET /api/superadmin/tenants-overview\` — paginated list with plan, status, seats, trial-days-left, MRR contribution, deletion state. Filter: \`?status_filter=trial|active|past_due|suspended|canceled\`.
- \`GET /api/superadmin/metrics/mrr\` — \`{mrr_cents, arr_cents, by_plan: {...}}\`.
- \`POST /api/superadmin/cron/metrics-refresh\` — cron trigger.

## Alerting

\`app/services/alerting.py\` — stdlib urllib Slack webhook. Hooked into:
- New signup → \`alert_new_signup\`
- Plan upgrade (Stripe checkout-completed with metadata.plan) → \`alert_plan_upgrade\`
- Deletion request → \`alert_deletion_requested\`

When \`SLACK_WEBHOOK_URL\` is unset, each call logs instead of firing. Exceptions never block the caller.

## Ops artifacts

- \`monitoring/grafana/dashboards/tenants-overview.json\` — stat panels for active/trial/MRR + timeseries per-tenant for employees, DAU, API rate.
- \`docs/ops/RUNBOOK-tenant-restore.md\` — single-tenant restore from daily \`pg_dump\` with retention/backup policy notes.

## Test plan

- [x] \`docker compose exec backend pytest tests/test_metrics_and_alerts.py -p no:asyncio\` → 9/9
- [x] Full unit suite: 465/465 (+9 since Phase 6)
- [x] MRR calc correct (plan × seats), past_due excluded
- [x] \`refresh_all\` updates gauges; DAU counts recent TimeEntries
- [x] Slack webhook: logs when unset, POSTs when configured
- [x] Superadmin /tenants-overview paginates + filters + MRR-per-tenant

## Operator setup (post-merge)

1. Import \`monitoring/grafana/dashboards/tenants-overview.json\` into Grafana.
2. Set \`SLACK_WEBHOOK_URL\` (optional) to get signup/upgrade/deletion notifications.
3. Wire \`/api/superadmin/cron/metrics-refresh\` into your cron (hourly or daily).
4. Review backup policy against \`docs/ops/RUNBOOK-tenant-restore.md\`.

## Roadmap

- Closes #98
- Phase 8 (#99 Go-Live) is the final phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)