### PR TITLE
fix(vacations): admin can prune rejected requests + audit-source widened

### DIFF
--- a/backend/alembic/versions/2026_04_25_0900-037_widen_audit_source.py
+++ b/backend/alembic/versions/2026_04_25_0900-037_widen_audit_source.py
@@ -1,0 +1,42 @@
+"""Widen time_entry_audit_logs.source from VARCHAR(20) to VARCHAR(40).
+
+The 20-char limit was set when only short source markers existed (``manual``,
+``import``, ``change_request``). Newer code paths emit ``vacation_request_cancel``
+(24 chars), which crashed every approved-future-vacation-request cancellation
+with ``StringDataRightTruncation`` → 500. Widening to 40 leaves headroom for
+future markers without forcing another migration.
+
+Revision ID: 037_widen_audit_source
+Revises: 036_tenant_lifecycle
+Create Date: 2026-04-25
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '037_widen_audit_source'
+down_revision = '036_tenant_lifecycle'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        'time_entry_audit_logs',
+        'source',
+        existing_type=sa.String(length=20),
+        type_=sa.String(length=40),
+        existing_nullable=False,
+        existing_server_default=None,
+    )
+
+
+def downgrade() -> None:
+    # Best-effort — will fail if any row already holds a >20-char value.
+    op.alter_column(
+        'time_entry_audit_logs',
+        'source',
+        existing_type=sa.String(length=40),
+        type_=sa.String(length=20),
+        existing_nullable=False,
+    )

--- a/backend/app/models/time_entry_audit_log.py
+++ b/backend/app/models/time_entry_audit_log.py
@@ -32,7 +32,9 @@ class TimeEntryAuditLog(Base):
     new_break_minutes = Column(Integer, nullable=True)
     new_note = Column(Text, nullable=True)
 
-    source = Column(String(20), nullable=False, default="manual")  # "manual", "change_request", or "import"
+    # Originally 20 chars (manual / import / change_request); widened to 40 in
+    # migration 037 because vacation_request_cancel (24 chars) didn't fit.
+    source = Column(String(40), nullable=False, default="manual")  # e.g. manual, import, change_request, vacation_request_cancel
     change_request_id = Column(UUID(as_uuid=True), ForeignKey("change_requests.id", ondelete="SET NULL"), nullable=True)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/app/routers/admin_vacations.py
+++ b/backend/app/routers/admin_vacations.py
@@ -254,10 +254,12 @@ def cancel_vacation_request_as_admin(
 ):
     """Admin cancellation of a vacation request on behalf of the user.
 
-    Mirrors the employee-side withdraw semantics:
+    Mirrors the employee-side withdraw semantics + lets admins prune dead rows:
     - PENDING → delete the request row.
     - APPROVED with start date strictly in the future → delete associated
-      absences + flip to WITHDRAWN.
+      absences + flip to WITHDRAWN (keeps the row for audit trail).
+    - REJECTED → delete the request row (no side effects: a rejected request
+      never produced absences, the rejection itself stays in the audit log).
 
     Tenant-scoped: admin cannot reach into foreign tenants.
     """
@@ -278,6 +280,14 @@ def cancel_vacation_request_as_admin(
         db.commit()
         return None
 
+    if vr.status == VacationRequestStatus.REJECTED.value:
+        # No side effects (no absences were ever created), so a plain row
+        # delete is safe. The original rejection event is preserved in the
+        # admin audit log via the review endpoint.
+        db.delete(vr)
+        db.commit()
+        return None
+
     if vr.status == VacationRequestStatus.APPROVED.value:
         if vr.date <= today_local():
             raise HTTPException(
@@ -290,5 +300,5 @@ def cancel_vacation_request_as_admin(
 
     raise HTTPException(
         status_code=400,
-        detail="Nur offene oder genehmigte zukünftige Anträge können storniert werden",
+        detail="Nur offene, abgelehnte oder genehmigte zukünftige Anträge können storniert werden",
     )

--- a/backend/tests/test_vacation_request_cancel.py
+++ b/backend/tests/test_vacation_request_cancel.py
@@ -283,3 +283,19 @@ class TestAdminCancel:
     def test_admin_404_for_unknown_id(self, admin_client):
         resp = admin_client.delete("/api/admin/vacation-requests/00000000-0000-0000-0000-000000000000")
         assert resp.status_code == 404
+
+    def test_admin_can_delete_rejected_request(self, db, employee, admin_client):
+        """Abgelehnte Anträge dürfen vom Admin geprundet werden — keine Side-Effects
+        (es gibt keine Absences zu einem rejected request), die Ablehnung selbst
+        bleibt im Audit-Log erhalten. Vorher gab der Endpoint 400 zurück, was
+        u.a. die E2E-Cleanup-Fixture brach (rejected leftovers akkumulierten)."""
+        vr = _vr(
+            db, employee, VacationRequestStatus.REJECTED.value,
+            date.today() + timedelta(days=10),
+        )
+        vr.rejection_reason = "E2E reject"
+        db.commit()
+
+        resp = admin_client.delete(f"/api/admin/vacation-requests/{vr.id}")
+        assert resp.status_code == 204
+        assert db.query(VacationRequest).filter(VacationRequest.id == vr.id).first() is None

--- a/e2e/fixtures/test-data.fixture.ts
+++ b/e2e/fixtures/test-data.fixture.ts
@@ -39,6 +39,12 @@ export type TestDataFixtures = {
     user_id?: string;
   }) => Promise<any>;
   createChangeRequest: (data: Record<string, unknown>) => Promise<any>;
+  createVacationRequest: (data: {
+    date: string;
+    end_date?: string;
+    hours: number;
+    note?: string;
+  }) => Promise<any>;
 };
 
 export const testDataTest = authTest.extend<TestDataFixtures>({
@@ -170,6 +176,30 @@ export const testDataTest = authTest.extend<TestDataFixtures>({
       try {
         await adminApi.delete(`/admin/change-requests/${id}`);
       } catch { /* already resolved or deleted */ }
+    }
+  },
+
+  // VacationRequests don't share /absences cleanup; the admin endpoint
+  // ``DELETE /admin/vacation-requests/{id}`` deletes pending rows and
+  // withdraws still-future approved ones, so it's a safe one-shot teardown
+  // even after a test has approved or rejected the request mid-run.
+  createVacationRequest: async ({ employeeApi, adminApi }, use) => {
+    const createdIds: string[] = [];
+    const factory = async (data: {
+      date: string;
+      end_date?: string;
+      hours: number;
+      note?: string;
+    }) => {
+      const result = await employeeApi.post('/vacation-requests', data);
+      if (result?.id) createdIds.push(result.id);
+      return result;
+    };
+    await use(factory);
+    for (const id of createdIds) {
+      try {
+        await adminApi.delete(`/admin/vacation-requests/${id}`);
+      } catch { /* already withdrawn / not found */ }
     }
   },
 });

--- a/e2e/tests/admin/vacation-approvals.spec.ts
+++ b/e2e/tests/admin/vacation-approvals.spec.ts
@@ -96,8 +96,7 @@ test.describe('Admin Vacation Approvals', () => {
   test('approve vacation request', async ({
     adminPage,
     adminApi,
-    employeeApi,
-    testEmployee,
+    createVacationRequest,
   }) => {
     // Enable approval requirement
     try {
@@ -107,15 +106,15 @@ test.describe('Admin Vacation Approvals', () => {
       return;
     }
 
-    // Create a vacation request as employee. Tag with a unique note marker
-    // so we can pick THIS request out of any leftover pending requests
-    // sharing the same employee last_name (parallel workers, prior runs).
-    // weekdayFromNow ensures the date is Mon-Fri so the approve path doesn't
-    // bail out with "Keine gültigen Arbeitstage im Zeitraum".
+    // Create the request via the fixture so the teardown deletes the row
+    // (or withdraws it if the test runs the approve step). Unique note marker
+    // disambiguates THIS request from any leftover pending entries that
+    // share the employee's last_name. weekdayFromNow ensures Mon-Fri so the
+    // approve path doesn't bail out with "Keine gültigen Arbeitstage im Zeitraum".
     const futureDate = weekdayFromNow(35);
     const uniqueNote = `E2E approve ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     try {
-      await employeeApi.post('/vacation-requests', {
+      await createVacationRequest({
         date: futureDate,
         hours: 8,
         note: uniqueNote,
@@ -140,15 +139,14 @@ test.describe('Admin Vacation Approvals', () => {
       adminPage.locator('[role="alert"]').filter({ hasText: /genehmigt/ })
     ).toBeVisible({ timeout: 10000 });
 
-    // Cleanup
+    // Cleanup setting; the request itself is teardown-handled by the fixture.
     try { await adminApi.put('/admin/settings/vacation_approval_required', { value: 'false' }); } catch {}
   });
 
   test('reject vacation request with reason', async ({
     adminPage,
     adminApi,
-    employeeApi,
-    testEmployee,
+    createVacationRequest,
   }) => {
     // Enable approval requirement
     try {
@@ -158,13 +156,12 @@ test.describe('Admin Vacation Approvals', () => {
       return;
     }
 
-    // Create a vacation request via /vacation-requests so it lands in the
-    // admin VacationRequests view; tag with a unique note marker so we can
-    // disambiguate from other pending requests of users with the same name.
+    // Create via fixture so teardown deletes the rejected request row.
+    // Unique note marker for disambiguation; weekdayFromNow for valid workdays.
     const futureDate = weekdayFromNow(40);
     const uniqueNote = `E2E reject ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     try {
-      await employeeApi.post('/vacation-requests', {
+      await createVacationRequest({
         date: futureDate,
         hours: 8,
         note: uniqueNote,
@@ -196,7 +193,7 @@ test.describe('Admin Vacation Approvals', () => {
       adminPage.locator('[role="alert"]').filter({ hasText: /abgelehnt/ })
     ).toBeVisible({ timeout: 10000 });
 
-    // Cleanup
+    // Cleanup setting; the request row is teardown-handled by the fixture.
     try { await adminApi.put('/admin/settings/vacation_approval_required', { value: 'false' }); } catch {}
   });
 });


### PR DESCRIPTION
## Summary

Beim Bauen einer sauberen E2E-Cleanup-Fixture für vacation-requests sind zwei **Production-Bugs** aufgefallen:

### 1. `DELETE /admin/vacation-requests/{id}` crasht bei APPROVED → 500
```
sqlalchemy.exc.DataError: (psycopg2.errors.StringDataRightTruncation)
value too long for type character varying(20)
```

Die ``time_entry_audit_logs.source``-Spalte war ``varchar(20)``, der Code emit beim Cancel-Pfad jedoch ``"vacation_request_cancel"`` (24 chars). **Jede** approved-future-Stornierung scheiterte mit 500 — der Bug existiert seit das Feature ausgeliefert wurde.

**Fix:** Migration `037_widen_audit_source` weitet die Spalte auf ``varchar(40)``. Model-Kommentar synchronisiert.

### 2. Endpoint lehnt REJECTED-Anträge ab → akkumulierende Karteileichen
Vor diesem PR liefen rejected Anträge nur in den 400-Pfad ("Nur offene oder genehmigte zukünftige…"). Wenn der Admin alte Ablehnungen löschen will → ging nicht. **Fix:** REJECTED → einfacher row-delete (keine Side-Effects, da rejected-Anträge nie Absences erzeugt haben; der Rejection-Event selbst ist im Admin-Audit-Log gespeichert).

### 3. E2E-Fixture
Neue ``createVacationRequest`` Factory in ``e2e/fixtures/test-data.fixture.ts``, analog zu ``createAbsence``. Tracked die erzeugte ID und löscht sie im teardown via dem nun erweiterten Admin-Endpoint. Die beiden Tests in ``vacation-approvals.spec.ts`` (approve/reject) nutzen die Fixture.

## Verifikation auf fresh DB

Nach Run der vollen `vacation-approvals.spec.ts`:

| Status | Vor diesem PR | Nach |
|---|---|---|
| pending | bis zu 13 leftover | 0 ✓ |
| approved | blockiert durch 500 | 0 ✓ |
| rejected | blockiert durch 400 | 0 ✓ |
| withdrawn | — | 1 (by design — audit-trail vom approve→cancel-Pfad) |

## Tests

- **Backend: 500 passed** (war 499) — neuer Test ``test_admin_can_delete_rejected_request`` deckt den REJECTED-Pfad ab. Alle 11 bestehenden Cancel-Tests grün, Migration läuft sauber durch.
- **E2E: 113/114 passed**, 1 skipped, 0 failed, 0 flaky.

## Test plan

- [x] Migration up + down auf Postgres 16
- [x] `tests/test_vacation_request_cancel.py` — 12/12 (war 11)
- [x] Volle Backend-Suite — 500/500
- [x] E2E `tests/admin/vacation-approvals.spec.ts` mehrfach mit DB-wipe — pending+approved+rejected jeweils 0 nach run

🤖 Generated with [Claude Code](https://claude.com/claude-code)