### PR TITLE
test(suite): tighten auth + export + endpoint assertions

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,105 +1,172 @@
-"""Tests for authentication service."""
+"""Tests for JWT token creation and decoding.
+
+Password-hashing tests live in ``test_auth_service.py`` — this module focuses
+only on the JWT-specific paths (``create_access_token``, ``create_refresh_token``,
+``decode_token``) to avoid duplicating assertions across files.
+"""
+from datetime import datetime, timedelta, timezone
+
+import jwt
 import pytest
+
+from app.config import settings
 from app.services import auth_service
 
 
-def test_hash_password():
-    """Prüft dass Passwort-Hashing einen vom Klartext verschiedenen, nicht-leeren Hash erzeugt."""
-    password = "securepassword123"
-    hashed = auth_service.hash_password(password)
-    
-    assert hashed is not None
-    assert hashed != password
-    assert len(hashed) > 0
+class TestCreateAccessToken:
+    """``create_access_token`` returns a signed JWT with role + tv claims."""
+
+    def test_payload_roundtrips(self):
+        """Prüft dass alle gesetzten Claims (sub, role, type, tv) 1:1 über
+        encode→decode erhalten bleiben — ein Payload-Drift würde Auth-Bugs
+        verursachen (z.B. falsche Rolle nach Refresh)."""
+        user_id = "test-user-id-123"
+        role = "employee"
+        tv = 7
+
+        token = auth_service.create_access_token(user_id, role, token_version=tv)
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[auth_service.ALGORITHM])
+
+        assert payload["sub"] == user_id
+        assert payload["role"] == role
+        assert payload["type"] == "access"
+        assert payload["tv"] == tv
+        assert "tid" not in payload  # no tenant_id passed
+
+    def test_tenant_id_claim_present_when_passed(self):
+        """Prüft dass tid-Claim nur dann im Payload landet, wenn ein
+        tenant_id übergeben wurde — Single-Tenant-Tokens müssen frei
+        von tid sein (Abwärtskompatibilität On-Prem)."""
+        token = auth_service.create_access_token(
+            "u-1", "admin", tenant_id="tenant-123",
+        )
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[auth_service.ALGORITHM])
+        assert payload["tid"] == "tenant-123"
+
+    def test_signed_with_hs256(self):
+        """Prüft dass der Token mit dem in auth_service.ALGORITHM dokumentierten
+        Algorithmus signiert wurde — ein ``alg: none``-Token oder alg-switch
+        wäre eine kritische Schwachstelle (JWT-alg-confusion-Angriff)."""
+        token = auth_service.create_access_token("u", "employee")
+        # The header holds the alg; any tampering would make
+        # decode-with-HS256 (see above) fail, but we also pin the header
+        # explicitly so a regression that switches algorithms is caught.
+        header = jwt.get_unverified_header(token)
+        assert header["alg"] == "HS256"
+
+    def test_expiry_respects_settings(self):
+        """Prüft dass der Token nach ACCESS_TOKEN_EXPIRE_MINUTES abläuft (±2s
+        Slack für Testlauf) — ein Token der nie abläuft wäre ein Security-
+        Bug auf Dauer."""
+        before = datetime.now(timezone.utc)
+        token = auth_service.create_access_token("u", "employee")
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[auth_service.ALGORITHM])
+
+        expected_exp = before + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+        actual_exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+        drift = abs((actual_exp - expected_exp).total_seconds())
+        assert drift < 2, f"exp drift {drift}s exceeds 2s tolerance"
 
 
-def test_verify_password():
-    """Prüft dass korrektes Passwort verifiziert und falsches abgelehnt wird."""
-    password = "securepassword123"
-    hashed = auth_service.hash_password(password)
-    
-    # Correct password should verify
-    assert auth_service.verify_password(password, hashed) is True
-    
-    # Wrong password should not verify
-    assert auth_service.verify_password("wrongpassword", hashed) is False
+class TestCreateRefreshToken:
+    """``create_refresh_token`` mirrors access tokens but with longer TTL
+    and ``type=refresh``."""
+
+    def test_payload_marked_as_refresh(self):
+        """Prüft dass refresh-Tokens type=refresh haben — access-type würde den
+        Refresh-Endpoint sonst täuschen (Token-Type-Confusion)."""
+        token = auth_service.create_refresh_token("u-1", token_version=3)
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[auth_service.ALGORITHM])
+        assert payload["type"] == "refresh"
+        assert payload["sub"] == "u-1"
+        assert payload["tv"] == 3
+
+    def test_refresh_ttl_is_days_not_minutes(self):
+        """Prüft dass refresh-Tokens ~7 Tage gültig sind (REFRESH_TOKEN_EXPIRE_DAYS),
+        also signifikant länger als access-Tokens — umgekehrt wäre die Trennung
+        access/refresh sinnlos."""
+        token = auth_service.create_refresh_token("u")
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[auth_service.ALGORITHM])
+        ttl = payload["exp"] - datetime.now(timezone.utc).timestamp()
+        # Must be longer than the access-token TTL by at least 10x
+        assert ttl > settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60 * 10
 
 
-def test_create_access_token():
-    """Prüft dass ein gültiger JWT-Access-Token mit user_id und Rolle erzeugt wird."""
-    user_id = "test-user-id-123"
-    role = "employee"
-    
-    token = auth_service.create_access_token(user_id, role)
-    
-    assert token is not None
-    assert isinstance(token, str)
-    assert len(token) > 0
+class TestDecodeToken:
+    """``decode_token`` is defensive — invalid input returns None, never raises."""
+
+    def test_valid_access_token_roundtrip(self):
+        """Prüft dass ein eben erzeugter access-Token cleanly decodiert wird."""
+        token = auth_service.create_access_token("user-1", "employee")
+        payload = auth_service.decode_token(token)
+        assert payload is not None
+        assert payload["sub"] == "user-1"
+        assert payload["type"] == "access"
+
+    def test_valid_refresh_token_roundtrip(self):
+        """Prüft dass ein eben erzeugter refresh-Token cleanly decodiert wird."""
+        token = auth_service.create_refresh_token("user-1")
+        payload = auth_service.decode_token(token)
+        assert payload is not None
+        assert payload["type"] == "refresh"
+
+    @pytest.mark.parametrize("bad_token", [
+        "invalid.token.here",
+        "not-a-jwt-at-all",
+        "",
+        "a.b",                       # too few segments
+        "a.b.c.d",                   # too many segments
+        "eyJhbGciOiJIUzI1NiJ9.e30.", # empty signature
+    ])
+    def test_malformed_tokens_return_none_not_raise(self, bad_token):
+        """Prüft dass defekte/tampered Tokens None liefern statt zu crashen —
+        Login/Refresh-Handler verlassen sich auf diese Defensive."""
+        assert auth_service.decode_token(bad_token) is None
+
+    def test_wrong_secret_signature_rejected(self):
+        """Prüft dass ein fremdsigniertes JWT verworfen wird — ohne diese
+        Prüfung könnte jemand mit beliebigem Secret Tokens fälschen."""
+        payload = {
+            "sub": "attacker",
+            "role": "admin",
+            "type": "access",
+            "tv": 0,
+            "exp": datetime.now(timezone.utc) + timedelta(minutes=30),
+        }
+        forged = jwt.encode(payload, "attacker-chosen-secret", algorithm="HS256")
+        assert auth_service.decode_token(forged) is None
+
+    def test_expired_token_rejected(self):
+        """Prüft dass abgelaufene Tokens abgewiesen werden — ein Token muss nach
+        exp wertlos sein, sonst ist Session-Kürzung unmöglich."""
+        expired = jwt.encode(
+            {
+                "sub": "u",
+                "role": "employee",
+                "type": "access",
+                "tv": 0,
+                "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
+            },
+            settings.SECRET_KEY,
+            algorithm="HS256",
+        )
+        assert auth_service.decode_token(expired) is None
 
 
-def test_create_refresh_token():
-    """Prüft dass ein gültiger JWT-Refresh-Token für Token-Erneuerung erzeugt wird."""
-    user_id = "test-user-id-123"
-    
-    token = auth_service.create_refresh_token(user_id)
-    
-    assert token is not None
-    assert isinstance(token, str)
-    assert len(token) > 0
+class TestLongPasswordVerify:
+    """F-041 backstop: hash_password + verify_password must not silently
+    collide for passwords >72 bytes (the old bcrypt truncation bug).
 
-
-def test_decode_valid_access_token():
-    """Prüft dass Access-Token korrekt decodiert wird und sub, role, type enthält."""
-    user_id = "test-user-id-123"
-    role = "employee"
-    
-    token = auth_service.create_access_token(user_id, role)
-    payload = auth_service.decode_token(token)
-    
-    assert payload is not None
-    assert payload["sub"] == user_id
-    assert payload["role"] == role
-    assert payload["type"] == "access"
-
-
-def test_decode_valid_refresh_token():
-    """Prüft dass Refresh-Token korrekt decodiert wird und type=refresh enthält."""
-    user_id = "test-user-id-123"
-    
-    token = auth_service.create_refresh_token(user_id)
-    payload = auth_service.decode_token(token)
-    
-    assert payload is not None
-    assert payload["sub"] == user_id
-    assert payload["type"] == "refresh"
-
-
-def test_decode_invalid_token():
-    """Prüft dass ein ungültiger Token None zurückgibt statt zu crashen — wichtig für Sicherheit."""
-    invalid_token = "invalid.token.here"
-    
-    payload = auth_service.decode_token(invalid_token)
-    
-    assert payload is None
-
-
-def test_long_password_not_truncated():
+    Kept in this module as a cross-cutting scenario next to JWT tests —
+    the scheme-level unit tests live in test_auth_service.py.
     """
-    F-041: bcrypt_sha256 hashes the full password with SHA-256 first, so
-    passwords >72 bytes are NOT silently truncated anymore. Two different
-    long passwords that share only their first 72 bytes must now produce
-    DIFFERENT verification results.
-    """
-    long_password = "a" * 100  # 100 characters
-    hashed = auth_service.hash_password(long_password)
 
-    # Same full password verifies
-    assert auth_service.verify_password(long_password, hashed) is True
-
-    # F-041: only the first 72 chars must NOT verify — this used to be
-    # a bcrypt truncation foot-gun that made "password123" + 100 random
-    # chars equivalent to "password123" + any other 100 chars.
-    assert auth_service.verify_password("a" * 72, hashed) is False
-
-    # And obviously a different full-length password fails
-    assert auth_service.verify_password("b" * 100, hashed) is False
+    def test_verify_rejects_72byte_prefix_of_longer_password(self):
+        """Prüft das Kern-Risiko von F-041: ein Angreifer mit Kenntnis der
+        ersten 72 Bytes darf NICHT erfolgreich einloggen — HMAC über den
+        ganzen String verhindert das."""
+        long_password = "a" * 100
+        hashed = auth_service.hash_password(long_password)
+        assert auth_service.verify_password(long_password, hashed) is True
+        assert auth_service.verify_password("a" * 72, hashed) is False
+        assert auth_service.verify_password("b" * 100, hashed) is False

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -312,9 +312,12 @@ class TestAuthLogin:
         test_app.dependency_overrides.clear()
 
         assert resp.status_code == 401
+        assert "detail" in resp.json(), "401 without a detail message is a UX bug"
 
     def test_login_nonexistent_user(self, _db_session, tenant):
-        """Prüft dass unbekannte Benutzernamen 401 liefern — keine User-Enumeration."""
+        """Prüft dass unbekannte Benutzernamen 401 liefern — Status-Code only
+        genügt nicht für die Enumeration-Garantie; siehe
+        ``test_login_nonexistent_vs_wrong_password_indistinguishable``."""
         def _override_db():
             yield _db_session
 
@@ -330,6 +333,41 @@ class TestAuthLogin:
         test_app.dependency_overrides.clear()
 
         assert resp.status_code == 401
+
+    def test_login_nonexistent_vs_wrong_password_indistinguishable(
+        self, _db_session, employee_user,
+    ):
+        """Prüft dass existierender User + falsches Passwort UND
+        nicht-existierender User IDENTISCHE Responses liefern — sonst kann
+        ein Angreifer an der Antwort ablesen, ob ein Username existiert
+        (Enumeration-Leak).
+
+        Status-Code UND Body werden verglichen. Timing wird NICHT geprüft
+        (F-040 setzt dafür einen Dummy-bcrypt-Hash, aber Timing-Unit-Tests
+        sind zu flaky für diese Suite)."""
+        def _override_db():
+            yield _db_session
+
+        test_app.dependency_overrides[get_db] = _override_db
+
+        with patch("app.routers.auth.set_superadmin_context"):
+            with TestClient(test_app) as client:
+                existing = client.post("/api/auth/login", json={
+                    "username": "employee",
+                    "password": "DefinitelyWrong!1",
+                })
+                nonexistent = client.post("/api/auth/login", json={
+                    "username": "no-such-user",
+                    "password": "DefinitelyWrong!1",
+                })
+
+        test_app.dependency_overrides.clear()
+
+        assert existing.status_code == nonexistent.status_code == 401
+        assert existing.json() == nonexistent.json(), (
+            f"response bodies differ — enumeration leak: existing={existing.json()!r} "
+            f"nonexistent={nonexistent.json()!r}"
+        )
 
     def test_login_empty_body(self, _db_session, tenant):
         """Prüft dass leerer Login-Body 422 liefert — Pydantic-Validierung greift."""
@@ -389,7 +427,10 @@ class TestTimeEntryList:
         assert resp.json() == []
 
     def test_list_with_entry(self, _db_session, employee_user, employee_client):
-        """Prüft dass angelegte Zeiteintraege in der Liste erscheinen — Grundfunktion Zeiterfassung."""
+        """Prüft dass angelegte Zeiteintraege in der Liste erscheinen — Grundfunktion
+        Zeiterfassung. ``==`` statt ``>=`` ist hier bewusst: wenn die Liste
+        mehr als einen Eintrag enthält, ist entweder der Tenant-Filter kaputt
+        oder Test-Isolation weg, beides wollen wir laut sehen."""
         entry = TimeEntry(
             user_id=employee_user.id,
             tenant_id=DEFAULT_TENANT_ID,
@@ -404,7 +445,7 @@ class TestTimeEntryList:
         resp = employee_client.get("/api/time-entries/")
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) >= 1
+        assert len(data) == 1, f"expected exactly one entry, got {len(data)}: {data!r}"
         assert data[0]["start_time"] == "08:00:00"
 
 

--- a/backend/tests/test_export_service.py
+++ b/backend/tests/test_export_service.py
@@ -1,8 +1,12 @@
 """Tests for export service (monthly Excel report generation)."""
-import pytest
+import zipfile
 from datetime import date, time
 from io import BytesIO
-from app.models import User, UserRole, TimeEntry
+
+import pytest
+from openpyxl import load_workbook
+
+from app.models import TimeEntry
 from app.services.export_service import generate_monthly_report
 from tests.conftest import DEFAULT_TENANT_ID
 
@@ -22,6 +26,22 @@ def _make_time_entry(db, user, entry_date, start_h, end_h, break_min=0):
     return entry
 
 
+def _load_xlsx(bio: BytesIO):
+    """Rewind + validate as a real XLSX and hand back the workbook.
+
+    Stronger than a ``data[:2] == b'PK'`` magic-byte check: any writer that
+    emits a truncated or structurally-broken workbook would still pass the
+    byte-check but fail to open in Excel. ``openpyxl.load_workbook`` performs
+    the same parse Excel does, so a green test here means the customer will
+    actually be able to open the file.
+    """
+    bio.seek(0)
+    data = bio.read()
+    assert zipfile.is_zipfile(BytesIO(data)), "output is not a valid zip (xlsx wrapper)"
+    bio.seek(0)
+    return load_workbook(bio, read_only=True), data
+
+
 class TestGenerateMonthlyReport:
     """Test generate_monthly_report() core behavior."""
 
@@ -30,31 +50,52 @@ class TestGenerateMonthlyReport:
         result = generate_monthly_report(db, 2026, 1)
         assert isinstance(result, BytesIO)
 
-    def test_returns_xlsx_magic_bytes(self, db, test_user):
-        """Prüft dass der Report gültiges XLSX-Format hat (PK Magic Bytes) — Datei muss in Excel öffenbar sein."""
+    def test_returns_openable_xlsx(self, db, test_user):
+        """Prüft dass der Report als echtes XLSX-File von openpyxl geladen werden
+        kann und mindestens ein Blatt enthält — magic-byte-Check (PK) ist zu
+        schwach, ein abgeschnittenes ZIP würde durchrutschen aber in Excel
+        nicht öffnen."""
         result = generate_monthly_report(db, 2026, 1)
-        data = result.read()
+        wb, data = _load_xlsx(result)
         assert len(data) > 0
-        # XLSX files are ZIP archives, starting with PK (0x504B)
-        assert data[:2] == b'PK'
+        assert len(wb.sheetnames) >= 1, f"no worksheets: {wb.sheetnames}"
 
-    def test_report_with_time_entries(self, db, test_user):
-        """Prüft dass der Report mit Zeiteinträgen valides XLSX erzeugt — Hauptanwendungsfall für Monatsexport."""
+    def test_report_with_time_entries_renders_hours(self, db, test_user):
+        """Prüft dass Zeiteinträge im Report tatsächlich als Stundenwerte im
+        Sheet landen — magic-byte-Pass sagt nichts darüber, ob Daten im
+        Workbook ankommen."""
         _make_time_entry(db, test_user, date(2026, 1, 5), 8, 17, 30)
         _make_time_entry(db, test_user, date(2026, 1, 6), 9, 16, 30)
         _make_time_entry(db, test_user, date(2026, 1, 7), 8, 12, 0)
 
         result = generate_monthly_report(db, 2026, 1)
-        data = result.read()
-        assert len(data) > 0
-        assert data[:2] == b'PK'
+        wb, _ = _load_xlsx(result)
+        # Find the test-user's sheet (openpyxl truncates sheet names to 31
+        # chars and strips illegal chars — any sheet that contains the user's
+        # last name is our target).
+        ws = next(
+            (wb[name] for name in wb.sheetnames if test_user.last_name in name),
+            wb[wb.sheetnames[0]],
+        )
+        flat = [
+            str(cell.value) if cell.value is not None else ""
+            for row in ws.iter_rows(values_only=False)
+            for cell in row
+        ]
+        # Zeiteinträge wurden mit 8:00/9:00 Startzeiten gebucht — mindestens
+        # einer dieser Werte muss im Sheet auftauchen, sonst wurde kein Eintrag
+        # gerendert.
+        haystack = " ".join(flat)
+        assert any(needle in haystack for needle in ("08:00", "8:00", "09:00", "9:00")), (
+            f"expected an 08:00/09:00 start time in the user sheet, got: {haystack[:400]}"
+        )
 
-    def test_report_empty_month(self, db, test_user):
-        """Prüft dass ein leerer Monat ohne Einträge trotzdem valides XLSX erzeugt — kein Crash bei neuen MA."""
+    def test_report_empty_month_still_opens(self, db, test_user):
+        """Prüft dass ein leerer Monat ohne Einträge trotzdem ein öffnebares XLSX
+        erzeugt — kein Crash bei neuen MA, Excel kann die Datei öffnen."""
         result = generate_monthly_report(db, 2026, 6)
-        data = result.read()
-        assert len(data) > 0
-        assert data[:2] == b'PK'
+        wb, _ = _load_xlsx(result)
+        assert len(wb.sheetnames) >= 1
 
     def test_report_no_active_users_raises(self, db, test_user):
         """Prüft dass ohne aktive User ein IndexError kommt — bekannte Limitation, openpyxl braucht mind. 1 Sheet."""
@@ -68,9 +109,8 @@ class TestGenerateMonthlyReport:
         """Prüft dass der Report mit Gesundheitsdaten-Flag valides XLSX erzeugt — DSGVO Art.9 Sonderfall."""
         _make_time_entry(db, test_user, date(2026, 1, 5), 8, 17, 30)
         result = generate_monthly_report(db, 2026, 1, include_health_data=True)
-        data = result.read()
-        assert len(data) > 0
-        assert data[:2] == b'PK'
+        wb, _ = _load_xlsx(result)
+        assert len(wb.sheetnames) >= 1
 
     def test_report_size_increases_with_entries(self, db, test_user):
         """Prüft dass der Report mit Einträgen grösser ist als ein leerer — Daten werden tatsächlich geschrieben."""


### PR DESCRIPTION
## Summary

Review der Unit-Test-Suite nach dem Dependency-Upgrade-Sprint (#109). Fokus auf echte Test-Qualität: Duplikate raus, schwache Assertions festziehen, Security-Garantien als Tests formulieren.

## Changes

### `test_auth.py` — Rewrite
Duplikate zu `test_auth_service.py` entfernt (hash/verify-Tests lebten doppelt), dafür JWT-Lücken geschlossen:

- **`TestCreateAccessToken`**: Payload-Roundtrip (sub/role/type/tv), `tid`-Claim-Handling, **`alg: HS256` Header-Pin** (schützt vor alg-confusion-Angriff), exp-Drift ±2s gegen `ACCESS_TOKEN_EXPIRE_MINUTES`
- **`TestCreateRefreshToken`**: `type=refresh`-Marker, TTL ≥10× Access-Token (trennt access/refresh-Rollen messbar)
- **`TestDecodeToken`**: `parametrize` über 6 malformed-Token-Shapes, **wrong-signature-Reject**, **expired-Token-Reject**
- `TestLongPasswordVerify`: F-041-Backstop behalten

### `test_export_service.py` — Magic-Byte → echtes XLSX-Parse
`_load_xlsx()` helper nutzt `zipfile.is_zipfile` + `openpyxl.load_workbook` — derselbe Parse den Excel fährt. Truncated / malformed ZIPs mit PK-Header-Pass würden vorher durchrutschen, jetzt nicht mehr. Neuer Test `test_report_with_time_entries_renders_hours` scannt das User-Sheet nach `08:00`/`09:00`-Startzeiten — beweist dass Daten in Cells landen, nicht nur dass ein gültiger Envelope existiert.

### `test_endpoints.py` — Weak-Assertion-Fixup
- `test_login_wrong_password`: `"detail"`-Body-Check ergänzt
- **NEUER `test_login_nonexistent_vs_wrong_password_indistinguishable`**: der Docstring-Claim "keine User-Enumeration" ruht jetzt auf einem echten Test — beide Login-Fehler werden verglichen (Status UND Body). **Bestanden** in diesem Commit, d.h. die Garantie hält aktuell
- `test_list_with_entry`: `len >= 1` → `len == 1` mit Fail-Message — würde multi-tenant-Leaks oder Test-Isolation-Brüche laut sichtbar machen

## Test plan

- [x] `docker compose run --rm backend pytest tests/ --ignore=test_tenant_rls --ignore=test_concurrency -q` → **499 passed** (war 489, +10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)