### PR TITLE
fix(vacation): security + DSGVO hardening from PR review (1.4.4)

### DIFF
--- a/backend/alembic/versions/2026_05_07_0900-038_vr_last_modified.py
+++ b/backend/alembic/versions/2026_05_07_0900-038_vr_last_modified.py
@@ -1,0 +1,52 @@
+"""Track who last modified a vacation request.
+
+Adds ``last_modified_by`` + ``last_modified_at`` to ``vacation_requests``.
+The motivation is DSGVO-style transparency: when an admin edits a
+pending request that was originally filed by an employee, the employee
+should be able to see *that* it was modified and *by whom*, not just
+the after-state. The columns also make the audit-log query a single
+JOIN instead of a fragile LIKE-on-format-string.
+
+``last_modified_by`` is set by ``apply_vacation_request_patch`` on
+every non-noop edit. NULL means the request has not been modified
+since creation. The admin's ``review`` (approve/reject) writes
+``reviewed_by``, not these columns — they specifically track CONTENT
+changes.
+
+Revision ID: 038_vr_last_modified
+Revises: 037_widen_audit_source
+Create Date: 2026-05-07
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '038_vr_last_modified'
+down_revision = '037_widen_audit_source'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'vacation_requests',
+        sa.Column(
+            'last_modified_by',
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey('users.id', ondelete='SET NULL'),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        'vacation_requests',
+        sa.Column(
+            'last_modified_at',
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('vacation_requests', 'last_modified_at')
+    op.drop_column('vacation_requests', 'last_modified_by')

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.4.3"
+APP_VERSION = "1.4.4"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/models/vacation_request.py
+++ b/backend/app/models/vacation_request.py
@@ -30,6 +30,12 @@ class VacationRequest(Base):
     rejection_reason = Column(Text, nullable=True)
     reviewed_by = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
     reviewed_at = Column(DateTime(timezone=True), nullable=True)
+    # Tracks the most recent CONTENT-altering edit (range / hours / type /
+    # note). Distinct from reviewed_by, which records approve/reject.
+    # NULL = never edited since creation. Drives the MA-side "Bearbeitet
+    # von Admin XY" badge (transparency, § 26 BDSG).
+    last_modified_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    last_modified_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 

--- a/backend/app/routers/admin_vacations.py
+++ b/backend/app/routers/admin_vacations.py
@@ -1,9 +1,10 @@
 """Admin sub-router: Vacation Request Management."""
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy.orm import Session
 from typing import List, Optional
 from datetime import datetime, timezone, timedelta
+from app.core.limiter import limiter
 from app.database import get_db
 from app.models import User, Absence, PublicHoliday, AbsenceType, TimeEntry, TimeEntryAuditLog
 from app.models.vacation_request import VacationRequest, VacationRequestStatus
@@ -13,7 +14,10 @@ from app.services import calculation_service
 from app.services.calculation_service import count_workdays
 from app.services.timezone_service import today_local
 from app.routers.admin_helpers import _create_audit_log
-from app.routers.vacation_requests import cancel_approved_vacation_request, _format_vacation_request_audit_text
+from app.routers.vacation_requests import (
+    cancel_approved_vacation_request,
+    apply_vacation_request_patch,
+)
 
 router = APIRouter(prefix="/api/admin", tags=["admin"], dependencies=[Depends(require_admin)])
 
@@ -32,6 +36,8 @@ def _enrich_vr_responses(vrs: list, db: Session) -> list[VacationRequestResponse
         user_ids.add(vr.user_id)
         if vr.reviewed_by:
             user_ids.add(vr.reviewed_by)
+        if vr.last_modified_by:
+            user_ids.add(vr.last_modified_by)
     user_ids.discard(None)
     users = db.query(User).filter(User.id.in_(user_ids)).all() if user_ids else []
     user_map = {u.id: u for u in users}
@@ -48,6 +54,11 @@ def _enrich_vr_responses(vrs: list, db: Session) -> list[VacationRequestResponse
             if reviewer:
                 resp.reviewer_first_name = reviewer.first_name
                 resp.reviewer_last_name = reviewer.last_name
+        if vr.last_modified_by:
+            modifier = user_map.get(vr.last_modified_by)
+            if modifier:
+                resp.last_modifier_first_name = modifier.first_name
+                resp.last_modifier_last_name = modifier.last_name
         # Compute workdays
         end = vr.end_date if vr.end_date else vr.date
         resp.days = count_workdays(db, vr.date, end)
@@ -247,7 +258,9 @@ def review_vacation_request(
 
 
 @router.patch("/vacation-requests/{request_id}", response_model=VacationRequestResponse)
+@limiter.limit("60/minute")
 def update_vacation_request_as_admin(
+    request: Request,
     request_id: str,
     data: VacationRequestUpdate,
     db: Session = Depends(get_db),
@@ -256,9 +269,10 @@ def update_vacation_request_as_admin(
     """Edit a PENDING vacation request on behalf of the requesting employee.
 
     Tenant-scoped: returns 404 (not 403) if the row belongs to another
-    tenant — don't leak existence. Mirrors the employee-side validation,
-    but the target user is the original requester (not the admin), so
-    work-day window and vacation budget are evaluated against them.
+    tenant — don't leak existence. Validation runs against the target
+    employee (not the admin) so work-day window + vacation budget are
+    evaluated against them. Patch / audit logic is shared with the MA
+    endpoint via ``apply_vacation_request_patch``.
     """
     vr = (
         db.query(VacationRequest)
@@ -284,98 +298,9 @@ def update_vacation_request_as_admin(
     if not target_user:
         raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 
-    old_audit_text = _format_vacation_request_audit_text(vr)
-    old_date = vr.date
-
-    # Apply patch (merge provided fields). model_fields_set distinguishes
-    # "field absent from request" (keep DB value) from "field sent as null"
-    # (clear nullable fields end_date / note).
-    fields_set = data.model_fields_set
-    new_date = data.date if "date" in fields_set and data.date is not None else vr.date
-    new_end_date = data.end_date if "end_date" in fields_set else vr.end_date
-    new_hours = data.hours if "hours" in fields_set and data.hours is not None else float(vr.hours)
-    new_note = data.note if "note" in fields_set else vr.note
-    new_absence_type = data.absence_type if "absence_type" in fields_set and data.absence_type is not None else vr.absence_type
-
-    no_change = (
-        new_date == vr.date
-        and new_end_date == vr.end_date
-        and float(new_hours) == float(vr.hours)
-        and new_note == vr.note
-        and new_absence_type == vr.absence_type
+    return apply_vacation_request_patch(
+        db, vr, data, target_user=target_user, acting_user=current_user
     )
-    if no_change:
-        return _enrich_vr_response(vr, db)
-
-    # Re-validation against TARGET USER, not admin
-    effective_end = new_end_date if new_end_date else new_date
-    if effective_end < new_date:
-        raise HTTPException(status_code=400, detail="Enddatum muss nach dem Startdatum liegen")
-    if target_user.first_work_day and new_date < target_user.first_work_day:
-        raise HTTPException(status_code=400, detail="Datum liegt vor dem ersten Arbeitstag")
-    if target_user.last_work_day and effective_end > target_user.last_work_day:
-        raise HTTPException(status_code=400, detail="Datum liegt nach dem letzten Arbeitstag")
-
-    other_pending = db.query(VacationRequest).filter(
-        VacationRequest.id != vr.id,
-        VacationRequest.user_id == target_user.id,
-        VacationRequest.tenant_id == current_user.tenant_id,
-        VacationRequest.status == VacationRequestStatus.PENDING.value,
-        VacationRequest.date <= effective_end,
-    ).all()
-    for e in other_pending:
-        e_end = e.end_date if e.end_date else e.date
-        if e_end >= new_date:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=f"Offener Urlaubsantrag für Zeitraum {e.date}–{e_end} existiert bereits",
-            )
-
-    if new_absence_type == "vacation":
-        dates_by_year: dict[int, list] = {}
-        d = new_date
-        while d <= effective_end:
-            if d.weekday() < 5:
-                dates_by_year.setdefault(d.year, []).append(d)
-            d += timedelta(days=1)
-        for check_year, year_dates in dates_by_year.items():
-            account = calculation_service.get_vacation_account(db, target_user, check_year)
-            year_hours_needed = sum(
-                float(calculation_service.get_daily_target_for_date(
-                    target_user, dd,
-                    weekly_hours=calculation_service.get_weekly_hours_for_date(db, target_user, dd),
-                ))
-                for dd in year_dates
-            )
-            if float(account['remaining_hours']) - year_hours_needed < 0:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Nicht genügend Urlaubstage für {check_year} ({account['remaining_days']:.1f} Tage verfügbar)",
-                )
-
-    vr.date = new_date
-    vr.end_date = new_end_date
-    vr.hours = new_hours
-    vr.note = new_note
-    vr.absence_type = new_absence_type
-
-    new_audit_text = _format_vacation_request_audit_text(vr)
-    audit = TimeEntryAuditLog(
-        time_entry_id=None,
-        user_id=vr.user_id,
-        changed_by=current_user.id,
-        action="update",
-        old_date=old_date,
-        new_date=vr.date,
-        old_note=old_audit_text,
-        new_note=new_audit_text,
-        source="vacation_request_edit",
-        tenant_id=vr.tenant_id,
-    )
-    db.add(audit)
-    db.commit()
-    db.refresh(vr)
-    return _enrich_vr_response(vr, db)
 
 
 @router.delete("/vacation-requests/{request_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/routers/superadmin.py
+++ b/backend/app/routers/superadmin.py
@@ -295,15 +295,19 @@ def cron_trial_check(
     from app.services.signup_service import suspend_expired_trials
     from app.services.stripe_service import suspend_canceled_after_grace
     from app.services.lifecycle_service import (
-        apply_scheduled_suspends, apply_scheduled_deletions,
+        apply_scheduled_suspends,
+        apply_scheduled_deletions,
+        purge_expired_vacation_audit_logs,
     )
     trials = suspend_expired_trials(db)
     canceled = suspend_canceled_after_grace(db)
     scheduled = apply_scheduled_suspends(db)
     anonymized = apply_scheduled_deletions(db)
+    audit_purged = purge_expired_vacation_audit_logs(db)
     return {
         "suspended_trials": trials,
         "suspended_canceled": canceled,
         "suspended_scheduled": scheduled,
         "anonymized_tenants": anonymized,
+        "vacation_audit_purged": audit_purged,
     }

--- a/backend/app/routers/vacation_requests.py
+++ b/backend/app/routers/vacation_requests.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, Depends, HTTPException, status, Query
+from fastapi import APIRouter, Depends, HTTPException, Request, status, Query
 from sqlalchemy.orm import Session
+from app.core.limiter import limiter
 from app.services.date_filters import date_in_year, date_in_month
 from typing import List, Optional
 from datetime import datetime, timezone, timedelta, date
@@ -36,20 +37,27 @@ def _enrich(vr: VacationRequest, db: Session) -> VacationRequestResponse:
         if reviewer:
             resp.reviewer_first_name = reviewer.first_name
             resp.reviewer_last_name = reviewer.last_name
+    if vr.last_modified_by:
+        modifier = db.query(User).filter(User.id == vr.last_modified_by).first()
+        if modifier:
+            resp.last_modifier_first_name = modifier.first_name
+            resp.last_modifier_last_name = modifier.last_name
     # Compute workdays
     end = vr.end_date if vr.end_date else vr.date
     resp.days = count_workdays(db, vr.date, end)
     return resp
 
 
-def _format_vacation_request_audit_text(vr: VacationRequest) -> str:
+def format_vacation_request_audit_text(vr: VacationRequest) -> str:
     """Compact one-line representation of a vacation request for audit logs.
 
     Used as `old_note` / `new_note` payload on edit/cancel events. Note is
-    truncated to 200 chars to keep audit-log queries cheap.
+    truncated to 200 chars to keep audit-log queries cheap. The `|`
+    separator is also stripped from the note so users can't forge fake
+    audit-row shapes via log injection (CWE-117).
     """
     end = vr.end_date if vr.end_date else vr.date
-    note = (vr.note or "").replace("\n", " ").strip()[:200]
+    note = (vr.note or "").replace("\n", " ").replace("|", "/").strip()[:200]
     text = (
         f"vacation_request {vr.id} | "
         f"{vr.date}..{end} | "
@@ -59,6 +67,146 @@ def _format_vacation_request_audit_text(vr: VacationRequest) -> str:
     if note:
         text += f" | {note}"
     return text
+
+
+def apply_vacation_request_patch(
+    db: Session,
+    vr: VacationRequest,
+    data: "VacationRequestUpdate",
+    target_user: User,
+    acting_user: User,
+) -> VacationRequestResponse:
+    """Shared edit logic for the MA + Admin PATCH endpoints.
+
+    Caller is responsible for:
+      * loading `vr` with `with_for_update()` and a tenant filter,
+      * verifying status == PENDING,
+      * authorising the actor (owner check for MA, role check for Admin),
+      * resolving `target_user` (== current user for MA, == vr owner for
+        Admin) so validation runs against the right account.
+
+    This helper handles the actual mutation + audit. Inputs are
+    normalised (notes stripped, hours rounded) so trivially-different
+    payloads don't flood the audit log (CWE-117 amplification + DSGVO
+    Art. 5(1)(c) data minimisation).
+    """
+    old_audit_text = format_vacation_request_audit_text(vr)
+    old_date = vr.date
+
+    # Apply patch. model_fields_set distinguishes "field absent" (keep DB)
+    # from "field=null" (clear nullable). Inputs are normalised before any
+    # equality compare so " x " vs "x" doesn't trigger a spurious audit.
+    fields_set = data.model_fields_set
+    new_date = data.date if "date" in fields_set and data.date is not None else vr.date
+    new_end_date = data.end_date if "end_date" in fields_set else vr.end_date
+    if "hours" in fields_set and data.hours is not None:
+        new_hours = round(float(data.hours), 2)
+    else:
+        new_hours = round(float(vr.hours), 2)
+    if "note" in fields_set:
+        new_note = (data.note or "").strip() if data.note is not None else None
+    else:
+        new_note = vr.note
+    new_absence_type = data.absence_type if "absence_type" in fields_set and data.absence_type is not None else vr.absence_type
+
+    no_change = (
+        new_date == vr.date
+        and new_end_date == vr.end_date
+        and new_hours == round(float(vr.hours), 2)
+        and (new_note or None) == (vr.note or None)
+        and new_absence_type == vr.absence_type
+    )
+    if no_change:
+        return _enrich(vr, db)
+
+    effective_end = new_end_date if new_end_date else new_date
+    if effective_end < new_date:
+        raise HTTPException(status_code=400, detail="Enddatum muss nach dem Startdatum liegen")
+    if target_user.first_work_day and new_date < target_user.first_work_day:
+        raise HTTPException(status_code=400, detail="Datum liegt vor dem ersten Arbeitstag")
+    if target_user.last_work_day and effective_end > target_user.last_work_day:
+        raise HTTPException(status_code=400, detail="Datum liegt nach dem letzten Arbeitstag")
+
+    other_pending = db.query(VacationRequest).filter(
+        VacationRequest.id != vr.id,
+        VacationRequest.user_id == target_user.id,
+        VacationRequest.tenant_id == vr.tenant_id,
+        VacationRequest.status == VacationRequestStatus.PENDING.value,
+        VacationRequest.date <= effective_end,
+    ).all()
+    for e in other_pending:
+        e_end = e.end_date if e.end_date else e.date
+        if e_end >= new_date:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Offener Urlaubsantrag für Zeitraum {e.date}–{e_end} existiert bereits",
+            )
+
+    if new_absence_type == "vacation":
+        from app.services import calculation_service
+        # Public holidays are excluded from the budget calc to stay
+        # consistent with the approve flow (admin_vacations.py:155-180).
+        # Without this, PATCH false-positives "insufficient budget" for
+        # ranges that contain holidays which approval would not consume.
+        years_in_range = set()
+        d = new_date
+        while d <= effective_end:
+            years_in_range.add(d.year)
+            d += timedelta(days=1)
+        holiday_dates: set = set()
+        if years_in_range:
+            for h in db.query(PublicHoliday).filter(
+                PublicHoliday.year.in_(years_in_range),
+                PublicHoliday.tenant_id == vr.tenant_id,
+            ).all():
+                holiday_dates.add(h.date)
+
+        dates_by_year: dict[int, list] = {}
+        d = new_date
+        while d <= effective_end:
+            if d.weekday() < 5 and d not in holiday_dates:
+                dates_by_year.setdefault(d.year, []).append(d)
+            d += timedelta(days=1)
+        for check_year, year_dates in dates_by_year.items():
+            account = calculation_service.get_vacation_account(db, target_user, check_year)
+            year_hours_needed = sum(
+                float(calculation_service.get_daily_target_for_date(
+                    target_user, dd,
+                    weekly_hours=calculation_service.get_weekly_hours_for_date(db, target_user, dd),
+                ))
+                for dd in year_dates
+            )
+            if float(account['remaining_hours']) - year_hours_needed < 0:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Nicht genügend Urlaubstage für {check_year} ({account['remaining_days']:.1f} Tage verfügbar)",
+                )
+
+    vr.date = new_date
+    vr.end_date = new_end_date
+    vr.hours = new_hours
+    vr.note = new_note
+    vr.absence_type = new_absence_type
+    vr.last_modified_by = acting_user.id
+    vr.last_modified_at = datetime.now(timezone.utc)
+
+    new_audit_text = format_vacation_request_audit_text(vr)
+    audit = TimeEntryAuditLog(
+        time_entry_id=None,
+        user_id=vr.user_id,
+        changed_by=acting_user.id,
+        action="update",
+        old_date=old_date,
+        new_date=vr.date,
+        old_note=old_audit_text,
+        new_note=new_audit_text,
+        source="vacation_request_edit",
+        tenant_id=vr.tenant_id,
+    )
+    db.add(audit)
+    db.commit()
+    db.refresh(vr)
+    return _enrich(vr, db)
 
 
 @router.post("/", response_model=VacationRequestResponse, status_code=status.HTTP_201_CREATED)
@@ -226,20 +374,16 @@ def cancel_approved_vacation_request(
 
 
 @router.patch("/{request_id}", response_model=VacationRequestResponse)
+@limiter.limit("60/minute")
 def update_vacation_request(
+    request: Request,
     request_id: str,
     data: VacationRequestUpdate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Edit an own PENDING vacation request.
-
-    All fields are optional; only the provided ones are updated. The
-    router re-validates the resulting full state (range, work-day window,
-    budget, pending-overlap) — same checks as create_vacation_request,
-    but the overlap check excludes this request itself.
-    """
-    # F-028 / belt-and-suspenders tenant scoping (F-026)
+    """Edit an own PENDING vacation request. Delegates the patch /
+    validation / audit work to ``apply_vacation_request_patch``."""
     vr = (
         db.query(VacationRequest)
         .filter(
@@ -258,110 +402,9 @@ def update_vacation_request(
             status_code=400,
             detail="Nur offene Anträge können bearbeitet werden",
         )
-
-    # Capture old state for audit BEFORE applying changes
-    old_audit_text = _format_vacation_request_audit_text(vr)
-    old_date = vr.date
-
-    # Apply patch (merge provided fields). model_fields_set distinguishes
-    # "field absent from request" (keep DB value) from "field sent as null"
-    # (clear the field). Without this, sending end_date=null would be
-    # silently ignored when collapsing a multi-day range to a single day.
-    fields_set = data.model_fields_set
-    new_date = data.date if "date" in fields_set and data.date is not None else vr.date
-    new_end_date = data.end_date if "end_date" in fields_set else vr.end_date
-    new_hours = data.hours if "hours" in fields_set and data.hours is not None else float(vr.hours)
-    new_note = data.note if "note" in fields_set else vr.note
-    new_absence_type = data.absence_type if "absence_type" in fields_set and data.absence_type is not None else vr.absence_type
-
-    # No-op detection: skip everything if nothing actually changes.
-    no_change = (
-        new_date == vr.date
-        and new_end_date == vr.end_date
-        and float(new_hours) == float(vr.hours)
-        and new_note == vr.note
-        and new_absence_type == vr.absence_type
+    return apply_vacation_request_patch(
+        db, vr, data, target_user=current_user, acting_user=current_user
     )
-    if no_change:
-        return _enrich(vr, db)
-
-    # Re-validation: range sanity
-    effective_end = new_end_date if new_end_date else new_date
-    if effective_end < new_date:
-        raise HTTPException(status_code=400, detail="Enddatum muss nach dem Startdatum liegen")
-
-    # First/last work day window
-    if current_user.first_work_day and new_date < current_user.first_work_day:
-        raise HTTPException(status_code=400, detail="Datum liegt vor dem ersten Arbeitstag")
-    if current_user.last_work_day and effective_end > current_user.last_work_day:
-        raise HTTPException(status_code=400, detail="Datum liegt nach dem letzten Arbeitstag")
-
-    # Pending-overlap with OTHER requests (exclude self via id)
-    other_pending = db.query(VacationRequest).filter(
-        VacationRequest.id != vr.id,
-        VacationRequest.user_id == current_user.id,
-        VacationRequest.tenant_id == current_user.tenant_id,
-        VacationRequest.status == VacationRequestStatus.PENDING.value,
-        VacationRequest.date <= effective_end,
-    ).all()
-    for e in other_pending:
-        e_end = e.end_date if e.end_date else e.date
-        if e_end >= new_date:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=f"Offener Urlaubsantrag für Zeitraum {e.date}–{e_end} existiert bereits",
-            )
-
-    # Vacation budget (vacation type only). Pending requests don't consume
-    # the budget — only Absences do — so no self-exclude needed here.
-    if new_absence_type == "vacation":
-        from app.services import calculation_service
-        dates_by_year: dict[int, list] = {}
-        d = new_date
-        while d <= effective_end:
-            if d.weekday() < 5:
-                dates_by_year.setdefault(d.year, []).append(d)
-            d += timedelta(days=1)
-        for check_year, year_dates in dates_by_year.items():
-            account = calculation_service.get_vacation_account(db, current_user, check_year)
-            year_hours_needed = sum(
-                float(calculation_service.get_daily_target_for_date(
-                    current_user, dd,
-                    weekly_hours=calculation_service.get_weekly_hours_for_date(db, current_user, dd),
-                ))
-                for dd in year_dates
-            )
-            if float(account['remaining_hours']) - year_hours_needed < 0:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Nicht genügend Urlaubstage für {check_year} ({account['remaining_days']:.1f} Tage verfügbar)",
-                )
-
-    # Apply changes
-    vr.date = new_date
-    vr.end_date = new_end_date
-    vr.hours = new_hours
-    vr.note = new_note
-    vr.absence_type = new_absence_type
-
-    # Write audit row
-    new_audit_text = _format_vacation_request_audit_text(vr)
-    audit = TimeEntryAuditLog(
-        time_entry_id=None,
-        user_id=vr.user_id,
-        changed_by=current_user.id,
-        action="update",
-        old_date=old_date,
-        new_date=vr.date,
-        old_note=old_audit_text,
-        new_note=new_audit_text,
-        source="vacation_request_edit",
-        tenant_id=vr.tenant_id,
-    )
-    db.add(audit)
-    db.commit()
-    db.refresh(vr)
-    return _enrich(vr, db)
 
 
 @router.delete("/{request_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -377,8 +420,22 @@ def withdraw_vacation_request(
       associated Absence rows and flip the request to WITHDRAWN. Past /
       started vacations cannot be cancelled because the work day has
       already happened (or is happening).
+
+    Row is locked via ``with_for_update`` to close the
+    edit-vs-withdraw race the edit-feature review flagged: if an admin
+    is mid-PATCH on a pending request and the user clicks Withdraw, we
+    don't want a torn state where the audit row is written for an edit
+    that lost to a concurrent delete.
     """
-    vr = db.query(VacationRequest).filter(VacationRequest.id == request_id).first()
+    vr = (
+        db.query(VacationRequest)
+        .filter(
+            VacationRequest.id == request_id,
+            VacationRequest.tenant_id == current_user.tenant_id,
+        )
+        .with_for_update()
+        .first()
+    )
     if not vr:
         raise HTTPException(status_code=404, detail="Urlaubsantrag nicht gefunden")
     if str(vr.user_id) != str(current_user.id):

--- a/backend/app/schemas/vacation_request.py
+++ b/backend/app/schemas/vacation_request.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from datetime import date, datetime
 from datetime import date as _date_type
 from typing import Optional, Literal
@@ -34,11 +34,17 @@ class VacationRequestUpdate(BaseModel):
     All fields optional — caller may patch any subset. The router
     re-validates the full effective state (start <= end, budget,
     work-day window, overlap with other pending) after merging.
+
+    `extra="forbid"` rejects unknown fields so a future refactor that
+    blindly assigns `data.model_dump(exclude_unset=True)` cannot become
+    a mass-assignment vector (e.g. status, reviewed_by, user_id).
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     date: Optional[_date_type] = None
     end_date: Optional[_date_type] = None
-    hours: Optional[float] = None
+    hours: Optional[float] = Field(None, ge=0, le=24)
     note: Optional[str] = None
     absence_type: Optional[str] = None
 
@@ -73,6 +79,13 @@ class VacationRequestResponse(BaseModel):
     reviewed_at: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime
+
+    # Last-edit tracking (Issue: DSGVO transparency) — drives the
+    # "Bearbeitet von Admin XY am ..." badge on the MA's view.
+    last_modified_by: Optional[uuid.UUID] = None
+    last_modified_at: Optional[datetime] = None
+    last_modifier_first_name: Optional[str] = None
+    last_modifier_last_name: Optional[str] = None
 
     # Enriched fields (populated by router)
     user_first_name: Optional[str] = None

--- a/backend/app/services/lifecycle_service.py
+++ b/backend/app/services/lifecycle_service.py
@@ -48,6 +48,17 @@ from app.models.tenant import Tenant
 SUSPEND_GRACE_DAYS = 7
 DELETE_GRACE_DAYS = 30
 
+# DSGVO Art. 5(1)(e) Speicherbegrenzung — vacation-request edit/cancel audit
+# rows reference an approval workflow, not the ArbZG-mandatory time-record
+# itself. We purge them after 730 days (gleichlauf mit ArbZG §16-Frist) so
+# the request-level history doesn't accumulate forever. Time-entry audits
+# (sources: manual / import / change_request) are NOT touched here.
+VACATION_AUDIT_RETENTION_DAYS = 730
+VACATION_AUDIT_SOURCES = (
+    "vacation_request_edit",
+    "vacation_request_cancel",
+)
+
 
 # ───────────────── Suspend / Deletion lifecycle ──────────────────────
 
@@ -134,6 +145,30 @@ def apply_scheduled_suspends(db: Session) -> int:
     if n:
         db.commit()
     return n
+
+
+def purge_expired_vacation_audit_logs(db: Session) -> int:
+    """Delete vacation-request edit/cancel audit rows older than the
+    retention window (DSGVO Art. 5 Abs. 1 lit. e).
+
+    Returns number of deleted rows. Tenant-scoped via WHERE on the model;
+    safe to run in a superadmin RLS context (the query carries no user
+    context). Time-entry audits (manual / import / change_request) are
+    intentionally excluded — those are bound to the ArbZG §16
+    record-retention obligation and must outlive this purge.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=VACATION_AUDIT_RETENTION_DAYS)
+    deleted = (
+        db.query(TimeEntryAuditLog)
+        .filter(
+            TimeEntryAuditLog.source.in_(VACATION_AUDIT_SOURCES),
+            TimeEntryAuditLog.created_at < cutoff,
+        )
+        .delete(synchronize_session=False)
+    )
+    if deleted:
+        db.commit()
+    return int(deleted or 0)
 
 
 def apply_scheduled_deletions(db: Session) -> int:

--- a/backend/tests/test_tenant_lifecycle.py
+++ b/backend/tests/test_tenant_lifecycle.py
@@ -117,6 +117,60 @@ def test_cron_respects_future_suspend(_db_session, tenant):
     assert count == 0
 
 
+# ─── Vacation-audit retention purge (DSGVO Art. 5(1)(e)) ────────────
+
+def _mk_audit(db, tenant_id, user_id, source, age_days):
+    from app.models import TimeEntryAuditLog
+    log = TimeEntryAuditLog(
+        time_entry_id=None, user_id=user_id, changed_by=user_id,
+        action="update", source=source, tenant_id=tenant_id,
+        new_note="x",
+    )
+    db.add(log)
+    db.flush()
+    log.created_at = datetime.now(timezone.utc) - timedelta(days=age_days)
+    db.commit()
+    return log
+
+
+def test_purge_old_vacation_edit_audits(_db_session, tenant):
+    user = _mk_user(_db_session, TID, "purger")
+    old_id = _mk_audit(_db_session, TID, user.id, "vacation_request_edit", age_days=800).id
+    young_id = _mk_audit(_db_session, TID, user.id, "vacation_request_edit", age_days=10).id
+    deleted = lifecycle_service.purge_expired_vacation_audit_logs(_db_session)
+    assert deleted == 1
+    from app.models import TimeEntryAuditLog
+    remaining = {a.id for a in _db_session.query(TimeEntryAuditLog).all()}
+    assert old_id not in remaining
+    assert young_id in remaining
+
+
+def test_purge_does_not_touch_arbzg_relevant_audits(_db_session, tenant):
+    """ArbZG §16 audit sources (manual / import / change_request /
+    dsgvo) must outlive the purge — they belong to time-entry retention."""
+    user = _mk_user(_db_session, TID, "keeper")
+    keep_sources = ("manual", "import", "change_request", "dsgvo")
+    keep_ids = [
+        _mk_audit(_db_session, TID, user.id, src, age_days=900).id
+        for src in keep_sources
+    ]
+    deleted = lifecycle_service.purge_expired_vacation_audit_logs(_db_session)
+    assert deleted == 0
+    from app.models import TimeEntryAuditLog
+    remaining = {a.id for a in _db_session.query(TimeEntryAuditLog).all()}
+    for kid in keep_ids:
+        assert kid in remaining
+
+
+def test_purge_handles_vacation_request_cancel_source(_db_session, tenant):
+    user = _mk_user(_db_session, TID, "canceller")
+    old_id = _mk_audit(_db_session, TID, user.id, "vacation_request_cancel", age_days=800).id
+    deleted = lifecycle_service.purge_expired_vacation_audit_logs(_db_session)
+    assert deleted == 1
+    from app.models import TimeEntryAuditLog
+    assert _db_session.query(TimeEntryAuditLog).filter_by(id=old_id).first() is None
+
+
 # ─── Deletion request + anonymization ──────────────────────────────
 
 def test_request_deletion_sets_timestamp(_db_session, admin_client):

--- a/backend/tests/test_tenant_rls.py
+++ b/backend/tests/test_tenant_rls.py
@@ -513,6 +513,121 @@ class TestTenantInvoicesIsolation:
             conn.close()
 
 
+class TestVacationRequestEditAuditIsolation:
+    """Verify vacation_request_edit audit rows are tenant-isolated under
+    real RLS (not just the app-layer F-026 filter).
+
+    The internal review claimed the audit row's tenant_id is set from
+    vr.tenant_id and the lookup query carries an explicit tenant filter.
+    This test closes the loop: even in the absence of the app-layer
+    filter, the Postgres RLS policy on time_entry_audit_logs blocks
+    cross-tenant reads. Spec test #12 closure.
+    """
+
+    def _seed_audit_rows(self, admin_engine):
+        """Insert one vacation_request_edit audit row per tenant."""
+        conn = admin_engine.connect()
+        try:
+            conn.execute(text(
+                "DELETE FROM time_entry_audit_logs "
+                "WHERE source = 'vacation_request_edit' "
+                "  AND new_note LIKE 'rls_audit_test_%'"
+            ))
+            for tid, uid, marker in [
+                (TENANT_A_ID, USER_A1_ID, "rls_audit_test_a"),
+                (TENANT_B_ID, USER_B1_ID, "rls_audit_test_b"),
+            ]:
+                conn.execute(text(
+                    """
+                    INSERT INTO time_entry_audit_logs
+                        (id, tenant_id, user_id, changed_by, action,
+                         source, new_note)
+                    VALUES (gen_random_uuid(), :tid, :uid, :uid,
+                            'update', 'vacation_request_edit', :note)
+                    """
+                ), {"tid": str(tid), "uid": str(uid), "note": marker})
+        finally:
+            conn.close()
+
+    def _cleanup_audit_rows(self, admin_engine):
+        conn = admin_engine.connect()
+        try:
+            conn.execute(text(
+                "DELETE FROM time_entry_audit_logs "
+                "WHERE new_note LIKE 'rls_audit_test_%'"
+            ))
+        finally:
+            conn.close()
+
+    def test_tenant_a_cannot_see_tenant_b_edit_audit(
+        self, app_engine, admin_engine, seed_data
+    ):
+        self._seed_audit_rows(admin_engine)
+        try:
+            conn, trans = _tenant_session(app_engine, TENANT_A_ID)
+            try:
+                rows = conn.execute(text(
+                    "SELECT new_note FROM time_entry_audit_logs "
+                    "WHERE source = 'vacation_request_edit' "
+                    "  AND new_note LIKE 'rls_audit_test_%'"
+                )).fetchall()
+                visible = {r[0] for r in rows}
+                assert "rls_audit_test_a" in visible
+                assert "rls_audit_test_b" not in visible, (
+                    "RLS leak: tenant A can read tenant B's vacation-edit audit row"
+                )
+            finally:
+                trans.rollback()
+                conn.close()
+        finally:
+            self._cleanup_audit_rows(admin_engine)
+
+    def test_tenant_b_cannot_see_tenant_a_edit_audit(
+        self, app_engine, admin_engine, seed_data
+    ):
+        self._seed_audit_rows(admin_engine)
+        try:
+            conn, trans = _tenant_session(app_engine, TENANT_B_ID)
+            try:
+                rows = conn.execute(text(
+                    "SELECT new_note FROM time_entry_audit_logs "
+                    "WHERE source = 'vacation_request_edit' "
+                    "  AND new_note LIKE 'rls_audit_test_%'"
+                )).fetchall()
+                visible = {r[0] for r in rows}
+                assert "rls_audit_test_b" in visible
+                assert "rls_audit_test_a" not in visible
+            finally:
+                trans.rollback()
+                conn.close()
+        finally:
+            self._cleanup_audit_rows(admin_engine)
+
+    def test_no_context_sees_no_edit_audit(
+        self, app_engine, admin_engine, seed_data
+    ):
+        """Even without tenant context, the audit row stays hidden — the
+        RLS policy fails-closed when app.tenant_id is unset."""
+        self._seed_audit_rows(admin_engine)
+        try:
+            conn, trans = _no_context_session(app_engine)
+            try:
+                count = conn.execute(text(
+                    "SELECT COUNT(*) FROM time_entry_audit_logs "
+                    "WHERE source = 'vacation_request_edit' "
+                    "  AND new_note LIKE 'rls_audit_test_%'"
+                )).scalar()
+                assert count == 0, (
+                    f"RLS leak: audit row visible without tenant context "
+                    f"(count={count})"
+                )
+            finally:
+                trans.rollback()
+                conn.close()
+        finally:
+            self._cleanup_audit_rows(admin_engine)
+
+
 class TestNoContextSecurity:
     """Verify that a session without any tenant/superadmin context sees nothing."""
 

--- a/backend/tests/test_vacation_request_edit.py
+++ b/backend/tests/test_vacation_request_edit.py
@@ -265,6 +265,112 @@ class TestEmployeeEdit:
         db.refresh(vr)
         assert vr.end_date is None
 
+    def test_edit_within_budget_does_not_self_count(
+        self, db, employee, employee_client
+    ):
+        """Spec #9 regression: editing a pending request must NOT
+        double-count its own hours against the vacation budget.
+
+        Setup: tight budget = 2 vacation days. Pending request consumes
+        the full budget. PATCH shifts the date range to a different week
+        but keeps the same length. If the impl wrongly summed the
+        existing pending hours into `account['remaining_hours']`, this
+        edit would fail with 400 (budget). Pending requests must NOT
+        consume budget — only Absences do.
+        """
+        employee.vacation_days = 2
+        db.commit()
+        # Mon + Tue in Q3 — deterministic weekdays, future-dated
+        start = date(2026, 9, 7)        # Monday
+        end = date(2026, 9, 8)          # Tuesday
+        vr = _vr(db, employee, start=start, end=end, hours=8.0)
+        # Shift to following week, same length
+        new_start = date(2026, 9, 14)   # Monday
+        new_end = date(2026, 9, 15)     # Tuesday
+        resp = employee_client.patch(
+            f"/api/vacation-requests/{vr.id}",
+            json={
+                "date": new_start.isoformat(),
+                "end_date": new_end.isoformat(),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        db.refresh(vr)
+        assert vr.date == new_start
+        assert vr.end_date == new_end
+
+    def test_edit_exceeds_budget_rejected(
+        self, db, employee, employee_client
+    ):
+        """Counterpart to self-exclude test: actual budget overflow
+        must still be rejected. Sanity-check that the budget guard is
+        intact and we didn't dilute it while fixing the double-count."""
+        employee.vacation_days = 2
+        db.commit()
+        start = date(2026, 9, 7)        # Monday
+        vr = _vr(db, employee, start=start, end=start + timedelta(days=1),
+                 hours=8.0)
+        # Try to extend to Mon-Fri = 5 weekdays, budget = 2 days
+        resp = employee_client.patch(
+            f"/api/vacation-requests/{vr.id}",
+            json={"end_date": (start + timedelta(days=4)).isoformat()},
+        )
+        assert resp.status_code == 400
+
+    def test_edit_unknown_field_rejected(self, db, employee, employee_client):
+        """Mass-assignment guard: extra="forbid" rejects unknown fields
+        like `status` / `reviewed_by` so a future refactor that blindly
+        applies model_dump cannot bypass the approval workflow."""
+        vr = _vr(db, employee)
+        resp = employee_client.patch(
+            f"/api/vacation-requests/{vr.id}",
+            json={"status": "approved", "note": "trying to self-approve"},
+        )
+        assert resp.status_code == 422
+
+    def test_edit_negative_hours_rejected(self, db, employee, employee_client):
+        """Field bounds: negative or absurd hours must be rejected at
+        the schema layer before any DB write."""
+        vr = _vr(db, employee)
+        resp = employee_client.patch(
+            f"/api/vacation-requests/{vr.id}", json={"hours": -1.0}
+        )
+        assert resp.status_code == 422
+
+    def test_edit_excessive_hours_rejected(self, db, employee, employee_client):
+        """Field bounds: hours > 24 (one calendar day) must be rejected."""
+        vr = _vr(db, employee)
+        resp = employee_client.patch(
+            f"/api/vacation-requests/{vr.id}", json={"hours": 9999.0}
+        )
+        assert resp.status_code == 422
+
+    def test_edit_note_pipe_escaped_in_audit(
+        self, db, employee, employee_client
+    ):
+        """Log-injection guard: `|` is the audit-text separator and must
+        be neutralized in user-supplied notes so attackers cannot forge
+        fake audit-row shapes (CWE-117)."""
+        vr = _vr(db, employee, note="alt")
+        resp = employee_client.patch(
+            f"/api/vacation-requests/{vr.id}",
+            json={"note": "fake | 2099-01-01..2099-12-31 | vacation | 999h"},
+        )
+        assert resp.status_code == 200, resp.text
+        audits = db.query(TimeEntryAuditLog).filter(
+            TimeEntryAuditLog.source == "vacation_request_edit"
+        ).all()
+        assert len(audits) == 1
+        # The literal injected `|` must not appear in the new-note slice
+        # past the legitimate format prefix.
+        new_note = audits[0].new_note or ""
+        # Split on the helper's separator: prefix has 4 segments before
+        # the user-supplied note (`vacation_request <id> | <range> | <type>
+        # | <hours> | <note>`). Anything more = injection succeeded.
+        assert new_note.count("|") == 4, (
+            f"User-supplied `|` not escaped: {new_note!r}"
+        )
+
 
 # ===========================================================================
 # Admin edit any pending in tenant
@@ -307,3 +413,53 @@ class TestAdminEdit:
             f"/api/admin/vacation-requests/{vr.id}", json={"note": "x"}
         )
         assert resp.status_code == 400
+
+    def test_admin_edit_sets_last_modified_by(
+        self, db, employee, admin, admin_client
+    ):
+        """DSGVO transparency: when an admin edits a MA's request, the
+        MA must be able to see WHO modified it. last_modified_by is the
+        single source of truth — drives the 'Bearbeitet von Admin XY'
+        badge on the MA's view."""
+        vr = _vr(db, employee, note="alt")
+        resp = admin_client.patch(
+            f"/api/admin/vacation-requests/{vr.id}",
+            json={"note": "admin änderung"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["last_modified_by"] == str(admin.id)
+        assert body["last_modified_at"] is not None
+        assert body["last_modifier_first_name"] == admin.first_name
+
+
+class TestLastModifiedTracking:
+    def test_self_edit_sets_self_as_modifier(
+        self, db, employee, employee_client
+    ):
+        """A self-edit also bumps last_modified_by — the badge can then
+        compare last_modified_by == user_id to decide whether to render
+        as 'self-edited' (no badge) or 'admin-edited' (badge)."""
+        vr = _vr(db, employee, note="alt")
+        resp = employee_client.patch(
+            f"/api/vacation-requests/{vr.id}", json={"note": "neu"}
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["last_modified_by"] == str(employee.id)
+        assert body["last_modified_at"] is not None
+
+    def test_noop_edit_does_not_bump_last_modified(
+        self, db, employee, employee_client
+    ):
+        """No-op edits must NOT touch last_modified_by — otherwise a
+        spurious 'Bearbeitet von ...' badge would appear after a
+        no-change PATCH."""
+        vr = _vr(db, employee, note="same")
+        resp = employee_client.patch(
+            f"/api/vacation-requests/{vr.id}", json={"note": "same"}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["last_modified_by"] is None
+        assert body["last_modified_at"] is None

--- a/e2e/tests/employee/absences.spec.ts
+++ b/e2e/tests/employee/absences.spec.ts
@@ -268,4 +268,54 @@ test.describe('Employee Absences', () => {
     // Cleanup approval setting (request itself is teardown-handled by fixture)
     try { await adminApi.put('/admin/settings/vacation_approval_required', { value: 'false' }); } catch {}
   });
+
+  test('edit modal shows initial values from the existing request', async ({
+    employeePage,
+    adminApi,
+    createVacationRequest,
+  }) => {
+    // Spec section 5: "Modal zeigt Initialwerte"
+    try {
+      await adminApi.put('/admin/settings/vacation_approval_required', { value: 'true' });
+    } catch {
+      test.skip();
+      return;
+    }
+
+    const startDate = weekdayFromNow(54);
+    const uniqueNote = `E2E prefill ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    try {
+      await createVacationRequest({
+        date: startDate,
+        hours: 7,
+        absence_type: 'training',
+        note: uniqueNote,
+      });
+    } catch {
+      try { await adminApi.put('/admin/settings/vacation_approval_required', { value: 'false' }); } catch {}
+      test.skip();
+      return;
+    }
+
+    await employeePage.goto('/absences');
+    await employeePage.waitForLoadState('networkidle');
+    await employeePage.getByRole('button', { name: /Meine Anträge/ }).click();
+    await employeePage.waitForLoadState('networkidle');
+
+    const card = employeePage.locator('div.bg-white').filter({ hasText: uniqueNote }).first();
+    await expect(card).toBeVisible({ timeout: 5000 });
+    await card.getByRole('button', { name: 'Antrag bearbeiten' }).click();
+
+    const dialog = employeePage.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // All four user-facing fields must reflect the existing request.
+    await expect(dialog.locator('input[type="date"]').first()).toHaveValue(startDate);
+    await expect(dialog.locator('input[type="number"]').first()).toHaveValue('7');
+    await expect(dialog.locator('select').first()).toHaveValue('training');
+    await expect(dialog.locator('input[type="text"]').first()).toHaveValue(uniqueNote);
+
+    await dialog.getByRole('button', { name: 'Abbrechen' }).click();
+    try { await adminApi.put('/admin/settings/vacation_approval_required', { value: 'false' }); } catch {}
+  });
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "axios": "^1.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.4.3",
+  "version": "1.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/VacationRequestEditModal.tsx
+++ b/frontend/src/components/VacationRequestEditModal.tsx
@@ -4,6 +4,11 @@ import apiClient from '../api/client';
 import { useToast } from '../contexts/ToastContext';
 import { getErrorMessage } from '../utils/errorMessage';
 import { parseHours } from '../utils/formatters';
+import { ABSENCE_TYPE_LABELS, type AbsenceType } from '../constants/absenceTypes';
+
+const EDITABLE_ABSENCE_TYPES: ReadonlyArray<Exclude<AbsenceType, 'sick'>> = [
+  'vacation', 'training', 'overtime', 'other',
+];
 
 interface VacationRequest {
   id: string;
@@ -54,13 +59,28 @@ export default function VacationRequestEditModal({
     e.preventDefault();
     setSubmitting(true);
     try {
-      await apiClient.patch(endpoint, {
-        date,
-        end_date: isDateRange && endDate ? endDate : null,
-        hours,
-        absence_type: type,
-        note: note || null,
-      });
+      // Send only fields that actually changed. The backend's
+      // model_fields_set distinguishes "absent" from "null", so a PATCH
+      // that omits unchanged fields keeps the audit-row diff clean and
+      // avoids spurious updates when the user clears+retypes the same
+      // value.
+      const body: Record<string, unknown> = {};
+      if (date !== request.date) body.date = date;
+      const newEndDate = isDateRange && endDate ? endDate : null;
+      if (newEndDate !== (request.end_date ?? null)) body.end_date = newEndDate;
+      if (hours !== Number(request.hours)) body.hours = hours;
+      if (type !== (request.absence_type ?? 'vacation')) body.absence_type = type;
+      const newNote = note || null;
+      if (newNote !== (request.note ?? null)) body.note = newNote;
+
+      if (Object.keys(body).length === 0) {
+        // Nothing changed — just close the modal with a neutral message.
+        toast.success('Keine Änderungen');
+        onSaved();
+        return;
+      }
+
+      await apiClient.patch(endpoint, body);
       toast.success('Antrag aktualisiert');
       onSaved();
     } catch (err) {
@@ -71,7 +91,7 @@ export default function VacationRequestEditModal({
   };
 
   return (
-    <div className="fixed inset-0 z-10000 flex items-center justify-center">
+    <div className="fixed inset-0 z-modal flex items-center justify-center">
       <div
         className="absolute inset-0 bg-black/50"
         onClick={onClose}
@@ -120,6 +140,7 @@ export default function VacationRequestEditModal({
                   value={date}
                   onChange={(e) => setDate(e.target.value)}
                   required
+                  autoFocus
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
                 />
               </div>
@@ -146,10 +167,9 @@ export default function VacationRequestEditModal({
                   onChange={(e) => setType(e.target.value)}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
                 >
-                  <option value="vacation">Urlaub</option>
-                  <option value="training">Fortbildung (außer Haus)</option>
-                  <option value="overtime">Überstundenausgleich</option>
-                  <option value="other">Sonstiges</option>
+                  {EDITABLE_ABSENCE_TYPES.map((t) => (
+                    <option key={t} value={t}>{ABSENCE_TYPE_LABELS[t]}</option>
+                  ))}
                 </select>
               </div>
               <div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,6 +23,12 @@
 
   --radius-2xl: 16px;
   --radius-xl: 12px;
+
+  /* Stacking context tokens — keep modals above ad-hoc dropdowns/tooltips
+     used elsewhere in the app. The numeric value is unchanged from the
+     ad-hoc `z-10000` literal that was inlined in VacationRequestEditModal
+     before this token was formalised. */
+  --z-modal: 10000;
 }
 
 /*

--- a/frontend/src/pages/AbsenceCalendarPage.tsx
+++ b/frontend/src/pages/AbsenceCalendarPage.tsx
@@ -17,6 +17,7 @@ import VacationRequestEditModal from '../components/VacationRequestEditModal';
 
 interface VacationRequest {
   id: string;
+  user_id?: string;
   date: string;
   end_date?: string;
   hours: number;
@@ -26,6 +27,10 @@ interface VacationRequest {
   status: string;
   rejection_reason?: string;
   created_at: string;
+  last_modified_by?: string;
+  last_modified_at?: string;
+  last_modifier_first_name?: string;
+  last_modifier_last_name?: string;
 }
 
 const vrStatusConfig = {
@@ -371,6 +376,14 @@ export default function AbsenceCalendarPage() {
                         {' · '}{vr.days != null ? `${vr.days} Tag${vr.days !== 1 ? 'e' : ''}` : `${vr.hours} h/Tag`}
                       </p>
                       {vr.note && <p className="text-sm text-gray-500 mt-0.5">{vr.note}</p>}
+                      {vr.last_modified_by && vr.user_id && vr.last_modified_by !== vr.user_id && vr.last_modified_at && (
+                        <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-2 py-1 mt-2 inline-block">
+                          Bearbeitet von {vr.last_modifier_first_name ?? 'Admin'}
+                          {vr.last_modifier_last_name ? ` ${vr.last_modifier_last_name}` : ''}
+                          {' am '}
+                          {format(new Date(vr.last_modified_at), 'dd.MM.yyyy HH:mm')}
+                        </p>
+                      )}
                     </div>
                     {(() => {
                       const todayStr = format(new Date(), 'yyyy-MM-dd');

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.4.3"
+APP_VERSION="1.4.4"
 PYTHON_VERSION="3.13.3"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 PYTHON_STANDALONE_TAG="20250529"


### PR DESCRIPTION
## Summary

Independent security / code-quality / DSGVO audit of `feature/vacation-request-edit` (already on master) surfaced gaps the internal review missed. This PR closes them in three priority tiers and bumps the patch version.

## Changes

### P1 — Pre-merge security
- Pydantic `extra="forbid"` on `VacationRequestUpdate` (mass-assignment guard)
- `hours` field bounded `ge=0, le=24` (block negative / inf)
- `|` escaped in audit-text helper (CWE-117 log-injection)
- `purge_expired_vacation_audit_logs()` cron — DSGVO Art. 5(1)(e) retention 730d, wired into `superadmin.cron_trial_check`
- 3 Postgres-only RLS isolation tests for `vacation_request_edit` audit rows
- Modal `autoFocus` + `ABSENCE_TYPE_LABELS` reuse

### P2 — Sprint
- **Migration 038** — `vacation_requests.last_modified_by` + `last_modified_at` (DSGVO transparency, § 26 BDSG)
- Frontend: amber badge ``Bearbeitet von <Admin> am …`` on MA card when admin edited
- Refactor: `apply_vacation_request_patch` helper (eliminates ~85% MA/Admin dup)
- Rate-limit `60/minute` on both PATCH endpoints
- `.strip()` + `round(hours, 2)` no-op normalisation (prevents audit flooding)
- E2E: ``edit modal shows initial values`` (spec #5)

### P3 — Backlog
- `withdraw_vacation_request`: `with_for_update` + tenant filter
- Helper: holiday-aware budget calc (consistent with approve flow)
- Modal: PATCH only changed fields
- `_format_vacation_request_audit_text` → public name
- `--z-modal: 10000` Tailwind theme token

## Test plan

- [x] backend pytest: 25 vacation-edit cases (16 → 25 with 9 new)
- [x] backend pytest: 18 lifecycle cases (15 → 18 with 3 new audit-purge)
- [x] Postgres RLS: 21 cases (18 → 21 with 3 new audit-isolation)
- [x] cross-tenant API: 12/12 green
- [x] Frontend tsc + vitest (42) + eslint (0 errors) + production build
- [x] E2E (vacation specs): 13 passed incl. modal-prefill, 2 flaky-passed-on-retry, 1 unrelated pre-existing fail (`create multi-day absence`)

## Out of scope (separate issues)

- #119 DSGVO Art. 15 self-service export
- #120 403→404 unification across foreign-resource endpoints
- #121 Audit-log tamper-resistance (HMAC chain / append-only role)

## Migration

`038_vr_last_modified.py` — additive, two nullable columns + FK with `ondelete=SET NULL`. Downgradeable.

## Pre-existing failures (not caused by this PR)

- `test_year_closing_invalid_year` — encoding bug in non-ASCII assertion, fails on master too

🤖 Generated with [Claude Code](https://claude.com/claude-code)