### PR TITLE
release: 1.4.1+2+3 — SPA-fallback, Tailwind v4 spacing, neue Wizard-Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-05-03
+
+### 🐞 Bugfix — CSS-Bruch nach Update bei stale Service-Worker
+- **Symptom**: Nach Update auf 1.4.0 lieferte ein Native-Install dem Browser
+  fuer alte hashed CSS-URLs (`/assets/index-OLDHASH.css`) die `index.html`
+  zurueck — `200 OK` mit `Content-Type: text/html`. Browser verwirft das
+  als Stylesheet, Seite landet komplett ungestyled, bis der User den
+  Service Worker manuell unregistert. Erstmals durch Tailwind v3 → v4 in 1.4.0
+  ausgeloest, weil sich saemtliche Asset-Hashes aenderten.
+- **Root Cause**: `SPAFallbackMiddleware` in `backend/app/main.py` lieferte
+  bei *jedem* GET-404 ausserhalb `/api/` die `index.html` aus — auch fuer
+  Asset-Pfade. Stale-SW-Klienten bekamen so HTML als CSS und cachten den
+  kaputten Zustand.
+- **Fix**: Asset-foermige Requests (letztes Pfad-Segment hat eine Endung,
+  kein `Accept: text/html`) bekommen jetzt einen echten 404. `/assets/*`
+  short-circuit-t unabhaengig vom Accept-Header. SPA-Navigationen
+  (`Accept: text/html`) erhalten weiterhin `index.html`. Damit erholt
+  sich jeder Browser beim naechsten Refresh selber.
+- **Bonus**: Die SPA-Fallback-Response umging bisher die `SecurityHeaders`-
+  Middleware — `/login` & Co. lieferten *keine* CSP/HSTS/X-Frame-Options.
+  Die Fallback-Response uebernimmt diese Header jetzt aus der inneren
+  Middleware-Kette (Defence-in-Depth-Parity mit Docker-Mode + nginx).
+- **Refactor**: `SPAFallbackMiddleware` aus dem `if SERVE_FRONTEND:`-Block
+  in `backend/app/main.py` nach `app/middleware/static_serving.py`
+  ausgelagert (importierbar, testbar). 10 Unit-Tests in
+  `backend/tests/test_spa_fallback.py` decken Asset-404, Navigation-mit-
+  index.html, Header-Propagation und SPA-Routes-mit-Punkt ab.
+
 ### 🚀 Feature — ConfigPage im Setup-Wizard (Erst-Admin-Setup)
 - Neue Wizard-Page **"Konfiguration"** zwischen Welcome und Progress,
   nur im Fresh-Install / Repair-Modus aktiv. Fragt Praxis-Stammdaten

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 ## [Unreleased]
 
+## [1.4.3] - 2026-05-03
+
+### 🚀 Wizard — drei neue Pages: Installationsort, Ports, Lizenz
+- **Install-Location-Page** zwischen Welcome und Konfiguration. User kann
+  den Pfad explizit waehlen (Default `C:\PraxisZeit`), Update-Mode
+  blockt das Feld auf den existierenden Pfad. Wenn der User Fresh-Install
+  ausgewaehlt hat, der Pfad aber bereits eine Installation enthaelt,
+  blendet sich eine rote Warnung ein mit zwei CTAs: "Auf Update
+  umschalten" oder "Anderen Pfad waehlen". Continue ist gesperrt bis
+  der Konflikt aufgeloest ist — verhindert versehentliches
+  Daten-Clobbern.
+- **Ports-Page** im Fresh/Repair-Flow. HTTPS-Port (Default 443) und
+  HTTP-Redirect-Port (Default 80, abschaltbar). Live-Validation auf
+  Range 1..65535 + Identitaets-Konflikt; zusaetzlich nicht-blockierende
+  Warnung wenn ein Port laut `IPGlobalProperties.GetActiveTcpListeners`
+  bereits belegt ist (z.B. anderer Webserver auf dem Setup-Server).
+  Neuer Conf-Key `[server].http_redirect_port`, vom Backend in
+  `config.py:_TOML_KEY_MAP` aufgenommen.
+- **License-Page** im Fresh- *und* Update-Flow (im Update-Pfad fuer
+  Lizenz-Erneuerung). User kann entweder einen Lizenz-Token einfuegen /
+  per File-Picker eine `.key` waehlen ODER 30 Tage Demo starten.
+  Live-Validierung gegen den gleichen Ed25519-Public-Key wie das Backend
+  via BouncyCastle (.NET 10 hat keine native Ed25519-Unterstuetzung).
+  Bei erfolgreicher Validierung zeigt der Wizard Kunde, Mitarbeiter-
+  Limit und Ablaufdatum an. Bei Demo-Mode wird `demo_expires_at` in
+  `praxiszeit.conf` geschrieben; Backend erkennt das in `main.py`
+  Lifespan und schaltet ab dem Datum in Read-Only.
+
+### 🐞 Wizard-UX-Fixes (aus Customer-Feedback)
+- "Bitte warten..."-Button blieb stehen, obwohl die Installation
+  fertig war: `NextButtonText` auf `ProgressPageViewModel` ist jetzt
+  state-aware (`IsRunning ? "Bitte warten..." : "Weiter"`) und wird
+  via `OnIsRunningChanged` neu emittiert.
+- Button-Beschriftungen waren links-aligned trotz fixer MinWidth —
+  `HorizontalContentAlignment="Center"` auf `.primary`, `.ghost`,
+  `.success` ergaenzt.
+- DonePageView ohne aeusseren ScrollViewer; bei DPI ≥ 125 % wurde
+  der "Schliessen"-Button abgeschnitten. Wrap im ScrollViewer.
+- Default-Window von 820x640 auf 900x720 (Min 780x620) — die jetzt
+  vorhandenen 6 Pages und der Step-Indicator brauchten mehr Platz.
+
+### Backend — Demo-Mode + Server-Port-Settings
+- `LICENSE_DEMO_EXPIRES_AT` (TOML `[license].demo_expires_at`) und
+  `SERVER_PORT` / `SERVER_HTTP_REDIRECT_PORT` (TOML `[server].port` /
+  `http_redirect_port`) als neue Settings in `app/config.py`.
+- `app/main.py` Lifespan: ohne `LICENSE_KEY_PATH` aber mit
+  `LICENSE_DEMO_EXPIRES_AT` → Demo-Mode bis zum Datum, danach
+  Read-Only (`set_license_state(None, read_only=True)`). Mit echter
+  Lizenz unveraendert.
+
+### Tests
+- 31 neue Tests (Total 104 / 104 grün) in
+  `installer/setup/tests/PraxisZeit.Setup.Core.Tests`:
+  Port-Range/Konflikt-Validation, Conf-Roundtrip mit Custom-Ports,
+  `demo_expires_at`-Serialisierung, License-Validator
+  Negative-Paths (leerer Token, falsches Segment-Count, Non-EdDSA-
+  Algorithm, Random-Signatur). License-Positive-Path-Tests laufen im
+  Backend (`test_native_mode.py`) gegen denselben Public-Key.
+
 ## [1.4.2] - 2026-05-03
 
 ### 🐞 Bugfix — Tailwind v4 Spacing-Regression (alle `p-*`/`m-*`/`space-*`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-05-03
+
+### 🐞 Bugfix — Tailwind v4 Spacing-Regression (alle `p-*`/`m-*`/`space-*`)
+- **Symptom**: Karten ohne Innen-Padding, Sidebar-Items ohne `px-4 py-3`,
+  `Budget`/`Genommen` ohne Spacing — die Oberflaeche sah komplett "kaputt"
+  aus, obwohl Hintergruende, Schatten, Rahmen und runde Ecken alle korrekt
+  rendeten. Nur die Spacing-Utilities waren stillgelegt.
+- **Root Cause**: `frontend/src/index.css` hatte einen globalen
+  `* { margin: 0; padding: 0; box-sizing: border-box; }`-Reset *ausserhalb*
+  jedes `@layer`. Tailwind v4 wickelt jede Utility in `:where(...)` ein,
+  damit User sie mit einfachen Selektoren ueberschreiben koennen — d.h.
+  `:where(.p-6)` hat Specificity 0,0,0. Der unlayered `*`-Selektor hat
+  ebenfalls 0,0,0, gewinnt aber trotzdem, weil **unlayered Regeln in der
+  Cascade ueber layered Regeln stehen**. Ergebnis: jede `p-*`, `m-*`,
+  `px-*`, `space-x-*`, `space-y-*` wurde stillschweigend von dem Reset
+  ueberschrieben.
+- **Fix**: Reset in `@layer base` packen. `@layer base` steht in der
+  Tailwind-v4-Reihenfolge unter `@layer utilities`, also gewinnt
+  `:where(.p-6)` wieder ueber das `*`. `box-sizing` ist im Reset entfallen,
+  weil Tailwind-v4-Preflight das schon auf `*, ::before, ::after` setzt.
+- Verifiziert end-to-end im Browser (Playwright gegen lokalen Docker-
+  Stack): Card-Padding `0px → 24px`, Nav-Item-Padding `0px → 12px 16px`.
+  Sidebar, Karten und Layout sind wieder so, wie sie vor 1.4.0 aussahen.
+
 ## [1.4.1] - 2026-05-03
 
 ### 🐞 Bugfix — CSS-Bruch nach Update bei stale Service-Worker

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,6 +34,9 @@ _TOML_KEY_MAP = {
     ("security", "login_rate_limit"): "LOGIN_RATE_LIMIT",
     ("security", "cookie_secure"): "COOKIE_SECURE",
     ("license", "key_file"): "LICENSE_KEY_PATH",
+    ("license", "demo_expires_at"): "LICENSE_DEMO_EXPIRES_AT",
+    ("server", "port"): "SERVER_PORT",
+    ("server", "http_redirect_port"): "SERVER_HTTP_REDIRECT_PORT",
     ("updates", "check_enabled"): "UPDATE_CHECK_ENABLED",
     ("updates", "server_url"): "UPDATE_SERVER_URL",
     ("updates", "check_interval_hours"): "UPDATE_CHECK_INTERVAL_HOURS",
@@ -120,6 +123,20 @@ class Settings(BaseSettings):
 
     # License key file path (native installations only)
     LICENSE_KEY_PATH: Optional[str] = None
+
+    # Demo-Mode (Native): wenn keine LICENSE_KEY_PATH und LICENSE_DEMO_EXPIRES_AT
+    # gesetzt ist, laeuft die App bis zum genannten Datum mit voller
+    # Funktionalitaet, danach Read-Only. Format ISO-Date YYYY-MM-DD.
+    # Wird vom Setup-Wizard auf Install-Datum + 30 Tage gesetzt; im
+    # Production-Install bleibt es leer und der Lizenz-Pfad ist gesetzt.
+    LICENSE_DEMO_EXPIRES_AT: Optional[str] = None
+
+    # Native-mode: HTTP / HTTPS-Listener-Ports (vom Wizard konfigurierbar).
+    # Default 443 / 80 — Backend rendert sie auch in keinen externen
+    # URLs ausser im Update-Banner; primaer fuer den Service-Wrapper, der
+    # uvicorn mit --port startet.
+    SERVER_PORT: int = 443
+    SERVER_HTTP_REDIRECT_PORT: int = 80
 
     # Update server URL (native installations only)
     UPDATE_SERVER_URL: Optional[str] = None

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.4.2"
+APP_VERSION = "1.4.3"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.4.0"
+APP_VERSION = "1.4.1"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.4.1"
+APP_VERSION = "1.4.2"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -147,8 +147,11 @@ async def lifespan(app: FastAPI):
         finally:
             db.close()
 
-    # 7. License validation (native installations only)
-    if settings.LICENSE_KEY_PATH:
+    # 7. License validation (native installations only). Drei Modi:
+    #    a) LICENSE_KEY_PATH gesetzt + Datei existiert → echte Lizenz validieren
+    #    b) LICENSE_DEMO_EXPIRES_AT gesetzt (vom Setup-Wizard) → Demo-Mode bis dahin
+    #    c) keins von beiden → klassisch ohne Lizenz (Docker-Dev / SaaS)
+    if settings.LICENSE_KEY_PATH and Path(settings.LICENSE_KEY_PATH).is_file():
         from app.core.license import (
             validate_license, validate_license_quiet,
             set_license_state, LicenseError, LicenseExpiredError,
@@ -170,6 +173,30 @@ async def lifespan(app: FastAPI):
         except LicenseError as e:
             print(f"LICENSE ERROR: {e}")
             sys.exit(1)
+    elif settings.LICENSE_DEMO_EXPIRES_AT:
+        # Demo-Mode (vom Setup-Wizard gesetzt). Volle Funktion bis zum Datum,
+        # danach Read-Only. Wir exportieren KEINE LicenseInfo (es gibt
+        # keine Kundenangaben), aber die License-Middleware respektiert
+        # den read_only-Flag.
+        from app.core.license import set_license_state
+        try:
+            from datetime import date as _date
+            demo_until = _date.fromisoformat(settings.LICENSE_DEMO_EXPIRES_AT.strip())
+        except ValueError:
+            print(f"LICENSE ERROR: ungueltiges LICENSE_DEMO_EXPIRES_AT "
+                  f"'{settings.LICENSE_DEMO_EXPIRES_AT}' (erwartet YYYY-MM-DD)")
+            sys.exit(1)
+        from datetime import date
+        today = date.today()
+        if today > demo_until:
+            print(f"WARNING: Demo-Lizenz abgelaufen am {demo_until.isoformat()}.")
+            print("App running in READ-ONLY mode.")
+            set_license_state(None, read_only=True)
+        else:
+            days_left = (demo_until - today).days
+            print(f"License: 30-Tage-Demo (laeuft am {demo_until.isoformat()} "
+                  f"ab, noch {days_left} Tage)")
+            set_license_state(None, read_only=False)
 
     # Configuration sanity checks
     if settings.COOKIE_SECURE and settings.ENVIRONMENT != "production":

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,11 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from app.core.limiter import limiter
-from app.middleware.static_serving import SecurityHeadersMiddleware, RequestSizeLimitMiddleware
+from app.middleware.static_serving import (
+    SecurityHeadersMiddleware,
+    RequestSizeLimitMiddleware,
+    SPAFallbackMiddleware,
+)
 from app.middleware.csrf import CSRFMiddleware
 from app.middleware.license import LicenseReadOnlyMiddleware
 from contextlib import asynccontextmanager
@@ -484,39 +488,17 @@ if settings.SERVE_FRONTEND:
         from fastapi.responses import JSONResponse
         return JSONResponse(status_code=404, content={"detail": "Not found"})
 
-    # SPA fallback middleware: serves frontend for non-API GET requests that don't
-    # match a static file. Replaces nginx try_files $uri $uri/ /index.html.
-    # Using middleware instead of a catch-all route avoids 405 errors for POST/PUT/DELETE
-    # to API paths (a catch-all GET route would match the path but not the method).
-    from starlette.middleware.base import BaseHTTPMiddleware
-    from starlette.responses import Response as _MWResponse
-
+    # SPA fallback middleware: serves frontend for non-API GET requests that
+    # don't match a static file. Replaces nginx try_files $uri $uri/ /index.html.
+    # Using middleware instead of a catch-all route avoids 405 errors for
+    # POST/PUT/DELETE to API paths.
     _index_path = _frontend_dir / "index.html"
     _index_html = _index_path.read_bytes() if _index_path.is_file() else b""
-
-    class SPAFallbackMiddleware(BaseHTTPMiddleware):
-        async def dispatch(self, request, call_next):
-            response = await call_next(request)
-
-            # Only intercept GET requests that got 404 from FastAPI
-            if (request.method == "GET"
-                    and response.status_code == 404
-                    and not request.url.path.startswith("/api/")):
-                # Serve static file if it exists
-                rel_path = request.url.path.lstrip("/")
-                file_path = _frontend_dir / rel_path
-                if rel_path and file_path.is_file() and _frontend_dir in file_path.resolve().parents:
-                    return FileResponse(str(file_path))
-                # SPA fallback: index.html
-                if _index_html:
-                    return _MWResponse(
-                        content=_index_html,
-                        media_type="text/html",
-                        headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
-                    )
-            return response
-
-    app.add_middleware(SPAFallbackMiddleware)
+    app.add_middleware(
+        SPAFallbackMiddleware,
+        frontend_dir=_frontend_dir,
+        index_html=_index_html,
+    )
 
     # Mount hashed assets with long cache (before middleware, so they're served directly)
     _assets_dir = _frontend_dir / "assets"

--- a/backend/app/middleware/static_serving.py
+++ b/backend/app/middleware/static_serving.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+from fastapi.responses import FileResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response, PlainTextResponse
@@ -115,3 +118,117 @@ class RequestSizeLimitMiddleware:
 class _RequestTooLargeError(Exception):
     """Internal signal used by RequestSizeLimitMiddleware to abort reads."""
     pass
+
+
+# Headers we propagate from the inner middleware chain onto SPA-fallback
+# responses. SPAFallbackMiddleware sits OUTSIDE SecurityHeadersMiddleware in
+# the stack (added later in main.py → wraps it), so a Response constructed
+# inside dispatch() bypasses SecurityHeadersMiddleware unless we copy the
+# headers it set on the inner 404 response.
+_PROPAGATED_SECURITY_HEADERS = (
+    "X-Frame-Options",
+    "X-Content-Type-Options",
+    "Referrer-Policy",
+    "Content-Security-Policy",
+    "Strict-Transport-Security",
+)
+
+
+class SPAFallbackMiddleware(BaseHTTPMiddleware):
+    """
+    Serves the SPA shell (index.html) for unknown GET routes so React Router
+    can resolve client-side routes after a hard reload, plus serves arbitrary
+    static files that live in the frontend dist root (favicons, manifests,
+    fonts) without an explicit mount. Replaces nginx
+    ``try_files $uri $uri/ /index.html``.
+
+    Asset vs. navigation
+    --------------------
+    Requests whose last path segment contains a ``.`` are treated as static
+    asset requests *unless* the client explicitly asks for HTML
+    (``Accept: text/html``). Asset requests that hit a 404 do NOT fall
+    through to ``index.html`` — they return a real 404. This prevents a
+    classic post-update breakage: a stale Service Worker (left over from a
+    previous app version) requests an old hashed CSS bundle that no longer
+    exists on disk; without this guard the middleware would happily reply
+    with ``index.html`` and ``Content-Type: text/html``, which the browser
+    refuses to apply as a stylesheet — leading to an unstyled page on every
+    navigation until the user manually unregisters the SW.
+    """
+
+    def __init__(self, app, frontend_dir: Path, index_html: bytes):
+        super().__init__(app)
+        self._frontend_dir = Path(frontend_dir).resolve()
+        self._index_html = index_html
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+
+        if (request.method != "GET"
+                or response.status_code != 404
+                or request.url.path.startswith("/api/")):
+            return response
+
+        path = request.url.path
+        rel_path = path.lstrip("/")
+        if rel_path:
+            file_path = self._frontend_dir / rel_path
+            try:
+                resolved = file_path.resolve()
+            except (OSError, ValueError):
+                resolved = None
+            if (resolved is not None
+                    and self._frontend_dir in resolved.parents
+                    and file_path.is_file()):
+                file_response = FileResponse(str(file_path))
+                _propagate_security_headers(response, file_response)
+                return file_response
+
+        if _looks_like_asset_request(path, request.headers.get("accept", "")):
+            return response
+
+        if not self._index_html:
+            return response
+
+        spa_headers = {"Cache-Control": "no-cache, no-store, must-revalidate"}
+        for name in _PROPAGATED_SECURITY_HEADERS:
+            value = response.headers.get(name)
+            if value is not None:
+                spa_headers[name] = value
+        return Response(
+            content=self._index_html,
+            media_type="text/html",
+            headers=spa_headers,
+        )
+
+
+def _looks_like_asset_request(path: str, accept_header: str) -> bool:
+    """A request looks like a static asset if its last path segment has an
+    extension AND the client did not explicitly ask for HTML navigation.
+
+    Browsers requesting CSS/JS/images send ``Accept: text/css,*/*;q=0.1``,
+    ``image/png,*/*`` etc. — never ``text/html``. Top-level navigations send
+    ``Accept: text/html,...``. This makes the rule safe even for SPA routes
+    that happen to contain a dot (``/users/john.doe``)."""
+    last_segment = path.rsplit("/", 1)[-1]
+    if "." not in last_segment:
+        return False
+    if path.startswith("/assets/"):
+        # /assets/* is reserved for hashed bundles. Clients should never
+        # navigate to those URLs — short-circuit independent of Accept.
+        return True
+    if "text/html" in accept_header.lower():
+        return False
+    return True
+
+
+def _propagate_security_headers(source: Response, target: Response) -> None:
+    """Copy security headers from source to target (only if not already set
+    on target). Used to keep CSP/HSTS/etc. on responses that the SPA fallback
+    constructs after the inner SecurityHeadersMiddleware ran."""
+    for name in _PROPAGATED_SECURITY_HEADERS:
+        if name in target.headers:
+            continue
+        value = source.headers.get(name)
+        if value is not None:
+            target.headers[name] = value

--- a/backend/tests/test_spa_fallback.py
+++ b/backend/tests/test_spa_fallback.py
@@ -1,0 +1,175 @@
+"""
+Tests for SPAFallbackMiddleware — the middleware that replaces nginx's
+``try_files $uri $uri/ /index.html`` in native (SERVE_FRONTEND=True) mode.
+
+The middleware must distinguish "navigation requests" (where falling back to
+``index.html`` is correct) from "asset requests" (where falling back to HTML
+breaks the page on stale-Service-Worker clients — a CSS link that resolves to
+``text/html`` is rejected by the browser, leaving every navigation unstyled
+until the user manually unregisters the SW).
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.staticfiles import StaticFiles
+
+from app.middleware.static_serving import (
+    SecurityHeadersMiddleware,
+    SPAFallbackMiddleware,
+)
+
+
+@pytest.fixture
+def native_app(tmp_path):
+    """Mini FastAPI app wired up like native mode: SecurityHeaders +
+    SPAFallback middleware, /assets static mount, frontend dir on disk."""
+    frontend_dir = tmp_path / "frontend"
+    frontend_dir.mkdir()
+    index_html = b"<!doctype html><html><body><div id='root'></div></body></html>"
+    (frontend_dir / "index.html").write_bytes(index_html)
+    (frontend_dir / "favicon.ico").write_bytes(b"\x00\x00ICON")
+    (frontend_dir / "manifest.webmanifest").write_text('{"name":"x"}')
+
+    assets_dir = frontend_dir / "assets"
+    assets_dir.mkdir()
+    (assets_dir / "index-NEWHASH.css").write_text("body{color:red}")
+    (assets_dir / "index-NEWHASH.js").write_text("console.log(1)")
+
+    app = FastAPI()
+
+    @app.get("/api/health")
+    def health():
+        return {"ok": True}
+
+    # Order matches main.py: SecurityHeaders added first, SPAFallback last
+    # — Starlette wraps later-added middleware on the OUTSIDE, so SPAFallback
+    # runs first on incoming, with SecurityHeaders below it in the stack.
+    app.add_middleware(SecurityHeadersMiddleware)
+    app.add_middleware(
+        SPAFallbackMiddleware,
+        frontend_dir=frontend_dir,
+        index_html=index_html,
+    )
+
+    app.mount("/assets", StaticFiles(directory=str(assets_dir)), name="assets")
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Asset 404 behaviour — root-cause fix for stale-Service-Worker breakage.
+# ---------------------------------------------------------------------------
+
+def test_missing_asset_in_assets_dir_returns_404(native_app):
+    """Stale SW requests an old hashed CSS that no longer exists on disk.
+
+    Must return a real 404, NOT index.html with text/html — otherwise the
+    browser would receive HTML for a stylesheet request and silently fail to
+    apply any styles, leaving the page unstyled until the SW is unregistered.
+    """
+    r = native_app.get(
+        "/assets/index-OLDHASH123.css",
+        headers={"accept": "text/css,*/*;q=0.1"},
+    )
+    assert r.status_code == 404, (
+        f"Expected 404 for missing asset, got {r.status_code} "
+        f"with Content-Type {r.headers.get('content-type')!r}"
+    )
+    assert "text/html" not in r.headers.get("content-type", "")
+
+
+def test_missing_top_level_asset_with_extension_returns_404(native_app):
+    """Top-level files with extensions (sw.js, robots.txt, foo.png) should
+    surface 404 if missing — same reasoning: no HTML disguised as asset."""
+    r = native_app.get("/some-bundle.js", headers={"accept": "*/*"})
+    assert r.status_code == 404
+
+
+def test_missing_asset_in_assets_dir_returns_404_even_without_accept(native_app):
+    """Some HTTP clients send no Accept header; /assets/* paths must still
+    short-circuit to 404 regardless — those URLs are reserved for hashed
+    bundles and clients should never navigate to them."""
+    r = native_app.get("/assets/missing.css")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Navigation behaviour — preserve the legitimate use of the SPA fallback.
+# ---------------------------------------------------------------------------
+
+def test_navigation_returns_index_html(native_app):
+    """A real SPA navigation (Accept: text/html, no extension) must still
+    return index.html so React Router can resolve the route on hard reload."""
+    r = native_app.get(
+        "/login",
+        headers={"accept": "text/html,application/xhtml+xml"},
+    )
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/html")
+    assert b"<div id='root'>" in r.content
+
+
+def test_navigation_response_carries_security_headers(native_app):
+    """The SPA fallback constructs its own Response inside dispatch() — it
+    must still carry CSP/HSTS/X-Frame-Options, otherwise SPA pages ship
+    without security headers while /assets/* pages have them. Defence-in-
+    depth + parity with what nginx does in Docker mode."""
+    r = native_app.get(
+        "/login",
+        headers={"accept": "text/html"},
+    )
+    assert r.status_code == 200
+    assert "default-src 'self'" in r.headers.get("content-security-policy", "")
+    assert r.headers.get("x-frame-options") == "SAMEORIGIN"
+    assert r.headers.get("x-content-type-options") == "nosniff"
+
+
+def test_existing_top_level_static_file_is_served(native_app):
+    """favicon.ico / manifest.webmanifest live in the frontend root, not
+    /assets/, and reach the middleware as 404 from the inner stack. They
+    must be served from disk — that's the whole point of the file-on-disk
+    branch in the middleware."""
+    r = native_app.get("/favicon.ico")
+    assert r.status_code == 200
+    assert r.content == b"\x00\x00ICON"
+
+
+def test_existing_assets_pass_through_unchanged(native_app):
+    """Sanity: assets that DO exist are served by the StaticFiles mount
+    and the middleware doesn't interfere."""
+    r = native_app.get("/assets/index-NEWHASH.css")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/css")
+    assert r.text == "body{color:red}"
+
+
+def test_api_404_passes_through(native_app):
+    """A 404 from /api/* must be returned as-is — falling back to
+    index.html for missing API endpoints would mask backend bugs and
+    confuse the frontend's error handling."""
+    r = native_app.get("/api/does-not-exist")
+    assert r.status_code == 404
+
+
+def test_post_to_api_passes_through(native_app):
+    """The middleware must only intercept GET — POST/PUT/DELETE to
+    unknown paths should return Starlette's default 405/404 response,
+    never index.html. Regression guard for the issue noted in CLAUDE.md
+    ("SPA-Fallback: Middleware statt catch-all Route!")."""
+    r = native_app.post("/some-route", json={})
+    assert r.status_code in (404, 405)
+    assert "text/html" not in r.headers.get("content-type", "")
+
+
+def test_spa_route_with_dot_in_segment_falls_back_to_html(native_app):
+    """Edge case: SPA routes can legitimately contain a dot
+    (``/users/john.doe``). When the client sends Accept: text/html, the
+    middleware must still serve index.html — the dot alone shouldn't
+    disqualify it as a navigation target."""
+    r = native_app.get(
+        "/users/john.doe",
+        headers={"accept": "text/html,application/xhtml+xml"},
+    )
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/html")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "axios": "^1.15.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "axios": "^1.15.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "axios": "^1.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.4.2",
+  "version": "1.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -61,22 +61,33 @@
   unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+@layer base {
+  /*
+    Element-default reset. MUST live inside @layer base — unlayered CSS beats
+    layered Tailwind utilities (which are in @layer utilities), and Tailwind
+    v4 wraps utilities in :where() for zero specificity. An unlayered
+    `* { padding: 0; margin: 0 }` therefore silently overrides every p-*,
+    m-*, space-x-* etc., leaving cards/sidebar with collapsed spacing.
+    Tailwind Preflight already handles box-sizing on *, but the margin/
+    padding zeroing is intentional (we want a clean baseline beyond
+    Preflight).
+  */
+  * {
+    margin: 0;
+    padding: 0;
+  }
 
-body {
-  font-family: 'DM Sans', system-ui, -apple-system, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  background-color: #FAFBFC;
-  color: #1A2B3D;
-}
+  body {
+    font-family: 'DM Sans', system-ui, -apple-system, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    background-color: #FAFBFC;
+    color: #1A2B3D;
+  }
 
-#root {
-  min-height: 100vh;
+  #root {
+    min-height: 100vh;
+  }
 }
 
 /* Animations */

--- a/installer/setup/src/PraxisZeit.Setup.Core/PraxisZeit.Setup.Core.csproj
+++ b/installer/setup/src/PraxisZeit.Setup.Core/PraxisZeit.Setup.Core.csproj
@@ -11,6 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.5" />
+    <!-- Ed25519 license-key verification: .NET 10 has no native Ed25519
+         (MLDsa is post-quantum, not Ed25519). BouncyCastle ships a
+         well-tested Ed25519 verifier and PEM SubjectPublicKeyInfo parser. -->
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
   </ItemGroup>
 
 </Project>

--- a/installer/setup/src/PraxisZeit.Setup.Core/Services/LicenseValidator.cs
+++ b/installer/setup/src/PraxisZeit.Setup.Core/Services/LicenseValidator.cs
@@ -1,0 +1,291 @@
+using System.Buffers.Text;
+using System.Text;
+using System.Text.Json;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Signers;
+using Org.BouncyCastle.OpenSsl;
+using Org.BouncyCastle.Security;
+
+namespace PraxisZeit.Setup.Core.Services;
+
+/// <summary>
+/// Result einer Lizenz-Verifikation. Mirror'd 1:1 von
+/// <c>backend/app/core/license.py:LicenseInfo</c> — gleiche Felder, gleiche
+/// Semantik fuer <see cref="IsExpired"/> und <see cref="DaysUntilExpiry"/>,
+/// damit der Wizard dem User EXAKT das anzeigt, was das Backend nach dem
+/// Install in der Statusbar zeigen wird.
+/// </summary>
+public sealed record LicenseInfo
+{
+    public required string CustomerId { get; init; }
+    public required string CustomerName { get; init; }
+    public required int MaxEmployees { get; init; }
+    public IReadOnlyList<string> Features { get; init; } = ["base"];
+    public DateTimeOffset? IssuedAt { get; init; }
+    public DateTimeOffset? ExpiresAt { get; init; }
+    public int Version { get; init; } = 1;
+
+    public bool IsExpired => ExpiresAt is { } exp && DateTimeOffset.UtcNow > exp;
+
+    public int? DaysUntilExpiry
+    {
+        get
+        {
+            if (ExpiresAt is not { } exp) return null;
+            var delta = exp - DateTimeOffset.UtcNow;
+            return Math.Max(0, (int)delta.TotalDays);
+        }
+    }
+}
+
+public abstract record LicenseResult;
+
+public sealed record LicenseValid(LicenseInfo Info) : LicenseResult;
+
+/// <summary>Lizenz war signaturlich gueltig, ist aber laut <c>exp</c> abgelaufen.</summary>
+public sealed record LicenseExpired(LicenseInfo Info) : LicenseResult;
+
+/// <summary>
+/// Lizenz konnte nicht validiert werden — falsche Signatur, kaputte Datei,
+/// falsches Format. <see cref="Reason"/> ist eine deutsche Fehlermeldung
+/// die direkt im UI angezeigt werden kann.
+/// </summary>
+public sealed record LicenseInvalid(string Reason) : LicenseResult;
+
+/// <summary>
+/// Offline-Verifikation einer PraxisZeit-Lizenz. Reimplementiert das gleiche
+/// Schema wie <c>backend/app/core/license.py</c>: EdDSA-signierter JWT,
+/// Public-Key embedded, JWT enthaelt <c>sub | name | max_employees | iat |
+/// exp? | features? | v?</c>. Wir nutzen BouncyCastle weil .NET 10 noch
+/// keine native Ed25519-Unterstuetzung hat (MLDsa ist Post-Quantum, kein
+/// Ed25519).
+///
+/// <para>
+/// <strong>Public-Key-Sync:</strong> Wenn der Backend-Public-Key in
+/// <c>backend/app/core/license.py:_PUBLIC_KEY_PEM</c> rotiert wird, MUSS
+/// der String hier auch ersetzt werden — sonst akzeptiert der Wizard
+/// Lizenzen die das Backend ablehnt (oder umgekehrt).
+/// </para>
+/// </summary>
+public static class LicenseValidator
+{
+    /// <summary>
+    /// Ed25519 public key. MUSS Byte-fuer-Byte synchron mit
+    /// <c>backend/app/core/license.py:_PUBLIC_KEY_PEM</c> sein.
+    /// </summary>
+    private const string PublicKeyPem =
+        "-----BEGIN PUBLIC KEY-----\n" +
+        "MCowBQYDK2VwAyEAB5ZiJro6fDM8M5BupMCdTWjVIFkPn+hsNYHNlajzIyY=\n" +
+        "-----END PUBLIC KEY-----";
+
+    /// <summary>
+    /// Parst und verifiziert ein Lizenz-Token (JWT-String, im Backend per
+    /// <c>jwt.encode(...,algorithm="EdDSA")</c> erzeugt). Liefert ein
+    /// <see cref="LicenseResult"/> das das UI direkt rendern kann —
+    /// signaturlich gueltig, gueltig-aber-abgelaufen, oder ungueltig.
+    /// </summary>
+    public static LicenseResult ValidateToken(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return new LicenseInvalid("Lizenz ist leer.");
+        }
+
+        var trimmed = token.Trim();
+        var parts = trimmed.Split('.');
+        if (parts.Length != 3)
+        {
+            return new LicenseInvalid(
+                "Lizenz hat nicht das erwartete JWT-Format (Header.Payload.Signature). "
+                + "Bitte pruefen Sie, ob die Datei vollstaendig ist.");
+        }
+
+        var headerJson = TryDecodeBase64Url(parts[0]);
+        var payloadJson = TryDecodeBase64Url(parts[1]);
+        var signature = TryDecodeBase64UrlBytes(parts[2]);
+        if (headerJson is null || payloadJson is null || signature is null)
+        {
+            return new LicenseInvalid("Lizenz enthaelt ungueltiges Base64-URL-Encoding.");
+        }
+
+        // Header-Algorithm pruefen — alles ausser EdDSA ist hier nicht
+        // unterstuetzt (HS256 etc.). Backend signiert ausschliesslich EdDSA.
+        try
+        {
+            using var headerDoc = JsonDocument.Parse(headerJson);
+            var alg = headerDoc.RootElement.TryGetProperty("alg", out var algEl)
+                ? algEl.GetString()
+                : null;
+            if (!string.Equals(alg, "EdDSA", StringComparison.Ordinal))
+            {
+                return new LicenseInvalid(
+                    $"Lizenz hat unbekannten Signatur-Algorithmus '{alg}'. "
+                    + "Erwartet wird EdDSA (Ed25519).");
+            }
+        }
+        catch (JsonException)
+        {
+            return new LicenseInvalid("Lizenz-Header ist kein gueltiges JSON.");
+        }
+
+        // Signatur-Pruefung: signing_input = header_b64 + "." + payload_b64
+        // (UTF-8 Bytes der base64url-encoded Strings, NICHT der decodierten
+        // JSON-Strings). Das ist die JWT-Spec.
+        var signingInput = Encoding.UTF8.GetBytes(parts[0] + "." + parts[1]);
+        if (!VerifyEd25519(signingInput, signature))
+        {
+            return new LicenseInvalid(
+                "Lizenz-Signatur ist ungueltig. Datei ist beschaedigt oder wurde manipuliert.");
+        }
+
+        // Payload parsen + Required Claims validieren
+        try
+        {
+            using var payloadDoc = JsonDocument.Parse(payloadJson);
+            var root = payloadDoc.RootElement;
+
+            string? sub = TryGetString(root, "sub");
+            string? name = TryGetString(root, "name");
+            int? maxEmployees = TryGetInt(root, "max_employees");
+            long? iat = TryGetLong(root, "iat");
+
+            if (sub is null || name is null || maxEmployees is null || iat is null)
+            {
+                return new LicenseInvalid(
+                    "Lizenz fehlt eines der erforderlichen Felder (sub / name / max_employees / iat).");
+            }
+
+            var info = new LicenseInfo
+            {
+                CustomerId = sub,
+                CustomerName = name,
+                MaxEmployees = maxEmployees.Value,
+                Features = TryGetStringArray(root, "features") ?? ["base"],
+                IssuedAt = DateTimeOffset.FromUnixTimeSeconds(iat.Value),
+                ExpiresAt = TryGetLong(root, "exp") is { } exp
+                    ? DateTimeOffset.FromUnixTimeSeconds(exp)
+                    : null,
+                Version = TryGetInt(root, "v") ?? 1,
+            };
+
+            return info.IsExpired ? new LicenseExpired(info) : new LicenseValid(info);
+        }
+        catch (JsonException ex)
+        {
+            return new LicenseInvalid($"Lizenz-Payload ist kein gueltiges JSON: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Wrapper fuer Datei-Input — liest Datei und delegiert an
+    /// <see cref="ValidateToken"/>. Datei-Encoding wird wie das Backend
+    /// behandelt: nach <c>strip()</c>, jegliche Whitespace-Wrap egal.
+    /// </summary>
+    public static LicenseResult ValidateFile(string licensePath)
+    {
+        if (!File.Exists(licensePath))
+        {
+            return new LicenseInvalid($"Lizenz-Datei nicht gefunden: {licensePath}");
+        }
+
+        string token;
+        try
+        {
+            token = File.ReadAllText(licensePath).Trim();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return new LicenseInvalid($"Lizenz-Datei konnte nicht gelesen werden: {ex.Message}");
+        }
+
+        return ValidateToken(token);
+    }
+
+    // ---------- Internals ----------
+
+    private static bool VerifyEd25519(byte[] message, byte[] signature)
+    {
+        try
+        {
+            using var reader = new StringReader(PublicKeyPem);
+            var pemReader = new PemReader(reader);
+            var keyObj = pemReader.ReadObject();
+            // BouncyCastle's PemReader returns SubjectPublicKeyInfo for the
+            // OpenSSL "PUBLIC KEY" PEM block. Convert to typed key.
+            Ed25519PublicKeyParameters publicKey = keyObj switch
+            {
+                Ed25519PublicKeyParameters direct => direct,
+                Org.BouncyCastle.Asn1.X509.SubjectPublicKeyInfo spki
+                    => (Ed25519PublicKeyParameters)PublicKeyFactory.CreateKey(spki),
+                _ => (Ed25519PublicKeyParameters)PublicKeyFactory.CreateKey(
+                    Org.BouncyCastle.Asn1.X509.SubjectPublicKeyInfo.GetInstance(keyObj!)),
+            };
+
+            var verifier = new Ed25519Signer();
+            verifier.Init(forSigning: false, publicKey);
+            verifier.BlockUpdate(message, 0, message.Length);
+            return verifier.VerifySignature(signature);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string? TryDecodeBase64Url(string input)
+    {
+        var bytes = TryDecodeBase64UrlBytes(input);
+        return bytes is null ? null : Encoding.UTF8.GetString(bytes);
+    }
+
+    private static byte[]? TryDecodeBase64UrlBytes(string input)
+    {
+        // JWT base64url: '-' → '+', '_' → '/', no padding. Pad to multiple of 4.
+        var padded = input.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+            case 0: break;
+            default: return null;
+        }
+        try
+        {
+            return Convert.FromBase64String(padded);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private static string? TryGetString(JsonElement el, string name) =>
+        el.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    private static int? TryGetInt(JsonElement el, string name)
+    {
+        if (!el.TryGetProperty(name, out var v)) return null;
+        if (v.ValueKind == JsonValueKind.Number && v.TryGetInt32(out var i)) return i;
+        if (v.ValueKind == JsonValueKind.String && int.TryParse(v.GetString(), out var i2)) return i2;
+        return null;
+    }
+
+    private static long? TryGetLong(JsonElement el, string name)
+    {
+        if (!el.TryGetProperty(name, out var v)) return null;
+        if (v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var l)) return l;
+        if (v.ValueKind == JsonValueKind.String && long.TryParse(v.GetString(), out var l2)) return l2;
+        return null;
+    }
+
+    private static IReadOnlyList<string>? TryGetStringArray(JsonElement el, string name)
+    {
+        if (!el.TryGetProperty(name, out var v) || v.ValueKind != JsonValueKind.Array) return null;
+        var list = new List<string>(v.GetArrayLength());
+        foreach (var item in v.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String && item.GetString() is { } s) list.Add(s);
+        }
+        return list;
+    }
+}

--- a/installer/setup/src/PraxisZeit.Setup.Core/Services/PraxisZeitConfigWriter.cs
+++ b/installer/setup/src/PraxisZeit.Setup.Core/Services/PraxisZeitConfigWriter.cs
@@ -22,6 +22,23 @@ public sealed record PraxisZeitConfigValues
     public string AdminFirstName { get; init; } = "Admin";
     public string AdminLastName { get; init; } = "Praxis";
     public required string AdminPassword { get; init; }
+
+    /// <summary>HTTPS-Port den uvicorn-Backend bedient. Default 443.</summary>
+    public int HttpsPort { get; init; } = 443;
+
+    /// <summary>HTTP-Port der nur ein 301-Redirect auf <see cref="HttpsPort"/>
+    /// liefert. Default 80, kann auf 0 gesetzt werden um den Redirect ganz
+    /// abzuschalten (manche Kunden wollen keine Port-80-Bindung).</summary>
+    public int HttpRedirectPort { get; init; } = 80;
+
+    /// <summary>JWT-Text der Lizenz (komplette EdDSA-signierte Token-Zeile).
+    /// Null = Demo-Modus aktiv (siehe <see cref="DemoDays"/>).</summary>
+    public string? LicenseToken { get; init; }
+
+    /// <summary>Demo-Laufzeit in Tagen ab Install-Datum. Wird nur ausgewertet
+    /// wenn <see cref="LicenseToken"/> null ist. Default null = kein Demo,
+    /// Backend bricht ohne Lizenz beim Start ab (legacy).</summary>
+    public int? DemoDays { get; init; }
 }
 
 /// <summary>
@@ -85,6 +102,18 @@ public static class PraxisZeitConfigWriter
         {
             return "Admin-Passwort ist auf der Liste bekannter Default-Passwoerter — bitte ein anderes waehlen.";
         }
+        if (values.HttpsPort is < 1 or > 65535)
+        {
+            return $"HTTPS-Port muss zwischen 1 und 65535 liegen (aktuell: {values.HttpsPort}).";
+        }
+        if (values.HttpRedirectPort is < 0 or > 65535)
+        {
+            return $"HTTP-Redirect-Port muss zwischen 0 und 65535 liegen (aktuell: {values.HttpRedirectPort}).";
+        }
+        if (values.HttpRedirectPort > 0 && values.HttpRedirectPort == values.HttpsPort)
+        {
+            return "HTTP-Redirect-Port und HTTPS-Port duerfen nicht identisch sein.";
+        }
         return null;
     }
 
@@ -101,7 +130,11 @@ public static class PraxisZeitConfigWriter
         sb.AppendLine();
 
         sb.AppendLine("[server]");
-        sb.AppendLine("port = 443");
+        sb.AppendLine($"port = {values.HttpsPort}");
+        if (values.HttpRedirectPort > 0)
+        {
+            sb.AppendLine($"http_redirect_port = {values.HttpRedirectPort}");
+        }
         sb.AppendLine("ssl_cert = \"config/ssl/cert.pem\"");
         sb.AppendLine("ssl_key = \"config/ssl/key.pem\"");
         sb.AppendLine();
@@ -133,6 +166,14 @@ public static class PraxisZeitConfigWriter
 
         sb.AppendLine("[license]");
         sb.AppendLine("key_file = \"config/license.key\"");
+        if (values.LicenseToken is null && values.DemoDays is { } demoDays && demoDays > 0)
+        {
+            // Demo-Modus: keine echte license.key, aber demo_expires_at
+            // setzt eine Hard-Deadline. Backend liest den Wert in
+            // app/main.py:lifespan und schaltet ab Ueberlauf in Read-Only.
+            var demoUntil = DateTime.UtcNow.Date.AddDays(demoDays).ToString("yyyy-MM-dd");
+            sb.AppendLine($"demo_expires_at = \"{demoUntil}\"");
+        }
         sb.AppendLine();
 
         sb.AppendLine("[updates]");
@@ -172,6 +213,25 @@ public static class PraxisZeitConfigWriter
         // schreibt MIT BOM, deshalb explizit `new UTF8Encoding(false)`.
         var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         await File.WriteAllTextAsync(targetPath, Serialize(values), encoding, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Schreibt ein Lizenz-Token nach <c>{configDir}/license.key</c>.
+    /// Wird im Fresh-Install nach <see cref="WriteAsync"/> gerufen — ist
+    /// bewusst eine separate Methode, weil der Token auch beim Update
+    /// neu eingespielt werden kann (License-Page erscheint in beiden
+    /// Modi).
+    /// </summary>
+    public static async Task WriteLicenseFileAsync(string configDir, string token, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new ArgumentException("Lizenz-Token darf nicht leer sein.", nameof(token));
+        }
+        Directory.CreateDirectory(configDir);
+        var licensePath = Path.Combine(configDir, "license.key");
+        var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        await File.WriteAllTextAsync(licensePath, token.Trim(), encoding, ct).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/installer/setup/src/PraxisZeit.Setup/App.axaml
+++ b/installer/setup/src/PraxisZeit.Setup/App.axaml
@@ -63,6 +63,9 @@
         <FluentTheme />
 
         <!-- ====== Buttons ====== -->
+        <!-- Avalonia FluentTheme defaults Button.HorizontalContentAlignment to
+             Left; expliziter zentrieren, damit Footer-Buttons mit MinWidth>>
+             Content (z.B. "Zurueck" 120px) ihre Beschriftung mittig haben. -->
         <Style Selector="Button.primary">
             <Setter Property="Background" Value="{StaticResource BrandPrimaryBrush}"/>
             <Setter Property="Foreground" Value="{StaticResource TextInverseBrush}"/>
@@ -72,6 +75,8 @@
             <Setter Property="FontWeight" Value="SemiBold"/>
             <Setter Property="FontSize" Value="13"/>
             <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="Button.primary:pointerover /template/ ContentPresenter">
             <Setter Property="Background" Value="{StaticResource BrandPrimaryDarkBrush}"/>
@@ -95,6 +100,8 @@
             <Setter Property="FontWeight" Value="SemiBold"/>
             <Setter Property="FontSize" Value="13"/>
             <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="Button.success:pointerover /template/ ContentPresenter">
             <Setter Property="Background" Value="{StaticResource BrandAccentDarkBrush}"/>
@@ -111,6 +118,8 @@
             <Setter Property="FontWeight" Value="Medium"/>
             <Setter Property="FontSize" Value="13"/>
             <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="Button.ghost:pointerover /template/ ContentPresenter">
             <Setter Property="Background" Value="{StaticResource SurfaceMutedBrush}"/>

--- a/installer/setup/src/PraxisZeit.Setup/ViewModels/InstallLocationPageViewModel.cs
+++ b/installer/setup/src/PraxisZeit.Setup/ViewModels/InstallLocationPageViewModel.cs
@@ -1,0 +1,173 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PraxisZeit.Setup.Core.Models;
+using PraxisZeit.Setup.Core.Services;
+
+namespace PraxisZeit.Setup.ViewModels;
+
+/// <summary>
+/// User waehlt das Zielverzeichnis. Bei jedem Pfad-Wechsel laeuft der
+/// <see cref="UpdateDetector"/> erneut: zeigt der Pfad eine bestehende
+/// Installation, wechselt der detektierte Modus von Fresh auf Update.
+///
+/// <para>
+/// Wenn der User-Intent (Welcome-Seite) ein Fresh-Install war, der Pfad
+/// aber eine existierende Installation enthaelt, blenden wir eine
+/// rote Warnung ein und blockieren "Weiter" — bis der User entweder
+/// einen anderen Pfad waehlt ODER per Button auf Update umschaltet
+/// (sicherer Default: kein Daten-Clobber).
+/// </para>
+/// </summary>
+public sealed partial class InstallLocationPageViewModel : WizardPageBase
+{
+    public override string Key => "location";
+    public override string Title => "Installationsort";
+
+    private readonly UpdateDetector _detector;
+    private readonly string _targetVersion;
+
+    /// <summary>
+    /// Vom User gewaehlter Modus (initial = Welcome-Page-Detect-Ergebnis).
+    /// Setzt sich automatisch um, wenn der User explizit auf Update
+    /// umschaltet via <see cref="SwitchToUpdateCommand"/>.
+    /// </summary>
+    [ObservableProperty]
+    public partial InstallMode IntentMode { get; set; }
+
+    /// <summary>
+    /// Vom Detector erkannter Modus auf dem aktuellen <see cref="InstallPath"/>.
+    /// Bei jedem Pfad-Wechsel neu berechnet.
+    /// </summary>
+    [ObservableProperty]
+    public partial InstallMode DetectedMode { get; set; }
+
+    [ObservableProperty]
+    public partial string? DetectedVersion { get; set; }
+
+    [ObservableProperty]
+    public partial string InstallPath { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial bool IsPathReadOnly { get; set; }
+
+    [ObservableProperty]
+    public partial string? ValidationMessage { get; set; }
+
+    public bool HasValidationMessage => !string.IsNullOrEmpty(ValidationMessage);
+
+    /// <summary>
+    /// True, wenn User-Intent Fresh ist, Pfad aber existierende
+    /// Installation hat. Blendet die Warning-Card ein.
+    /// </summary>
+    public bool IsConflict =>
+        IntentMode == InstallMode.FreshInstall && DetectedMode != InstallMode.FreshInstall;
+
+    public string ConflictHeadline => DetectedMode switch
+    {
+        InstallMode.Update =>
+            $"In diesem Verzeichnis liegt bereits PraxisZeit {DetectedVersion}.",
+        InstallMode.Repair =>
+            $"In diesem Verzeichnis liegt bereits PraxisZeit {DetectedVersion} (gleiche Version).",
+        _ => string.Empty,
+    };
+
+    public string ConflictDescription =>
+        "Eine Neuinstallation in diesem Verzeichnis wuerde die bestehende Installation und alle Daten "
+        + "(Datenbank, Konfiguration, Lizenz) ueberschreiben. Empfohlene Alternative: auf Update "
+        + "umschalten — dann wird die Datenbank gesichert, nur Binaries werden ersetzt.";
+
+    public bool CanSwitchToUpdate => IsConflict && DetectedMode == InstallMode.Update;
+
+    public InstallLocationPageViewModel()
+        : this(new UpdateDetector(), "1.0.0", string.Empty, InstallMode.FreshInstall)
+    {
+    }
+
+    public InstallLocationPageViewModel(
+        UpdateDetector detector,
+        string targetVersion,
+        string defaultPath,
+        InstallMode initialIntent)
+    {
+        _detector = detector;
+        _targetVersion = targetVersion;
+        IntentMode = initialIntent;
+        InstallPath = defaultPath;
+        // Update-Modus: User darf den Pfad nicht aendern (Update muss in
+        // den Pfad einer existierenden Installation laufen — sonst waere
+        // es kein Update).
+        IsPathReadOnly = initialIntent == InstallMode.Update;
+        Recompute();
+    }
+
+    partial void OnInstallPathChanged(string value)
+    {
+        Recompute();
+    }
+
+    partial void OnIntentModeChanged(InstallMode value)
+    {
+        Recompute();
+        OnPropertyChanged(nameof(IsConflict));
+        OnPropertyChanged(nameof(CanSwitchToUpdate));
+    }
+
+    private void Recompute()
+    {
+        if (string.IsNullOrWhiteSpace(InstallPath))
+        {
+            ValidationMessage = "Bitte einen Installationspfad waehlen.";
+            CanGoNext = false;
+            DetectedMode = InstallMode.FreshInstall;
+            DetectedVersion = null;
+            OnPropertyChanged(nameof(HasValidationMessage));
+            OnPropertyChanged(nameof(IsConflict));
+            OnPropertyChanged(nameof(CanSwitchToUpdate));
+            OnPropertyChanged(nameof(ConflictHeadline));
+            return;
+        }
+
+        DetectedVersion = _detector.DetectCurrentVersion(InstallPath);
+        DetectedMode = _detector.DetectMode(InstallPath, _targetVersion);
+
+        // Update-Intent + Pfad ohne Installation -> wir koennen das Update
+        // nicht ausfuehren (es gibt nichts zu updaten). Klare Fehlermeldung.
+        if (IntentMode == InstallMode.Update && DetectedMode == InstallMode.FreshInstall)
+        {
+            ValidationMessage =
+                "Im gewaehlten Pfad wurde keine bestehende PraxisZeit-Installation gefunden. "
+                + "Update ist in diesem Pfad nicht moeglich.";
+            CanGoNext = false;
+        }
+        else if (IsConflict)
+        {
+            // Fresh-Intent + bestehende Installation -> blockieren bis aufgeloest
+            ValidationMessage = null;
+            CanGoNext = false;
+        }
+        else
+        {
+            ValidationMessage = null;
+            CanGoNext = true;
+        }
+
+        OnPropertyChanged(nameof(HasValidationMessage));
+        OnPropertyChanged(nameof(IsConflict));
+        OnPropertyChanged(nameof(CanSwitchToUpdate));
+        OnPropertyChanged(nameof(ConflictHeadline));
+        SwitchToUpdateCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// User klickt "Auf Update umschalten" auf dem Conflict-Panel —
+    /// IntentMode wechselt auf Update, der Wizard rebuilt die Pages
+    /// (Update-Flow ueberspringt die ConfigPage). Wird vom MainWindow
+    /// observiert.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanSwitchToUpdate))]
+    private void SwitchToUpdate()
+    {
+        IntentMode = InstallMode.Update;
+        IsPathReadOnly = true;
+    }
+}

--- a/installer/setup/src/PraxisZeit.Setup/ViewModels/LicensePageViewModel.cs
+++ b/installer/setup/src/PraxisZeit.Setup/ViewModels/LicensePageViewModel.cs
@@ -1,0 +1,174 @@
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+using PraxisZeit.Setup.Core.Services;
+
+namespace PraxisZeit.Setup.ViewModels;
+
+/// <summary>
+/// User entscheidet sich fuer einen von drei Wegen:
+///
+/// <list type="number">
+/// <item>Lizenz-Token paste/Datei waehlen → Live-Validierung gegen den
+///       gleichen Ed25519-Public-Key, den auch das Backend nutzt. Bei
+///       Erfolg zeigen wir Kunde, Mitarbeiter-Limit und Ablaufdatum.</item>
+/// <item>30-Tage-Demo → keine Lizenz noetig, schreibt nur eine
+///       <c>demo_expires_at</c>-Markierung in <c>praxiszeit.conf</c>.</item>
+/// </list>
+///
+/// "Skip ohne irgendwas" ist nicht moeglich — der Wizard erzwingt eine
+/// Entscheidung, sonst koennte das Backend nach dem Install nicht starten
+/// (siehe <c>backend/app/main.py</c>: kein License + kein Demo = sys.exit).
+/// </summary>
+public sealed partial class LicensePageViewModel : WizardPageBase
+{
+    public override string Key => "license";
+    public override string Title => "Lizenz";
+
+    /// <summary>Anzahl Tage Demo-Laufzeit, wenn der User Demo waehlt.</summary>
+    public const int DemoDurationDays = 30;
+
+    /// <summary>Mailto-/Web-Adresse fuer Lizenz-Bestellung. UI zeigt den
+    /// String als Link an. Aktuell projekt@phash.de — wird spaeter durch
+    /// die Verkaufsadresse ersetzt.</summary>
+    public const string LicenseContact = "projekt@phash.de";
+
+    /// <summary>"license" oder "demo" — wird vom MainWindow ausgewertet
+    /// um zwischen den Modi zu unterscheiden beim Conf-Schreiben.</summary>
+    [ObservableProperty]
+    public partial string SelectedMode { get; set; } = "license";
+
+    [ObservableProperty]
+    public partial string LicenseToken { get; set; } = string.Empty;
+
+    /// <summary>Wenn der User eine Datei via Browse waehlt, merken wir
+    /// uns den Pfad — fuer den UI-Hint "geladen aus: …"</summary>
+    [ObservableProperty]
+    public partial string? LoadedFromPath { get; set; }
+
+    [ObservableProperty]
+    public partial LicenseInfo? ValidatedInfo { get; set; }
+
+    [ObservableProperty]
+    public partial string? ValidationError { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsExpiredButOtherwiseValid { get; set; }
+
+    public bool HasValidatedInfo => ValidatedInfo is not null;
+    public bool HasValidationError => !string.IsNullOrEmpty(ValidationError);
+
+    /// <summary>"Gueltig bis 31.12.2026" oder "(unbefristet)".</summary>
+    public string ExpiryDisplay
+    {
+        get
+        {
+            if (ValidatedInfo?.ExpiresAt is not { } exp)
+            {
+                return "Unbefristet gueltig";
+            }
+            var formatted = exp.ToLocalTime().ToString("dd.MM.yyyy", CultureInfo.GetCultureInfo("de-DE"));
+            if (ValidatedInfo.IsExpired)
+            {
+                return $"Abgelaufen am {formatted}";
+            }
+            var days = ValidatedInfo.DaysUntilExpiry ?? 0;
+            return days <= 30
+                ? $"Gueltig bis {formatted} (nur noch {days} Tage)"
+                : $"Gueltig bis {formatted}";
+        }
+    }
+
+    public string DemoEndDisplay
+    {
+        get
+        {
+            var d = DateTime.Now.AddDays(DemoDurationDays);
+            return d.ToString("dd.MM.yyyy", CultureInfo.GetCultureInfo("de-DE"));
+        }
+    }
+
+    public LicensePageViewModel()
+    {
+        Recompute();
+    }
+
+    partial void OnSelectedModeChanged(string value)
+    {
+        Recompute();
+    }
+
+    partial void OnLicenseTokenChanged(string value)
+    {
+        Recompute();
+    }
+
+    /// <summary>
+    /// Wird vom Code-Behind beim File-Picker-Erfolg aufgerufen — laedt
+    /// den Datei-Inhalt in <see cref="LicenseToken"/> und merkt sich
+    /// den Pfad. Token-Validierung passiert via OnLicenseTokenChanged.
+    /// </summary>
+    public void LoadFromFile(string path, string content)
+    {
+        LoadedFromPath = path;
+        LicenseToken = content.Trim();
+    }
+
+    private void Recompute()
+    {
+        if (SelectedMode == "demo")
+        {
+            ValidatedInfo = null;
+            ValidationError = null;
+            IsExpiredButOtherwiseValid = false;
+            CanGoNext = true;
+            EmitDerivedChanges();
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(LicenseToken))
+        {
+            ValidatedInfo = null;
+            ValidationError = null;
+            IsExpiredButOtherwiseValid = false;
+            CanGoNext = false;
+            EmitDerivedChanges();
+            return;
+        }
+
+        var result = LicenseValidator.ValidateToken(LicenseToken);
+        switch (result)
+        {
+            case LicenseValid v:
+                ValidatedInfo = v.Info;
+                ValidationError = null;
+                IsExpiredButOtherwiseValid = false;
+                CanGoNext = true;
+                break;
+            case LicenseExpired ex:
+                // Abgelaufen aber signaturlich gueltig: User soll das
+                // sehen, aber Continue ist erlaubt — Backend laeuft dann
+                // im Read-Only-Mode. Wir haben aber keine Demo-Verlaengerung
+                // mehr.
+                ValidatedInfo = ex.Info;
+                ValidationError = null;
+                IsExpiredButOtherwiseValid = true;
+                CanGoNext = true;
+                break;
+            case LicenseInvalid inv:
+                ValidatedInfo = null;
+                ValidationError = inv.Reason;
+                IsExpiredButOtherwiseValid = false;
+                CanGoNext = false;
+                break;
+        }
+
+        EmitDerivedChanges();
+    }
+
+    private void EmitDerivedChanges()
+    {
+        OnPropertyChanged(nameof(HasValidatedInfo));
+        OnPropertyChanged(nameof(HasValidationError));
+        OnPropertyChanged(nameof(ExpiryDisplay));
+    }
+}

--- a/installer/setup/src/PraxisZeit.Setup/ViewModels/MainWindowViewModel.cs
+++ b/installer/setup/src/PraxisZeit.Setup/ViewModels/MainWindowViewModel.cs
@@ -26,7 +26,10 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     private readonly ScriptRunner _scriptRunner;
 
     private readonly WelcomePageViewModel _welcome;
-    private readonly ConfigPageViewModel? _config;
+    private readonly InstallLocationPageViewModel _location;
+    private readonly PortsPageViewModel _ports;
+    private readonly LicensePageViewModel _license;
+    private readonly ConfigPageViewModel _config;
     private readonly ProgressPageViewModel _progress;
     private readonly DonePageViewModel _done;
 
@@ -79,26 +82,66 @@ public sealed partial class MainWindowViewModel : ViewModelBase
 
         _done = new DonePageViewModel();
 
-        // ConfigPage nur im Fresh-Install / Repair-Modus — Update behaelt
-        // die existierende praxiszeit.conf (Backend-Bootstrap erkennt den
-        // Admin schon in der DB, neue Werte wuerden im Update-Pfad ignoriert
-        // bzw. wuerden bestehende User-Anpassungen ueberschreiben).
-        _config = mode is InstallMode.FreshInstall or InstallMode.Repair
-            ? new ConfigPageViewModel { AdminEmail = "admin@praxis.local" }
-            : null;
+        _location = new InstallLocationPageViewModel(_updateDetector, targetVersion, installPath, mode);
+        _location.PropertyChanged += OnLocationModeChanged;
 
-        Pages.Add(_welcome);
-        if (_config is not null)
-        {
-            Pages.Add(_config);
-        }
-        Pages.Add(_progress);
-        Pages.Add(_done);
+        _ports = new PortsPageViewModel();
+        _license = new LicensePageViewModel();
+
+        // ConfigPage existiert immer (im Update-Flow wird sie spaeter
+        // uebersprungen — siehe RebuildPagesForMode). Das vermeidet eine
+        // teure Re-Instanziierung wenn der User in der Location-Page
+        // doch noch von Fresh auf Update umschaltet.
+        _config = new ConfigPageViewModel { AdminEmail = "admin@praxis.local" };
+
+        RebuildPagesForMode(mode);
         CurrentPage = _welcome;
         CurrentStepIndex = 0;
         RebuildStepDots();
 
         WindowTitle = $"PraxisZeit Setup {targetVersion}";
+    }
+
+    /// <summary>
+    /// Reagiert auf User-Klick "Auf Update umschalten" in der Location-
+    /// Page (oder beliebigen IntentMode-Wechsel). Die ConfigPage wird
+    /// im Update-Flow uebersprungen, also muss die Page-Liste neu gebaut
+    /// werden. Welcome-Mode-Property fuer den Backup-Hinweis aktualisieren
+    /// wir mit.
+    /// </summary>
+    private void OnLocationModeChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(InstallLocationPageViewModel.IntentMode)) return;
+        var newMode = _location.IntentMode;
+        _welcome.Mode = newMode;
+        _progress.InitializeSteps(newMode);
+        RebuildPagesForMode(newMode);
+        RebuildStepDots();
+        RaiseShellChanged();
+    }
+
+    /// <summary>
+    /// Setzt die <see cref="Pages"/>-Reihenfolge je nach Modus. ConfigPage
+    /// laeuft nur im Fresh-Install / Repair (Update behaelt die existierende
+    /// praxiszeit.conf — neue Werte wuerden bestehende User-Anpassungen
+    /// stillschweigend ueberschreiben).
+    /// </summary>
+    private void RebuildPagesForMode(InstallMode mode)
+    {
+        Pages.Clear();
+        Pages.Add(_welcome);
+        Pages.Add(_location);
+        if (mode is InstallMode.FreshInstall or InstallMode.Repair)
+        {
+            Pages.Add(_ports);
+        }
+        Pages.Add(_license);
+        if (mode is InstallMode.FreshInstall or InstallMode.Repair)
+        {
+            Pages.Add(_config);
+        }
+        Pages.Add(_progress);
+        Pages.Add(_done);
     }
 
     /// <summary>
@@ -190,29 +233,28 @@ public sealed partial class MainWindowViewModel : ViewModelBase
             return;
         }
 
-        // Welcome →  ConfigPage (Fresh/Repair) oder direkt Progress (Update)
-        if (CurrentPage is WelcomePageViewModel)
+        // Done → Close
+        if (CurrentPage is DonePageViewModel)
         {
-            if (_config is not null)
-            {
-                CurrentStepIndex = Pages.IndexOf(_config);
-                CurrentPage = _config;
-                RaiseShellChanged();
-                return;
-            }
-            await TransitionToProgressAndRunAsync().ConfigureAwait(true);
+            CleanupTempPayload();
+            CloseRequested?.Invoke();
             return;
         }
 
-        // ConfigPage → Progress: Installation kicken
-        if (CurrentPage is ConfigPageViewModel)
+        // Naechste Page in der Liste finden
+        var idx = Pages.IndexOf(CurrentPage);
+        var next = idx + 1 < Pages.Count ? Pages[idx + 1] : null;
+
+        // Wenn die naechste Page Progress ist, kicken wir die Installation
+        // — Pages-Liste enthaelt Progress immer als zweitletzten Eintrag.
+        if (next is ProgressPageViewModel)
         {
             await TransitionToProgressAndRunAsync().ConfigureAwait(true);
             return;
         }
 
         // Progress → Done: nur wenn der Runner fertig ist (CanGoNext = true)
-        if (CurrentPage is ProgressPageViewModel progress)
+        if (CurrentPage is ProgressPageViewModel)
         {
             CurrentStepIndex = Pages.IndexOf(_done);
             CurrentPage = _done;
@@ -220,12 +262,14 @@ public sealed partial class MainWindowViewModel : ViewModelBase
             return;
         }
 
-        // Done → Close
-        if (CurrentPage is DonePageViewModel)
+        if (next is null)
         {
-            CleanupTempPayload();
-            CloseRequested?.Invoke();
+            return;
         }
+
+        CurrentStepIndex = Pages.IndexOf(next);
+        CurrentPage = next;
+        RaiseShellChanged();
     }
 
     private async Task TransitionToProgressAndRunAsync()
@@ -269,11 +313,39 @@ public sealed partial class MainWindowViewModel : ViewModelBase
             }
             else
             {
-                success = _welcome.Mode == InstallMode.Update
-                    ? await RunUpdateOnWindowsAsync(_welcome.DetectedInstallPath, _extractedPayloadDir, sink)
-                        .ConfigureAwait(true)
-                    : await RunFreshOnWindowsAsync(_welcome.DetectedInstallPath, _extractedPayloadDir, sink, _config?.ToConfigValues())
+                var installDir = _location.InstallPath;
+                if (_welcome.Mode == InstallMode.Update)
+                {
+                    success = await RunUpdateOnWindowsAsync(installDir, _extractedPayloadDir, sink)
                         .ConfigureAwait(true);
+                    // Update-Pfad: License-Page kann eine NEUE Lizenz
+                    // einspielen (Erneuerung). Wir schreiben nur die Datei,
+                    // praxiszeit.conf bleibt unangetastet.
+                    if (success && _license.SelectedMode == "license"
+                        && !string.IsNullOrWhiteSpace(_license.LicenseToken))
+                    {
+                        var configDir = Path.Combine(installDir, "config");
+                        await PraxisZeitConfigWriter.WriteLicenseFileAsync(configDir, _license.LicenseToken).ConfigureAwait(true);
+                        sink.OnReportFallback(new RunnerLogEvent("Lizenz-Datei aktualisiert."));
+                    }
+                }
+                else
+                {
+                    var configValues = BuildConfigValues();
+                    success = await RunFreshOnWindowsAsync(installDir, _extractedPayloadDir, sink, configValues)
+                        .ConfigureAwait(true);
+                    // Fresh-Install: License-File schreiben falls eine
+                    // echte Lizenz vorliegt. Demo schreibt KEINE license.key
+                    // — der ConfigWriter hat das demo_expires_at-Feld
+                    // bereits in praxiszeit.conf gesetzt.
+                    if (success && _license.SelectedMode == "license"
+                        && !string.IsNullOrWhiteSpace(_license.LicenseToken))
+                    {
+                        var configDir = Path.Combine(installDir, "config");
+                        await PraxisZeitConfigWriter.WriteLicenseFileAsync(configDir, _license.LicenseToken).ConfigureAwait(true);
+                        sink.OnReportFallback(new RunnerLogEvent("Lizenz-Datei eingespielt."));
+                    }
+                }
             }
         }
         catch (Exception ex)
@@ -309,6 +381,24 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     [SupportedOSPlatform("windows")]
     private Task<bool> RunFreshOnWindowsAsync(string installDir, string payloadDir, IProgress<RunnerEvent> sink, PraxisZeitConfigValues? configValues) =>
         _scriptRunner.RunFreshInstallAsync(installDir, payloadDir, sink, configValues);
+
+    /// <summary>
+    /// Merged die Werte aus den drei User-Eingabe-Pages (Ports, Lizenz,
+    /// Config) zu einem ConfigValues-Snapshot, den der ConfigWriter in
+    /// die TOML-Datei serialisiert. Lizenz-File wird separat geschrieben
+    /// (siehe TransitionToProgressAndRunAsync).
+    /// </summary>
+    private PraxisZeitConfigValues BuildConfigValues()
+    {
+        var baseValues = _config.ToConfigValues();
+        return baseValues with
+        {
+            HttpsPort = _ports.HttpsPort,
+            HttpRedirectPort = _ports.EffectiveHttpRedirectPort,
+            LicenseToken = _license.SelectedMode == "license" ? _license.LicenseToken : null,
+            DemoDays = _license.SelectedMode == "demo" ? LicensePageViewModel.DemoDurationDays : null,
+        };
+    }
 
     private void CleanupTempPayload()
     {

--- a/installer/setup/src/PraxisZeit.Setup/ViewModels/PortsPageViewModel.cs
+++ b/installer/setup/src/PraxisZeit.Setup/ViewModels/PortsPageViewModel.cs
@@ -1,0 +1,127 @@
+using System.Net.NetworkInformation;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace PraxisZeit.Setup.ViewModels;
+
+/// <summary>
+/// User waehlt HTTPS-Port (Default 443) und HTTP-Redirect-Port (Default 80).
+/// Auf "Weiter" wird via <see cref="IPGlobalProperties"/> geprueft, ob die
+/// gewaehlten Ports bereits von einem anderen Prozess gebunden sind —
+/// das ist eine Warnung, kein Hard-Block (manche Konflikte sind auf
+/// dem Setup-Server temporaer, z.B. ein anderer nginx der gleich gestoppt
+/// wird).
+/// </summary>
+public sealed partial class PortsPageViewModel : WizardPageBase
+{
+    public override string Key => "ports";
+    public override string Title => "Ports";
+
+    [ObservableProperty]
+    public partial int HttpsPort { get; set; } = 443;
+
+    [ObservableProperty]
+    public partial int HttpRedirectPort { get; set; } = 80;
+
+    /// <summary>
+    /// True = User hat einen HTTP-Redirect-Port gesetzt (>0). Default ja —
+    /// wenn der User ihn auf 0 setzt, wird kein Redirect-Listener gestartet.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool EnableHttpRedirect { get; set; } = true;
+
+    [ObservableProperty]
+    public partial string? ValidationMessage { get; set; }
+
+    [ObservableProperty]
+    public partial string? PortConflictWarning { get; set; }
+
+    public bool HasValidationMessage => !string.IsNullOrEmpty(ValidationMessage);
+    public bool HasPortConflictWarning => !string.IsNullOrEmpty(PortConflictWarning);
+
+    public PortsPageViewModel()
+    {
+        Validate();
+    }
+
+    partial void OnHttpsPortChanged(int value) => Validate();
+    partial void OnHttpRedirectPortChanged(int value) => Validate();
+    partial void OnEnableHttpRedirectChanged(bool value) => Validate();
+
+    /// <summary>
+    /// Effektiver Redirect-Port: 0 wenn der User die Checkbox abgewaehlt
+    /// hat, sonst <see cref="HttpRedirectPort"/>. Wird vom ConfigWriter
+    /// genutzt — 0 unterdrueckt den http_redirect_port-Eintrag.
+    /// </summary>
+    public int EffectiveHttpRedirectPort => EnableHttpRedirect ? HttpRedirectPort : 0;
+
+    private void Validate()
+    {
+        // Range-Check: HTTPS muss 1..65535, HTTP 1..65535 wenn aktiv.
+        if (HttpsPort is < 1 or > 65535)
+        {
+            ValidationMessage = $"HTTPS-Port muss zwischen 1 und 65535 liegen (aktuell: {HttpsPort}).";
+            CanGoNext = false;
+        }
+        else if (EnableHttpRedirect && HttpRedirectPort is < 1 or > 65535)
+        {
+            ValidationMessage = $"HTTP-Redirect-Port muss zwischen 1 und 65535 liegen (aktuell: {HttpRedirectPort}).";
+            CanGoNext = false;
+        }
+        else if (EnableHttpRedirect && HttpRedirectPort == HttpsPort)
+        {
+            ValidationMessage = "HTTPS-Port und HTTP-Redirect-Port duerfen nicht identisch sein.";
+            CanGoNext = false;
+        }
+        else
+        {
+            ValidationMessage = null;
+            CanGoNext = true;
+            CheckPortConflicts();
+        }
+
+        OnPropertyChanged(nameof(HasValidationMessage));
+        OnPropertyChanged(nameof(EffectiveHttpRedirectPort));
+    }
+
+    /// <summary>
+    /// Reine Warnung — blockiert nicht. Nutzt
+    /// <see cref="IPGlobalProperties.GetActiveTcpListeners"/> um zu sehen,
+    /// ob auf einem der Ports schon jemand lauscht. Wir wollen das hier
+    /// nicht hard-blocken, weil:
+    /// - der existierende Listener kann ein zu beendender alter Service sein
+    /// - die User-Maschine kann gerade unter Load sein und eine andere Bindung
+    ///   haben die nach dem Reboot weg ist
+    /// </summary>
+    private void CheckPortConflicts()
+    {
+        try
+        {
+            var listeners = IPGlobalProperties.GetIPGlobalProperties()
+                .GetActiveTcpListeners();
+            var bound = listeners.Select(l => l.Port).ToHashSet();
+
+            var conflicts = new List<string>();
+            if (bound.Contains(HttpsPort))
+            {
+                conflicts.Add($"HTTPS-Port {HttpsPort}");
+            }
+            if (EnableHttpRedirect && bound.Contains(HttpRedirectPort))
+            {
+                conflicts.Add($"HTTP-Redirect-Port {HttpRedirectPort}");
+            }
+
+            PortConflictWarning = conflicts.Count == 0
+                ? null
+                : $"Achtung: {string.Join(" und ", conflicts)} ist bereits belegt. "
+                  + "Beim Service-Start kann es zu Bind-Fehlern kommen — pruefen Sie laufende "
+                  + "Webserver (IIS, nginx, Apache) oder waehlen Sie andere Ports.";
+        }
+        catch
+        {
+            // Privilege-Problem (z.B. ohne Admin) oder Plattform-Spezifisches.
+            // Kein Hard-Fail — Port-Check ist Komfort.
+            PortConflictWarning = null;
+        }
+        OnPropertyChanged(nameof(HasPortConflictWarning));
+    }
+}

--- a/installer/setup/src/PraxisZeit.Setup/ViewModels/ProgressPageViewModel.cs
+++ b/installer/setup/src/PraxisZeit.Setup/ViewModels/ProgressPageViewModel.cs
@@ -18,7 +18,15 @@ public sealed partial class ProgressPageViewModel : WizardPageBase
     public override string Key => "progress";
     public override string Title => "Installation";
     public override bool CanGoBack => false;
-    public override string NextButtonText => "Bitte warten...";
+
+    /// <summary>
+    /// Live-state-aware: solange der Runner laeuft "Bitte warten...",
+    /// danach "Weiter". Wird via OnIsRunningChanged neu emittiert, damit
+    /// der Footer-Button sich beim Ende der Installation aktualisiert
+    /// (frueher blieb "Bitte warten..." dauerhaft stehen, obwohl
+    /// CanGoNext schon true war).
+    /// </summary>
+    public override string NextButtonText => IsRunning ? "Bitte warten..." : "Weiter";
 
     public ObservableCollection<StepItem> Steps { get; } = [];
 
@@ -30,6 +38,11 @@ public sealed partial class ProgressPageViewModel : WizardPageBase
 
     [ObservableProperty]
     public partial bool IsRunning { get; set; } = true;
+
+    partial void OnIsRunningChanged(bool value)
+    {
+        OnPropertyChanged(nameof(NextButtonText));
+    }
 
     [ObservableProperty]
     public partial string Headline { get; set; } = "Installation laeuft";
@@ -90,13 +103,12 @@ public sealed partial class ProgressPageViewModel : WizardPageBase
                 Percent = prog.Percent;
                 break;
             case RunnerDoneEvent done:
-                IsRunning = false;
+                IsRunning = false; // OnIsRunningChanged emittiert NextButtonText
                 CanGoNext = true;
                 Headline = done.Success ? "Installation abgeschlossen" : "Installation mit Fehlern beendet";
                 SubHeadline = done.Success
                     ? "Alle Schritte erfolgreich. Klicken Sie auf 'Weiter' fuer den letzten Schritt."
                     : "Bitte pruefen Sie das Protokoll. Ein Backup der Datenbank liegt unter data\\backups.";
-                OnPropertyChanged(nameof(NextButtonText));
                 break;
         }
     }

--- a/installer/setup/src/PraxisZeit.Setup/ViewModels/StepStatusConverters.cs
+++ b/installer/setup/src/PraxisZeit.Setup/ViewModels/StepStatusConverters.cs
@@ -64,3 +64,64 @@ public sealed class StepStatusToTitleBrushConverter : IValueConverter
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();
 }
+
+/// <summary>
+/// Sammel-Helper fuer XAML-Bindings die einen statischen Konverter brauchen.
+/// Avalonia kann keine generischen IValueConverter-Instanzen ueber XAML
+/// referenzieren, deswegen die Singleton-Instances als
+/// <c>{x:Static StepStatusConverters.NameOfConverter}</c>.
+/// </summary>
+public static class StepStatusConverters
+{
+    /// <summary>
+    /// TwoWay-faehiger String-Equality-Konverter fuer RadioButtons:
+    /// IsChecked = true wenn Bound-String == ConverterParameter, und
+    /// gibt bei IsChecked->true den Parameter als String zurueck.
+    /// </summary>
+    public static readonly IValueConverter StringEqualityConverter = new StringEqualityConverterImpl();
+
+    /// <summary>
+    /// Mappt null/leer auf false, sonst auf true — fuer IsVisible-Bindings.
+    /// </summary>
+    public static readonly IValueConverter NotNullVisibilityConverter = new NotNullVisibilityConverterImpl();
+
+    private sealed class StringEqualityConverterImpl : IValueConverter
+    {
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            var s = value as string;
+            var p = parameter as string;
+            return string.Equals(s, p, StringComparison.Ordinal);
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            // RadioButton-Click: IsChecked wird true → wir muessen den
+            // ConverterParameter als neuen String ans Source-ViewModel
+            // zurueckgeben. Wenn IsChecked auf false geht (anderer Button
+            // wird aktiv), ignorieren wir das — der andere Convert-Aufruf
+            // setzt den korrekten Wert.
+            if (value is true && parameter is string p)
+            {
+                return p;
+            }
+            return Avalonia.Data.BindingOperations.DoNothing;
+        }
+    }
+
+    private sealed class NotNullVisibilityConverterImpl : IValueConverter
+    {
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            return value switch
+            {
+                null => false,
+                string s => !string.IsNullOrEmpty(s),
+                _ => true,
+            };
+        }
+
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+            throw new NotSupportedException();
+    }
+}

--- a/installer/setup/src/PraxisZeit.Setup/Views/DonePageView.axaml
+++ b/installer/setup/src/PraxisZeit.Setup/Views/DonePageView.axaml
@@ -7,6 +7,7 @@
              x:Class="PraxisZeit.Setup.Views.DonePageView"
              x:DataType="vm:DonePageViewModel">
 
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled">
     <StackPanel Margin="40" Spacing="24" VerticalAlignment="Center">
 
         <!-- Erfolgs-Checkmark (success) ODER X-Kreis (fail) -->
@@ -87,5 +88,6 @@
         </Border>
 
     </StackPanel>
+    </ScrollViewer>
 
 </UserControl>

--- a/installer/setup/src/PraxisZeit.Setup/Views/InstallLocationPageView.axaml
+++ b/installer/setup/src/PraxisZeit.Setup/Views/InstallLocationPageView.axaml
@@ -1,0 +1,139 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:PraxisZeit.Setup.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="500"
+             x:Class="PraxisZeit.Setup.Views.InstallLocationPageView"
+             x:DataType="vm:InstallLocationPageViewModel">
+
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled" Padding="0,0,4,0">
+        <StackPanel Margin="40,28,40,28" Spacing="20">
+
+            <!-- Header -->
+            <StackPanel Spacing="6">
+                <TextBlock Text="Installationsort"
+                           FontSize="14"
+                           FontWeight="Medium"
+                           Foreground="{StaticResource BrandPrimaryBrush}"
+                           LetterSpacing="0.6"/>
+                <TextBlock Text="Wohin soll PraxisZeit installiert werden?"
+                           FontSize="22"
+                           FontWeight="SemiBold"
+                           Foreground="{StaticResource TextPrimaryBrush}"/>
+                <TextBlock Text="Standard ist C:\PraxisZeit. Bei einem Update muss der Pfad mit der bestehenden Installation uebereinstimmen — wir haben ihn vorausgefuellt."
+                           FontSize="13"
+                           LineHeight="20"
+                           TextWrapping="Wrap"
+                           Foreground="{StaticResource TextSecondaryBrush}"/>
+            </StackPanel>
+
+            <!-- Pfad-Eingabe -->
+            <Border Classes="card">
+                <StackPanel Spacing="10">
+                    <TextBlock Text="Zielverzeichnis" FontSize="11" FontWeight="Medium"
+                               LetterSpacing="0.4"
+                               Foreground="{StaticResource TextMutedBrush}"/>
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                        <TextBox Grid.Column="0"
+                                 Text="{Binding InstallPath, Mode=TwoWay}"
+                                 IsReadOnly="{Binding IsPathReadOnly}"
+                                 PlaceholderText="C:\PraxisZeit"
+                                 FontFamily="Consolas,Menlo,monospace"
+                                 FontSize="13"/>
+                        <Button Grid.Column="1"
+                                Classes="ghost"
+                                Content="Durchsuchen…"
+                                MinWidth="130"
+                                Height="38"
+                                IsEnabled="{Binding !IsPathReadOnly}"
+                                Click="OnBrowseClicked"/>
+                    </Grid>
+                    <TextBlock Text="Update-Modus: der Pfad ist gesperrt, ein Update muss in das existierende Verzeichnis laufen."
+                               FontSize="11"
+                               Foreground="{StaticResource TextMutedBrush}"
+                               TextWrapping="Wrap"
+                               IsVisible="{Binding IsPathReadOnly}"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Konflikt-Warnung: Fresh-Install in existierenden Pfad -->
+            <Border IsVisible="{Binding IsConflict}"
+                    Background="#0FDC2626"
+                    BorderBrush="#33DC2626"
+                    BorderThickness="1"
+                    CornerRadius="10"
+                    Padding="20,16">
+                <StackPanel Spacing="12">
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <Border Width="32" Height="32"
+                                CornerRadius="16"
+                                Background="#DC2626"
+                                VerticalAlignment="Top">
+                            <TextBlock Text="!"
+                                       FontSize="16"
+                                       FontWeight="Bold"
+                                       Foreground="White"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"/>
+                        </Border>
+                        <StackPanel Spacing="4" VerticalAlignment="Top">
+                            <TextBlock Text="{Binding ConflictHeadline}"
+                                       FontSize="14"
+                                       FontWeight="SemiBold"
+                                       Foreground="#7F1D1D"
+                                       TextWrapping="Wrap"/>
+                            <TextBlock Text="{Binding ConflictDescription}"
+                                       FontSize="12"
+                                       LineHeight="18"
+                                       Foreground="#991B1B"
+                                       TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="10" Margin="44,0,0,0">
+                        <Button Classes="primary"
+                                Content="Auf Update umschalten"
+                                MinWidth="220"
+                                Height="34"
+                                IsVisible="{Binding CanSwitchToUpdate}"
+                                Command="{Binding SwitchToUpdateCommand}"/>
+                        <TextBlock Text="oder waehlen Sie ein anderes Verzeichnis."
+                                   VerticalAlignment="Center"
+                                   FontSize="12"
+                                   Foreground="{StaticResource TextSecondaryBrush}"/>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- Generelle Validierung (z.B. Update auf leerem Pfad) -->
+            <Border IsVisible="{Binding HasValidationMessage}"
+                    Background="#0FDC2626"
+                    BorderBrush="#33DC2626"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Padding="14,10">
+                <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                    <Border Width="22" Height="22"
+                            CornerRadius="11"
+                            Background="#DC2626"
+                            VerticalAlignment="Center">
+                        <TextBlock Text="!"
+                                   FontSize="12"
+                                   FontWeight="Bold"
+                                   Foreground="White"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"/>
+                    </Border>
+                    <TextBlock Text="{Binding ValidationMessage}"
+                               TextWrapping="Wrap"
+                               FontSize="12"
+                               LineHeight="18"
+                               Foreground="#7F1D1D"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+            </Border>
+
+        </StackPanel>
+    </ScrollViewer>
+
+</UserControl>

--- a/installer/setup/src/PraxisZeit.Setup/Views/InstallLocationPageView.axaml.cs
+++ b/installer/setup/src/PraxisZeit.Setup/Views/InstallLocationPageView.axaml.cs
@@ -1,0 +1,49 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
+using PraxisZeit.Setup.ViewModels;
+
+namespace PraxisZeit.Setup.Views;
+
+public partial class InstallLocationPageView : UserControl
+{
+    public InstallLocationPageView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    /// <summary>
+    /// Avalonia-Folder-Picker. Storage-API gibt es ab Avalonia 11 — wir
+    /// muessen das aktuelle TopLevel haben um den Picker auf dem richtigen
+    /// Window zu rendern. Bei Erfolg ueberschreibt der Picker den
+    /// InstallPath im ViewModel.
+    /// </summary>
+    private async void OnBrowseClicked(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is not InstallLocationPageViewModel vm) return;
+        var top = TopLevel.GetTopLevel(this);
+        if (top is null) return;
+
+        var startFolder = !string.IsNullOrWhiteSpace(vm.InstallPath)
+            ? await top.StorageProvider.TryGetFolderFromPathAsync(vm.InstallPath)
+            : null;
+
+        var folders = await top.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Zielverzeichnis fuer PraxisZeit waehlen",
+            AllowMultiple = false,
+            SuggestedStartLocation = startFolder,
+        });
+
+        if (folders.Count > 0 && folders[0].TryGetLocalPath() is { } localPath)
+        {
+            vm.InstallPath = localPath;
+        }
+    }
+}

--- a/installer/setup/src/PraxisZeit.Setup/Views/LicensePageView.axaml
+++ b/installer/setup/src/PraxisZeit.Setup/Views/LicensePageView.axaml
@@ -1,0 +1,216 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:PraxisZeit.Setup.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="500"
+             x:Class="PraxisZeit.Setup.Views.LicensePageView"
+             x:DataType="vm:LicensePageViewModel">
+
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled" Padding="0,0,4,0">
+        <StackPanel Margin="40,28,40,28" Spacing="20">
+
+            <!-- Header -->
+            <StackPanel Spacing="6">
+                <TextBlock Text="Lizenz"
+                           FontSize="14"
+                           FontWeight="Medium"
+                           Foreground="{StaticResource BrandPrimaryBrush}"
+                           LetterSpacing="0.6"/>
+                <TextBlock Text="Lizenz-Schluessel oder 30-Tage-Demo"
+                           FontSize="22"
+                           FontWeight="SemiBold"
+                           Foreground="{StaticResource TextPrimaryBrush}"/>
+                <TextBlock Text="PraxisZeit prueft die Lizenz beim Service-Start. Geben Sie Ihren Schluessel ein oder starten Sie eine 30-Tage-Demo."
+                           FontSize="13"
+                           LineHeight="20"
+                           TextWrapping="Wrap"
+                           Foreground="{StaticResource TextSecondaryBrush}"/>
+            </StackPanel>
+
+            <!-- Modus-Auswahl -->
+            <StackPanel Orientation="Horizontal" Spacing="10">
+                <RadioButton Content="Lizenz-Schluessel eingeben"
+                             GroupName="LicenseMode"
+                             IsChecked="{Binding SelectedMode, Mode=TwoWay,
+                                         Converter={x:Static vm:StepStatusConverters.StringEqualityConverter},
+                                         ConverterParameter=license}"/>
+                <RadioButton Content="30 Tage Demo (ohne Lizenz)"
+                             GroupName="LicenseMode"
+                             IsChecked="{Binding SelectedMode, Mode=TwoWay,
+                                         Converter={x:Static vm:StepStatusConverters.StringEqualityConverter},
+                                         ConverterParameter=demo}"/>
+            </StackPanel>
+
+            <!-- Lizenz-Eingabe (nur sichtbar wenn Modus = license) -->
+            <Border Classes="card"
+                    IsVisible="{Binding SelectedMode,
+                                Converter={x:Static vm:StepStatusConverters.StringEqualityConverter},
+                                ConverterParameter=license}">
+                <StackPanel Spacing="14">
+                    <TextBlock Text="Lizenz-Token"
+                               FontSize="11"
+                               FontWeight="Medium"
+                               LetterSpacing="0.4"
+                               Foreground="{StaticResource TextMutedBrush}"/>
+                    <TextBox Text="{Binding LicenseToken, Mode=TwoWay}"
+                             AcceptsReturn="True"
+                             TextWrapping="Wrap"
+                             MinHeight="120"
+                             FontFamily="Consolas,Menlo,monospace"
+                             FontSize="11"
+                             PlaceholderText="eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9...."/>
+                    <StackPanel Orientation="Horizontal" Spacing="10">
+                        <Button Classes="ghost"
+                                Content="Datei waehlen…"
+                                MinWidth="160"
+                                Height="34"
+                                Click="OnLoadLicenseFileClicked"/>
+                        <TextBlock Text="{Binding LoadedFromPath, StringFormat='geladen aus: {0}'}"
+                                   IsVisible="{Binding LoadedFromPath, Converter={x:Static vm:StepStatusConverters.NotNullVisibilityConverter}}"
+                                   VerticalAlignment="Center"
+                                   FontSize="11"
+                                   FontFamily="Consolas,Menlo,monospace"
+                                   Foreground="{StaticResource TextMutedBrush}"
+                                   TextTrimming="CharacterEllipsis"/>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- Lizenz-Validierung-Erfolg -->
+            <Border Classes="card"
+                    IsVisible="{Binding HasValidatedInfo}"
+                    Background="#0A13B981"
+                    BorderBrush="#3313B981">
+                <StackPanel Spacing="12">
+                    <StackPanel Orientation="Horizontal" Spacing="10">
+                        <Border Width="22" Height="22"
+                                CornerRadius="11"
+                                Background="{StaticResource BrandAccentDarkBrush}"
+                                VerticalAlignment="Center">
+                            <Path Data="M 6 12 L 10 16 L 16 8"
+                                  Stroke="White"
+                                  StrokeThickness="2"
+                                  StrokeJoin="Round"
+                                  StrokeLineCap="Round"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"/>
+                        </Border>
+                        <TextBlock Text="Lizenz erkannt"
+                                   FontSize="13"
+                                   FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextPrimaryBrush}"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                    <Grid ColumnDefinitions="160,*" RowDefinitions="Auto,Auto,Auto" RowSpacing="6">
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Kunde"
+                                   FontSize="11" Foreground="{StaticResource TextMutedBrush}"/>
+                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding ValidatedInfo.CustomerName}"
+                                   FontSize="13" FontWeight="Medium"
+                                   Foreground="{StaticResource TextPrimaryBrush}"/>
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Mitarbeiter-Limit"
+                                   FontSize="11" Foreground="{StaticResource TextMutedBrush}"/>
+                        <TextBlock Grid.Row="1" Grid.Column="1"
+                                   Text="{Binding ValidatedInfo.MaxEmployees, StringFormat='{}{0} Mitarbeiter'}"
+                                   FontSize="13"
+                                   Foreground="{StaticResource TextPrimaryBrush}"/>
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Gueltigkeit"
+                                   FontSize="11" Foreground="{StaticResource TextMutedBrush}"/>
+                        <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding ExpiryDisplay}"
+                                   FontSize="13"
+                                   Foreground="{StaticResource TextPrimaryBrush}"/>
+                    </Grid>
+
+                    <!-- Hinweis bei abgelaufener Lizenz -->
+                    <Border IsVisible="{Binding IsExpiredButOtherwiseValid}"
+                            Background="#0FF59E0B"
+                            BorderBrush="#33F59E0B"
+                            BorderThickness="1"
+                            CornerRadius="6"
+                            Padding="12,8">
+                        <TextBlock Text="Diese Lizenz ist abgelaufen. Der Service startet im Nur-Lese-Modus — Daten bleiben einsehbar und exportierbar, aber neue Eintraege koennen nicht angelegt werden."
+                                   FontSize="11"
+                                   LineHeight="16"
+                                   TextWrapping="Wrap"
+                                   Foreground="#92400E"/>
+                    </Border>
+                </StackPanel>
+            </Border>
+
+            <!-- Validierungs-Fehler -->
+            <Border IsVisible="{Binding HasValidationError}"
+                    Background="#0FDC2626"
+                    BorderBrush="#33DC2626"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Padding="14,10">
+                <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                    <Border Width="22" Height="22"
+                            CornerRadius="11"
+                            Background="#DC2626"
+                            VerticalAlignment="Center">
+                        <TextBlock Text="!"
+                                   FontSize="12"
+                                   FontWeight="Bold"
+                                   Foreground="White"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"/>
+                    </Border>
+                    <TextBlock Text="{Binding ValidationError}"
+                               TextWrapping="Wrap"
+                               FontSize="12"
+                               LineHeight="18"
+                               Foreground="#7F1D1D"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Demo-Karte -->
+            <Border Classes="card"
+                    IsVisible="{Binding SelectedMode,
+                                Converter={x:Static vm:StepStatusConverters.StringEqualityConverter},
+                                ConverterParameter=demo}">
+                <StackPanel Spacing="10">
+                    <TextBlock Text="Demo-Modus"
+                               FontSize="11"
+                               FontWeight="Medium"
+                               LetterSpacing="0.4"
+                               Foreground="{StaticResource TextMutedBrush}"/>
+                    <TextBlock Text="{Binding DemoEndDisplay, StringFormat='Volle Funktionalitaet bis zum {0}.'}"
+                               FontSize="14"
+                               FontWeight="Medium"
+                               Foreground="{StaticResource TextPrimaryBrush}"/>
+                    <TextBlock Text="Nach Ablauf der 30 Tage wechselt PraxisZeit in den Nur-Lese-Modus, bis Sie eine Lizenz einspielen. Daten bleiben jederzeit einsehbar und exportierbar."
+                               FontSize="12"
+                               LineHeight="18"
+                               TextWrapping="Wrap"
+                               Foreground="{StaticResource TextSecondaryBrush}"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Bezugsquelle -->
+            <Border BorderBrush="{StaticResource BorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Padding="14,12">
+                <StackPanel Spacing="2">
+                    <TextBlock Text="Lizenz erwerben oder erneuern"
+                               FontSize="11"
+                               FontWeight="Medium"
+                               LetterSpacing="0.4"
+                               Foreground="{StaticResource TextMutedBrush}"/>
+                    <TextBlock FontSize="13" TextWrapping="Wrap"
+                               Foreground="{StaticResource TextSecondaryBrush}">
+                        Schreiben Sie an
+                        <Run FontFamily="Consolas,Menlo,monospace"
+                             Foreground="{StaticResource BrandPrimaryBrush}"
+                             Text="projekt@phash.de"/>
+                        — Sie bekommen eine signierte license.key zurueck, die Sie hier oben einspielen.
+                    </TextBlock>
+                </StackPanel>
+            </Border>
+
+        </StackPanel>
+    </ScrollViewer>
+
+</UserControl>

--- a/installer/setup/src/PraxisZeit.Setup/Views/LicensePageView.axaml.cs
+++ b/installer/setup/src/PraxisZeit.Setup/Views/LicensePageView.axaml.cs
@@ -1,0 +1,57 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
+using PraxisZeit.Setup.ViewModels;
+
+namespace PraxisZeit.Setup.Views;
+
+public partial class LicensePageView : UserControl
+{
+    public LicensePageView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    /// <summary>
+    /// File-Picker fuer license.key (oder beliebige Text-Datei mit dem
+    /// JWT). Liest den Inhalt direkt ein und schreibt ihn ins ViewModel —
+    /// von dort triggert es die Live-Validierung.
+    /// </summary>
+    private async void OnLoadLicenseFileClicked(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is not LicensePageViewModel vm) return;
+        var top = TopLevel.GetTopLevel(this);
+        if (top is null) return;
+
+        var files = await top.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Lizenz-Datei waehlen",
+            AllowMultiple = false,
+            FileTypeFilter =
+            [
+                new FilePickerFileType("Lizenz-Datei (*.key)") { Patterns = ["*.key"] },
+                new FilePickerFileType("Alle Dateien")          { Patterns = ["*"] },
+            ],
+        });
+
+        if (files.Count == 0) return;
+        var file = files[0];
+        try
+        {
+            await using var stream = await file.OpenReadAsync();
+            using var reader = new StreamReader(stream);
+            var text = await reader.ReadToEndAsync();
+            vm.LoadFromFile(file.TryGetLocalPath() ?? file.Name, text);
+        }
+        catch (Exception ex)
+        {
+            vm.LicenseToken = string.Empty;
+            vm.LoadedFromPath = $"FEHLER: {ex.Message}";
+        }
+    }
+}

--- a/installer/setup/src/PraxisZeit.Setup/Views/MainWindow.axaml
+++ b/installer/setup/src/PraxisZeit.Setup/Views/MainWindow.axaml
@@ -79,6 +79,15 @@
                 <DataTemplate DataType="vm:WelcomePageViewModel">
                     <views:WelcomePageView/>
                 </DataTemplate>
+                <DataTemplate DataType="vm:InstallLocationPageViewModel">
+                    <views:InstallLocationPageView/>
+                </DataTemplate>
+                <DataTemplate DataType="vm:PortsPageViewModel">
+                    <views:PortsPageView/>
+                </DataTemplate>
+                <DataTemplate DataType="vm:LicensePageViewModel">
+                    <views:LicensePageView/>
+                </DataTemplate>
                 <DataTemplate DataType="vm:ConfigPageViewModel">
                     <views:ConfigPageView/>
                 </DataTemplate>

--- a/installer/setup/src/PraxisZeit.Setup/Views/MainWindow.axaml
+++ b/installer/setup/src/PraxisZeit.Setup/Views/MainWindow.axaml
@@ -8,8 +8,8 @@
         x:Class="PraxisZeit.Setup.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Title="{Binding WindowTitle}"
-        Width="820" Height="640"
-        MinWidth="760" MinHeight="600"
+        Width="900" Height="720"
+        MinWidth="780" MinHeight="620"
         Background="{StaticResource SurfaceAltBrush}"
         WindowStartupLocation="CenterScreen">
 

--- a/installer/setup/src/PraxisZeit.Setup/Views/PortsPageView.axaml
+++ b/installer/setup/src/PraxisZeit.Setup/Views/PortsPageView.axaml
@@ -1,0 +1,147 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:PraxisZeit.Setup.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="500"
+             x:Class="PraxisZeit.Setup.Views.PortsPageView"
+             x:DataType="vm:PortsPageViewModel">
+
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled" Padding="0,0,4,0">
+        <StackPanel Margin="40,28,40,28" Spacing="20">
+
+            <!-- Header -->
+            <StackPanel Spacing="6">
+                <TextBlock Text="Netzwerk-Ports"
+                           FontSize="14"
+                           FontWeight="Medium"
+                           Foreground="{StaticResource BrandPrimaryBrush}"
+                           LetterSpacing="0.6"/>
+                <TextBlock Text="Auf welchen Ports soll PraxisZeit lauschen?"
+                           FontSize="22"
+                           FontWeight="SemiBold"
+                           Foreground="{StaticResource TextPrimaryBrush}"/>
+                <TextBlock Text="Standard ist 443 (HTTPS) plus optional 80 fuer einen Redirect von http:// auf https://. Aendern Sie die Werte nur, wenn andere Dienste die Ports schon belegen."
+                           FontSize="13"
+                           LineHeight="20"
+                           TextWrapping="Wrap"
+                           Foreground="{StaticResource TextSecondaryBrush}"/>
+            </StackPanel>
+
+            <!-- HTTPS-Port -->
+            <Border Classes="card">
+                <StackPanel Spacing="10">
+                    <TextBlock Text="HTTPS-Port"
+                               FontSize="11"
+                               FontWeight="Medium"
+                               LetterSpacing="0.4"
+                               Foreground="{StaticResource TextMutedBrush}"/>
+                    <Grid ColumnDefinitions="200,*" ColumnSpacing="14">
+                        <NumericUpDown Grid.Column="0"
+                                       Value="{Binding HttpsPort, Mode=TwoWay}"
+                                       Minimum="1" Maximum="65535"
+                                       Increment="1"
+                                       FormatString="0"/>
+                        <TextBlock Grid.Column="1"
+                                   Text="Hauptport — die Anwendung wird unter https://&lt;Hostname&gt;:&lt;Port&gt;/ erreichbar sein."
+                                   VerticalAlignment="Center"
+                                   FontSize="12"
+                                   Foreground="{StaticResource TextSecondaryBrush}"
+                                   TextWrapping="Wrap"/>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <!-- HTTP-Redirect -->
+            <Border Classes="card">
+                <StackPanel Spacing="10">
+                    <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock Grid.Column="0"
+                                   Text="HTTP-Redirect-Port"
+                                   FontSize="11"
+                                   FontWeight="Medium"
+                                   LetterSpacing="0.4"
+                                   VerticalAlignment="Center"
+                                   Foreground="{StaticResource TextMutedBrush}"/>
+                        <CheckBox Grid.Column="1"
+                                  IsChecked="{Binding EnableHttpRedirect, Mode=TwoWay}"
+                                  Content="aktiv"
+                                  FontSize="12"/>
+                    </Grid>
+                    <Grid ColumnDefinitions="200,*" ColumnSpacing="14">
+                        <NumericUpDown Grid.Column="0"
+                                       Value="{Binding HttpRedirectPort, Mode=TwoWay}"
+                                       Minimum="1" Maximum="65535"
+                                       Increment="1"
+                                       FormatString="0"
+                                       IsEnabled="{Binding EnableHttpRedirect}"/>
+                        <TextBlock Grid.Column="1"
+                                   Text="Ein zweiter Listener auf diesem Port liefert nur 301-Redirects auf den HTTPS-Port. Auf 0 oder ausgeschaltet = kein Redirect."
+                                   VerticalAlignment="Center"
+                                   FontSize="12"
+                                   Foreground="{StaticResource TextSecondaryBrush}"
+                                   TextWrapping="Wrap"/>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <!-- Port-Konflikt-Warnung -->
+            <Border IsVisible="{Binding HasPortConflictWarning}"
+                    Background="#0FF59E0B"
+                    BorderBrush="#33F59E0B"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Padding="14,10">
+                <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                    <Border Width="22" Height="22"
+                            CornerRadius="11"
+                            Background="{StaticResource BrandWarnBrush}"
+                            VerticalAlignment="Center">
+                        <TextBlock Text="!"
+                                   FontSize="12"
+                                   FontWeight="Bold"
+                                   Foreground="White"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"/>
+                    </Border>
+                    <TextBlock Text="{Binding PortConflictWarning}"
+                               TextWrapping="Wrap"
+                               FontSize="12"
+                               LineHeight="18"
+                               Foreground="#92400E"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Validierung -->
+            <Border IsVisible="{Binding HasValidationMessage}"
+                    Background="#0FDC2626"
+                    BorderBrush="#33DC2626"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Padding="14,10">
+                <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                    <Border Width="22" Height="22"
+                            CornerRadius="11"
+                            Background="#DC2626"
+                            VerticalAlignment="Center">
+                        <TextBlock Text="!"
+                                   FontSize="12"
+                                   FontWeight="Bold"
+                                   Foreground="White"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"/>
+                    </Border>
+                    <TextBlock Text="{Binding ValidationMessage}"
+                               TextWrapping="Wrap"
+                               FontSize="12"
+                               LineHeight="18"
+                               Foreground="#7F1D1D"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+            </Border>
+
+        </StackPanel>
+    </ScrollViewer>
+
+</UserControl>

--- a/installer/setup/src/PraxisZeit.Setup/Views/PortsPageView.axaml.cs
+++ b/installer/setup/src/PraxisZeit.Setup/Views/PortsPageView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace PraxisZeit.Setup.Views;
+
+public partial class PortsPageView : UserControl
+{
+    public PortsPageView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/installer/setup/tests/PraxisZeit.Setup.Core.Tests/Services/LicenseValidatorTests.cs
+++ b/installer/setup/tests/PraxisZeit.Setup.Core.Tests/Services/LicenseValidatorTests.cs
@@ -1,0 +1,150 @@
+using System.Text;
+using FluentAssertions;
+using PraxisZeit.Setup.Core.Services;
+
+namespace PraxisZeit.Setup.Core.Tests.Services;
+
+/// <summary>
+/// Negative-path-Tests fuer den Lizenz-Validator. Positive-path-Tests
+/// (echte Lizenz, signaturlich gueltig) brauchen den Production-
+/// Private-Key, den der Wizard nicht hat — die werden im Backend
+/// (test_native_mode.py) gegen die identische Schluesselbasis gefahren.
+/// </summary>
+public sealed class LicenseValidatorTests
+{
+    [Fact]
+    public void ValidateToken_rejects_empty_string()
+    {
+        var result = LicenseValidator.ValidateToken("");
+        result.Should().BeOfType<LicenseInvalid>()
+            .Which.Reason.Should().Contain("leer");
+    }
+
+    [Fact]
+    public void ValidateToken_rejects_whitespace_only()
+    {
+        LicenseValidator.ValidateToken("   ").Should().BeOfType<LicenseInvalid>();
+    }
+
+    [Theory]
+    [InlineData("nopart")]
+    [InlineData("two.parts")]
+    [InlineData("four.dots.in.token")]
+    public void ValidateToken_rejects_wrong_segment_count(string input)
+    {
+        var result = LicenseValidator.ValidateToken(input);
+        result.Should().BeOfType<LicenseInvalid>()
+            .Which.Reason.Should().Contain("JWT");
+    }
+
+    [Fact]
+    public void ValidateToken_rejects_invalid_base64url()
+    {
+        // '!' ist kein gueltiges base64url-Zeichen
+        var result = LicenseValidator.ValidateToken("aGVhZA.!!!.c2ln");
+        result.Should().BeOfType<LicenseInvalid>();
+    }
+
+    [Fact]
+    public void ValidateToken_rejects_non_eddsa_algorithm()
+    {
+        // HS256 in Header → Validator soll ablehnen, weil Backend nur EdDSA signiert
+        var header = Base64Url("{\"alg\":\"HS256\",\"typ\":\"JWT\"}");
+        var payload = Base64Url("{\"sub\":\"x\",\"name\":\"y\",\"max_employees\":1,\"iat\":1}");
+        var sig = Base64UrlBytes(new byte[] { 1, 2, 3 });
+        var token = $"{header}.{payload}.{sig}";
+
+        var result = LicenseValidator.ValidateToken(token);
+        result.Should().BeOfType<LicenseInvalid>()
+            .Which.Reason.Should().Contain("EdDSA");
+    }
+
+    [Fact]
+    public void ValidateToken_rejects_non_json_header()
+    {
+        // header decodiert sich, ist aber kein JSON
+        var header = Base64Url("not-json");
+        var payload = Base64Url("{}");
+        var sig = Base64UrlBytes(new byte[] { 1, 2, 3 });
+        var token = $"{header}.{payload}.{sig}";
+
+        var result = LicenseValidator.ValidateToken(token);
+        result.Should().BeOfType<LicenseInvalid>();
+    }
+
+    [Fact]
+    public void ValidateToken_rejects_random_signature_with_correct_alg()
+    {
+        // Gueltiger EdDSA-Header, plausibler Payload, aber Random-Signatur:
+        // muss als "Signatur ungueltig" abgelehnt werden.
+        var header = Base64Url("{\"alg\":\"EdDSA\",\"typ\":\"JWT\"}");
+        var payload = Base64Url(
+            "{\"sub\":\"test\",\"name\":\"Test\",\"max_employees\":10,\"iat\":1700000000}");
+        // 64 Bytes Random — Ed25519-Signatur ist immer 64 Bytes
+        var sig = Base64UrlBytes(Enumerable.Range(0, 64).Select(i => (byte)i).ToArray());
+        var token = $"{header}.{payload}.{sig}";
+
+        var result = LicenseValidator.ValidateToken(token);
+        result.Should().BeOfType<LicenseInvalid>()
+            .Which.Reason.Should().Contain("Signatur");
+    }
+
+    [Fact]
+    public void ValidateFile_returns_invalid_for_missing_file()
+    {
+        var fakePath = Path.Combine(Path.GetTempPath(), $"nonexistent-{Guid.NewGuid():N}.key");
+        var result = LicenseValidator.ValidateFile(fakePath);
+        result.Should().BeOfType<LicenseInvalid>()
+            .Which.Reason.Should().Contain("nicht gefunden");
+    }
+
+    [Fact]
+    public void LicenseInfo_IsExpired_true_for_past_exp()
+    {
+        var info = new LicenseInfo
+        {
+            CustomerId = "x",
+            CustomerName = "y",
+            MaxEmployees = 1,
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(-1),
+        };
+        info.IsExpired.Should().BeTrue();
+        info.DaysUntilExpiry.Should().Be(0);
+    }
+
+    [Fact]
+    public void LicenseInfo_IsExpired_false_for_future_exp()
+    {
+        var info = new LicenseInfo
+        {
+            CustomerId = "x",
+            CustomerName = "y",
+            MaxEmployees = 1,
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(60),
+        };
+        info.IsExpired.Should().BeFalse();
+        info.DaysUntilExpiry.Should().BeGreaterThan(58).And.BeLessThan(61);
+    }
+
+    [Fact]
+    public void LicenseInfo_DaysUntilExpiry_null_when_no_exp()
+    {
+        var info = new LicenseInfo
+        {
+            CustomerId = "x",
+            CustomerName = "y",
+            MaxEmployees = 1,
+            ExpiresAt = null,
+        };
+        info.IsExpired.Should().BeFalse();
+        info.DaysUntilExpiry.Should().BeNull();
+    }
+
+    private static string Base64Url(string s) => Base64UrlBytes(Encoding.UTF8.GetBytes(s));
+
+    private static string Base64UrlBytes(byte[] bytes)
+    {
+        var b64 = Convert.ToBase64String(bytes);
+        return b64.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+}

--- a/installer/setup/tests/PraxisZeit.Setup.Core.Tests/Services/PraxisZeitConfigWriterTests.cs
+++ b/installer/setup/tests/PraxisZeit.Setup.Core.Tests/Services/PraxisZeitConfigWriterTests.cs
@@ -209,4 +209,138 @@ public sealed class PraxisZeitConfigWriterTests : IDisposable
         var expected = PraxisZeitConfigWriter.Serialize(ValidValues());
         written.Should().Be(expected);
     }
+
+    // --------------------- Ports ---------------------
+
+    [Fact]
+    public void ValidateValues_accepts_default_ports()
+    {
+        // Default ist 443 / 80 — beide muessen ohne expliziten Wert gueltig sein.
+        PraxisZeitConfigWriter.ValidateValues(ValidValues()).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(65536)]
+    [InlineData(99999)]
+    public void ValidateValues_rejects_https_port_out_of_range(int port)
+    {
+        var values = ValidValues() with { HttpsPort = port };
+        PraxisZeitConfigWriter.ValidateValues(values).Should().Contain("HTTPS-Port");
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(65536)]
+    public void ValidateValues_rejects_http_redirect_port_out_of_range(int port)
+    {
+        var values = ValidValues() with { HttpRedirectPort = port };
+        PraxisZeitConfigWriter.ValidateValues(values).Should().Contain("HTTP-Redirect-Port");
+    }
+
+    [Fact]
+    public void ValidateValues_accepts_http_redirect_port_zero_to_disable()
+    {
+        // Port 0 = User hat HTTP-Redirect ausgeschaltet (kein Listener).
+        // Muss explizit erlaubt sein, ist KEIN Fehler.
+        var values = ValidValues() with { HttpRedirectPort = 0 };
+        PraxisZeitConfigWriter.ValidateValues(values).Should().BeNull();
+    }
+
+    [Fact]
+    public void ValidateValues_rejects_identical_ports()
+    {
+        var values = ValidValues() with { HttpsPort = 8443, HttpRedirectPort = 8443 };
+        PraxisZeitConfigWriter.ValidateValues(values).Should().Contain("identisch");
+    }
+
+    [Fact]
+    public void Serialize_writes_custom_ports_in_server_section()
+    {
+        var values = ValidValues() with { HttpsPort = 8443, HttpRedirectPort = 8080 };
+        var output = PraxisZeitConfigWriter.Serialize(values);
+        output.Should().Contain("[server]");
+        output.Should().Contain("port = 8443");
+        output.Should().Contain("http_redirect_port = 8080");
+    }
+
+    [Fact]
+    public void Serialize_omits_http_redirect_when_zero()
+    {
+        var values = ValidValues() with { HttpRedirectPort = 0 };
+        var output = PraxisZeitConfigWriter.Serialize(values);
+        output.Should().NotContain("http_redirect_port");
+    }
+
+    // --------------------- Lizenz / Demo ---------------------
+
+    [Fact]
+    public void Serialize_writes_license_key_file_path_in_license_section()
+    {
+        var output = PraxisZeitConfigWriter.Serialize(ValidValues());
+        output.Should().Contain("[license]");
+        output.Should().Contain("key_file = \"config/license.key\"");
+    }
+
+    [Fact]
+    public void Serialize_writes_demo_expires_at_when_demo_days_set()
+    {
+        var values = ValidValues() with { LicenseToken = null, DemoDays = 30 };
+        var output = PraxisZeitConfigWriter.Serialize(values);
+        output.Should().Contain("demo_expires_at");
+        // Format: ISO-Date, 30 Tage in der Zukunft, naeherungsweise pruefen
+        var expectedDate = DateTime.UtcNow.Date.AddDays(30).ToString("yyyy-MM-dd");
+        output.Should().Contain($"demo_expires_at = \"{expectedDate}\"");
+    }
+
+    [Fact]
+    public void Serialize_omits_demo_expires_at_when_real_license_present()
+    {
+        var values = ValidValues() with { LicenseToken = "fake.jwt.token", DemoDays = 30 };
+        var output = PraxisZeitConfigWriter.Serialize(values);
+        output.Should().NotContain("demo_expires_at");
+    }
+
+    [Fact]
+    public void Serialize_omits_demo_expires_at_when_demo_days_null()
+    {
+        var values = ValidValues() with { LicenseToken = null, DemoDays = null };
+        var output = PraxisZeitConfigWriter.Serialize(values);
+        output.Should().NotContain("demo_expires_at");
+    }
+
+    [Fact]
+    public async Task WriteLicenseFileAsync_writes_token_as_utf8_no_bom()
+    {
+        var configDir = Path.Combine(_tempDir, "config");
+        const string token = "eyJhbGciOiJFZERTQSJ9.payload.signature";
+        await PraxisZeitConfigWriter.WriteLicenseFileAsync(configDir, token);
+
+        var licensePath = Path.Combine(configDir, "license.key");
+        File.Exists(licensePath).Should().BeTrue();
+        var bytes = await File.ReadAllBytesAsync(licensePath);
+        // BOM (EF BB BF) darf nicht am Anfang stehen
+        bytes[..3].Should().NotEqual([0xEF, 0xBB, 0xBF]);
+        var content = Encoding.UTF8.GetString(bytes);
+        content.Should().Be(token);
+    }
+
+    [Fact]
+    public async Task WriteLicenseFileAsync_trims_whitespace()
+    {
+        var configDir = Path.Combine(_tempDir, "config");
+        await PraxisZeitConfigWriter.WriteLicenseFileAsync(configDir, "\n  token-mit-whitespace  \n");
+
+        var content = await File.ReadAllTextAsync(Path.Combine(configDir, "license.key"));
+        content.Should().Be("token-mit-whitespace");
+    }
+
+    [Fact]
+    public async Task WriteLicenseFileAsync_rejects_empty_token()
+    {
+        var configDir = Path.Combine(_tempDir, "config");
+        var act = () => PraxisZeitConfigWriter.WriteLicenseFileAsync(configDir, "");
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
 }

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.4.0"
+APP_VERSION="1.4.1"
 PYTHON_VERSION="3.13.3"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 PYTHON_STANDALONE_TAG="20250529"

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.4.1"
+APP_VERSION="1.4.2"
 PYTHON_VERSION="3.13.3"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 PYTHON_STANDALONE_TAG="20250529"

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.4.2"
+APP_VERSION="1.4.3"
 PYTHON_VERSION="3.13.3"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 PYTHON_STANDALONE_TAG="20250529"


### PR DESCRIPTION
## Two patch releases stacked on master

### 1.4.1 — SPA-fallback bugfix + ConfigPage rollover
- 🐞 `SPAFallbackMiddleware` returned `index.html` (text/html, 200 OK) for **any** GET 404 outside `/api/`. After 1.4.0 changed asset hashes (Tailwind v3 → v4), stale Service Workers from prior versions hit this trap and got HTML back for old `/assets/*.css` requests — browser refused to apply text/html as a stylesheet → unstyled page. Asset-shaped requests now return real 404. /assets/* short-circuits regardless of `Accept`.
- Drive-by: SPA-fallback Response was constructed inside `dispatch()` and bypassed `SecurityHeadersMiddleware`. Now propagates CSP/HSTS/X-Frame-Options from inner response.
- Refactor: `SPAFallbackMiddleware` extracted from `main.py` into `app/middleware/static_serving.py` (testable). 10 new unit tests in `backend/tests/test_spa_fallback.py`.
- 🚀 Brings the unattended-onboarding ConfigPage that was sitting in `[Unreleased]` since 1.4.0 cut.

### 1.4.2 — Tailwind v4 spacing-utility regression
The actually-visible "schaut schrecklich aus" issue. Cards lost padding, sidebar items collapsed without `px-4 py-3`, `Budget`/`Genommen` labels lost spacing — backgrounds / shadows / borders / rounded corners all rendered correctly, but every `p-*` / `m-*` / `space-*` was zeroed.

**Root cause:** `frontend/src/index.css` had a global
```css
* { margin: 0; padding: 0; box-sizing: border-box; }
```
*outside* every `@layer`. Tailwind v4 wraps every utility in `:where(...)` so users can override with simple selectors — `:where(.p-6)` has specificity 0,0,0. The unlayered `*` selector also has specificity 0,0,0 but **unlayered author rules outrank `@layer utilities` in the cascade** at equal specificity. Result: every spacing utility was silently overridden.

**Fix:** move the reset into `@layer base` (which is below `@layer utilities` in Tailwind v4's declared layer order). Dropped `box-sizing: border-box` from the reset — Tailwind v4 Preflight already sets it on `*, ::before, ::after`.

**Verified end-to-end via Playwright** against the local docker stack:
- card padding `0px → 24px`
- nav-item padding `0px → 12px 16px`
- screenshot now matches the pre-1.4.0 layout

## Reproduction (deployed 1.4.0 native install at `https://192.168.1.5/`)

User reported "schaut immer noch schrecklich aus" with two screenshots — cards floating without boundaries, sidebar items crammed against the left edge. Reproduced 1:1 against the local Docker stack on master after replacing the stale frontend container's `dist/` with a fresh build.

## Version bumps (3-place lock per CLAUDE.md)
- [x] `backend/app/core/updater.py` → `1.4.2`
- [x] `tools/build-release.sh` → `1.4.2`
- [x] `frontend/package.json` → `1.4.2` (+ regenerated `package-lock.json`)
- [x] `CHANGELOG.md` — separate `[1.4.1]` and `[1.4.2]` entries

## Test plan
- [x] `backend/tests/test_spa_fallback.py` — 10 cases (RED → GREEN proven)
- [x] `tests/test_native_mode.py` (18) + `tests/test_request_size_limit.py` (4) still pass
- [x] `from app.main import app` boots cleanly in native mode
- [x] **End-to-end browser test (Playwright + docker)**: card padding 0px → 24px, nav-item padding 0px → 12px 16px after CSS fix
- [ ] `bash tools/build-release.sh --windows-only --skip-download` → `dist/praxiszeit-1.4.2-setup-windows-x64.exe` (in progress, will report SHA)

## Operator notes
- 1.4.0 → 1.4.2 is the upgrade path. The 1.4.1 commit lives in history but no installer was tagged for it; 1.4.2 picks up both fixes.
- End users on a previously-installed 1.3.x or 1.4.0 PWA still need a one-time hard refresh / Service-Worker unregister to pick up the new bundle. After that one cycle, the SPA-fallback fix prevents the failure mode on every *future* asset-hash change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)