### PR TITLE
feat: Bootstrap-Admin ohne Zeitzaehlung + rollenspezifisches Onboarding

### DIFF
--- a/backend/alembic/versions/2026_05_26_0900-039_user_onboarding.py
+++ b/backend/alembic/versions/2026_05_26_0900-039_user_onboarding.py
@@ -1,0 +1,36 @@
+"""Add users.onboarding_completed_at for the first-login onboarding tour.
+
+NULL = onboarding not yet seen -> the frontend shows a role-specific welcome
+modal on first login, then POSTs /auth/onboarding/complete to set the
+timestamp (so it does not reappear on other devices / future logins).
+
+Existing users are backfilled to "completed" (now) so upgrading an install
+that has been in use for months does not suddenly interrupt everyone — only
+genuinely new accounts (incl. the bootstrap admin on a fresh install, which is
+created after migrations run) start with NULL and see the onboarding.
+
+Revision ID: 039_user_onboarding
+Revises: 038_vr_last_modified
+Create Date: 2026-05-26
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '039_user_onboarding'
+down_revision = '038_vr_last_modified'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'users',
+        sa.Column('onboarding_completed_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    # Bestandsnutzer nicht mit dem Onboarding belaestigen -> als "gesehen" markieren.
+    op.execute("UPDATE users SET onboarding_completed_at = now() WHERE onboarding_completed_at IS NULL")
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'onboarding_completed_at')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -104,6 +104,11 @@ async def lifespan(app: FastAPI):
                     weekly_hours=40.0,
                     vacation_days=30,
                     is_active=True,
+                    # Bootstrap-Admin ist ein technisches Konto, kein zeiterfasster
+                    # Mitarbeiter -> aus der Zeitzaehlung nehmen (keine "Buchung
+                    # fehlt"-Warnungen, nicht im Team-Fehlbuchungs-Widget).
+                    # Per Benutzerverwaltung jederzeit umstellbar.
+                    track_hours=False,
                     tenant_id=default_tenant_id,
                 )
                 db.add(admin)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -49,6 +49,7 @@ class User(Base):
     last_work_day = Column(Date, nullable=True)   # Letzter Arbeitstag
     profile_picture = Column(Text, nullable=True)  # Base64 data URI
     deactivated_at = Column(DateTime(timezone=True), nullable=True)  # Grace-Period-Start bei Deaktivierung
+    onboarding_completed_at = Column(DateTime(timezone=True), nullable=True)  # NULL = Onboarding (Erst-Login-Tour) noch nicht gesehen
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -365,6 +365,25 @@ def update_calendar_color(
     return UserResponse.model_validate(current_user)
 
 
+@router.post("/onboarding/complete", response_model=UserResponse)
+def complete_onboarding(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """Markiert die Erst-Login-Onboarding-Tour als gesehen (idempotent).
+
+    NULL onboarding_completed_at = noch nicht gesehen -> Frontend zeigt das
+    rollenspezifische Welcome-Modal. Nach Bestaetigung ruft das Frontend diesen
+    Endpoint, sodass es bei kuenftigen Logins (auch auf anderen Geraeten) nicht
+    erneut erscheint.
+    """
+    if current_user.onboarding_completed_at is None:
+        current_user.onboarding_completed_at = datetime.now(timezone.utc)
+        db.commit()
+        db.refresh(current_user)
+    return UserResponse.model_validate(current_user)
+
+
 @router.put("/profile", response_model=UserResponse)
 def update_profile(
     profile_data: UpdateProfileRequest,

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -23,6 +23,13 @@ def _get_missing_bookings_for_user(db: Session, user: User, tenant_id=None) -> L
     to is_holiday() — CLAUDE.md mandates passing tenant_id on every
     holiday lookup (multi-tenant correctness).
     """
+    # Nutzer ohne Soll/Ist-Zeiterfassung (z.B. das technische Bootstrap-Admin-
+    # Konto, track_hours=False) werden nicht zur Buchung erwartet -> keine
+    # "Buchung fehlt"-Warnungen. Das Team-Widget filtert track_hours bereits in
+    # der Query; dieser Guard deckt das eigene Dashboard + /missing-bookings ab.
+    if not user.track_hours:
+        return []
+
     today = today_local()
     if tenant_id is None:
         tenant_id = user.tenant_id

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -110,6 +110,7 @@ class UserResponse(UserBase):
     totp_enabled: bool = False  # F-019: 2FA status
     profile_picture: Optional[str] = None
     deactivated_at: Optional[datetime] = None  # Grace-Period-Start
+    onboarding_completed_at: Optional[datetime] = None  # NULL = Onboarding noch nicht gesehen
     created_at: datetime
     suggested_vacation_days: int
     vacation_carryover_deadline: Optional[date] = None

--- a/backend/tests/test_dashboard_track_hours.py
+++ b/backend/tests/test_dashboard_track_hours.py
@@ -1,0 +1,29 @@
+"""Nutzer ohne Soll/Ist-Zeiterfassung (track_hours=False) — z.B. das technische
+Bootstrap-Admin-Konto — duerfen NICHT in der Missing-Bookings-Logik auftauchen
+(keine "Buchung fehlt"-Warnungen auf dem eigenen Dashboard).
+
+Regression-Guard fuer das Feature "Bootstrap-Admin ausserhalb der Zeitzaehlung".
+Der track_hours-Guard greift VOR jedem DB-Zugriff, daher reicht ein In-Memory-
+User ohne Session.
+"""
+from app.models.user import User, UserRole
+from app.routers.dashboard import _get_missing_bookings_for_user
+
+
+def _make_admin(track_hours: bool) -> User:
+    return User(
+        username="admin",
+        email="admin@praxis.local",
+        password_hash="x",
+        first_name="Admin",
+        last_name="DerAdmin",
+        role=UserRole.ADMIN,
+        weekly_hours=40,
+        track_hours=track_hours,
+    )
+
+
+def test_non_tracking_user_has_no_missing_bookings():
+    # track_hours=False short-circuitet vor jedem DB-Query -> db darf None sein.
+    admin = _make_admin(track_hours=False)
+    assert _get_missing_bookings_for_user(None, admin) == []

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -401,6 +401,29 @@ class TestAuthMe:
         assert resp.status_code in (401, 403)
 
 
+class TestOnboardingComplete:
+    """POST /api/auth/onboarding/complete — Erst-Login-Onboarding als gesehen markieren."""
+
+    def test_complete_sets_timestamp(self, employee_client):
+        """Markiert das Onboarding als gesehen; /me spiegelt den Zeitstempel."""
+        resp = employee_client.post("/api/auth/onboarding/complete")
+        assert resp.status_code == 200
+        assert resp.json()["onboarding_completed_at"] is not None
+        me = employee_client.get("/api/auth/me").json()
+        assert me["onboarding_completed_at"] is not None
+
+    def test_complete_is_idempotent(self, employee_client):
+        """Mehrfaches Aufrufen aendert den ersten Zeitstempel nicht."""
+        first = employee_client.post("/api/auth/onboarding/complete").json()["onboarding_completed_at"]
+        second = employee_client.post("/api/auth/onboarding/complete").json()["onboarding_completed_at"]
+        assert first is not None and second == first
+
+    def test_complete_requires_auth(self, unauthenticated_client):
+        """Ohne Token kein Zugriff."""
+        resp = unauthenticated_client.post("/api/auth/onboarding/complete")
+        assert resp.status_code in (401, 403)
+
+
 class TestAuthLogout:
     """POST /api/auth/logout"""
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -31,6 +31,7 @@ import {
 import HelpPanel from './HelpPanel';
 import StampWidget from './StampWidget';
 import { DocDrawer } from './DocDrawer';
+import OnboardingModal from './OnboardingModal';
 
 export default function Layout() {
   const { user, logout } = useAuthStore();
@@ -475,6 +476,8 @@ export default function Layout() {
         isAdmin={user?.role === 'admin'}
         initialTab={drawerTab}
       />
+
+      <OnboardingModal />
     </div>
   );
 }

--- a/frontend/src/components/OnboardingModal.tsx
+++ b/frontend/src/components/OnboardingModal.tsx
@@ -1,0 +1,129 @@
+import { useState, useEffect, useCallback, type ComponentType } from 'react';
+import {
+  LayoutDashboard, Users, FileEdit, FileText,
+  Clock, Calendar, User as UserIcon, BookOpen,
+} from 'lucide-react';
+import { useAuthStore } from '../stores/authStore';
+import apiClient from '../api/client';
+
+interface Feature {
+  icon: ComponentType<{ size?: number | string; className?: string }>;
+  title: string;
+  desc: string;
+}
+
+const ADMIN_FEATURES: Feature[] = [
+  { icon: LayoutDashboard, title: 'Admin-Dashboard', desc: 'Überblick über Team-Stunden, Salden und fehlende Buchungen.' },
+  { icon: Users, title: 'Benutzerverwaltung', desc: 'Mitarbeiter anlegen, Arbeitszeiten und Urlaubskonten pflegen.' },
+  { icon: FileEdit, title: 'Änderungsanträge', desc: 'Korrekturen der Mitarbeiter prüfen und freigeben.' },
+  { icon: FileText, title: 'Berichte', desc: 'Monats-/Jahresauswertungen ansehen und exportieren.' },
+];
+
+const EMPLOYEE_FEATURES: Feature[] = [
+  { icon: Clock, title: 'Zeiterfassung', desc: 'Ein- und ausstempeln, Arbeitszeiten erfassen und ansehen.' },
+  { icon: Calendar, title: 'Abwesenheiten', desc: 'Urlaub und Krankheit beantragen und im Kalender sehen.' },
+  { icon: FileEdit, title: 'Änderungsanträge', desc: 'Korrekturen an deinen Einträgen beantragen.' },
+  { icon: UserIcon, title: 'Profil', desc: 'Deine Daten, Kalenderfarbe und Passwort verwalten.' },
+];
+
+/**
+ * Rollenspezifisches Welcome-Onboarding beim allerersten Login.
+ *
+ * Sichtbar, solange der eingeloggte Nutzer `onboarding_completed_at == null`
+ * hat. Beim Schließen (Button/Escape/Overlay) wird `POST /auth/onboarding/
+ * complete` gerufen, das den Zeitstempel setzt — danach erscheint es nicht
+ * wieder (auch nicht auf anderen Geräten). Selbst-entscheidend: einfach in
+ * Layout mounten, kein Prop nötig.
+ */
+export default function OnboardingModal() {
+  const { user, setUser } = useAuthStore();
+  const [closed, setClosed] = useState(false);
+
+  const show = !!user && !closed && !user.onboarding_completed_at;
+
+  const complete = useCallback(async () => {
+    setClosed(true); // optimistisch sofort ausblenden
+    const current = useAuthStore.getState().user;
+    if (!current) return;
+    try {
+      const resp = await apiClient.post('/auth/onboarding/complete');
+      setUser({ ...current, ...resp.data }); // Flag persistieren -> kein erneutes Anzeigen
+    } catch {
+      // Best-effort: diese Sitzung ausgeblendet; beim nächsten Login erneuter Versuch.
+    }
+  }, [setUser]);
+
+  useEffect(() => {
+    if (!show) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') void complete(); };
+    document.addEventListener('keydown', onKey);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = '';
+    };
+  }, [show, complete]);
+
+  if (!show) return null;
+
+  const isAdmin = user!.role === 'admin';
+  const features = isAdmin ? ADMIN_FEATURES : EMPLOYEE_FEATURES;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/40" onClick={() => void complete()} aria-hidden="true" />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Willkommen bei PraxisZeit"
+        className="relative z-10 bg-white rounded-xl shadow-2xl w-full max-w-lg flex flex-col max-h-[90vh]"
+      >
+        {/* Header */}
+        <div className="px-6 pt-6 pb-4 border-b border-gray-100">
+          <h2 className="text-xl font-semibold text-gray-900">Willkommen bei PraxisZeit 👋</h2>
+          <p className="mt-1 text-sm text-gray-500">
+            {isAdmin
+              ? `Schön, dass du da bist, ${user!.first_name}! Als Administrator hast du diese Bereiche:`
+              : `Schön, dass du da bist, ${user!.first_name}! Das kannst du hier tun:`}
+          </p>
+        </div>
+
+        {/* Feature-Liste */}
+        <div className="px-6 py-4 space-y-3 overflow-y-auto">
+          {features.map((f) => (
+            <div key={f.title} className="flex items-start gap-3">
+              <div className="shrink-0 w-9 h-9 rounded-lg bg-blue-50 text-blue-600 flex items-center justify-center">
+                <f.icon size={18} />
+              </div>
+              <div>
+                <div className="text-sm font-medium text-gray-900">{f.title}</div>
+                <div className="text-sm text-gray-500 leading-snug">{f.desc}</div>
+              </div>
+            </div>
+          ))}
+
+          <div className="flex items-start gap-3 pt-1">
+            <div className="shrink-0 w-9 h-9 rounded-lg bg-gray-50 text-gray-500 flex items-center justify-center">
+              <BookOpen size={18} />
+            </div>
+            <div className="text-sm text-gray-500 leading-snug self-center">
+              {isAdmin ? 'Admin-Handbuch' : 'Handbuch & Cheat-Sheet'} findest du jederzeit unten links in der Seitenleiste.
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-gray-100 flex justify-end shrink-0">
+          <button
+            onClick={() => void complete()}
+            autoFocus
+            className="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
+          >
+            Los geht's
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -17,6 +17,7 @@ interface User {
   is_active: boolean;
   totp_enabled: boolean;
   profile_picture?: string | null;
+  onboarding_completed_at?: string | null;  // NULL = Onboarding noch nicht gesehen
   created_at: string;
   use_daily_schedule: boolean;
   hours_monday: number | null;


### PR DESCRIPTION
@
Zwei UX-Verbesserungen für den Erst-Install:

## 1. Bootstrap-Admin außerhalb der Zeitzählung
Das beim Erst-Install angelegte technische Admin-Konto erschien mit „Buchung fehlt"-Warnungen + im Team-Fehlbuchungs-Widget.
- `main.py`: Bootstrap-Admin mit `track_hours=False`
- `dashboard.py`: `_get_missing_bookings_for_user` überspringt `track_hours=False`-Nutzer (eigenes Dashboard; Team-Widget filterte bereits)
- Keine Migration (Feld existierte; in der Benutzerverwaltung editierbar → Bestands-Admins per UI umstellbar)

## 2. Rollenspezifisches Onboarding beim ersten Login
- **Backend:** `User.onboarding_completed_at` + Migration `039` (backfillt Bestandsnutzer → nur neue Konten sehen es) + `UserResponse`-Feld + `POST /api/auth/onboarding/complete` (idempotent)
- **Frontend:** `OnboardingModal` (Admin- vs. Mitarbeiter-Inhalt) in `Layout` gemountet; Schließen → Endpoint → erscheint nie wieder (geräteübergreifend)

## Tests / Verifikation
- `test_dashboard_track_hours.py` (track_hours=False → keine Missing-Bookings)
- `TestOnboardingComplete` in `test_endpoints.py` (setzt Flag, idempotent, Auth)
- Frontend `tsc --noEmit`: 0 Fehler; Backend `py_compile`: ok (pytest läuft in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@