### PR TITLE
fix(review): Medium/Low-Findings + E2E-Härtung (Review 2026-05-28)

### DIFF
--- a/backend/app/routers/admin_change_requests.py
+++ b/backend/app/routers/admin_change_requests.py
@@ -160,7 +160,12 @@ def review_change_request(
                     detail="Ein Zeiteintrag mit diesem Datum und dieser Startzeit existiert bereits.",
                 )
         elif cr.request_type == ChangeRequestType.UPDATE:
-            entry = db.query(TimeEntry).filter(TimeEntry.id == cr.time_entry_id).first()
+            # N-3: lock the target entry for the duration of the approval txn,
+            # matching the update_time_entry path — prevents a concurrent admin
+            # edit from racing the re-validation/materialisation below.
+            entry = db.query(TimeEntry).filter(
+                TimeEntry.id == cr.time_entry_id
+            ).with_for_update().first()
             if not entry:
                 raise HTTPException(status_code=404, detail="Zeiteintrag nicht mehr vorhanden")
             # Check for unique constraint violation on date/start_time change
@@ -178,7 +183,12 @@ def review_change_request(
                     )
 
         elif cr.request_type == ChangeRequestType.DELETE:
-            entry = db.query(TimeEntry).filter(TimeEntry.id == cr.time_entry_id).first()
+            # N-3: lock the target entry for the duration of the approval txn,
+            # matching the update_time_entry path — prevents a concurrent admin
+            # edit from racing the re-validation/materialisation below.
+            entry = db.query(TimeEntry).filter(
+                TimeEntry.id == cr.time_entry_id
+            ).with_for_update().first()
             if not entry:
                 raise HTTPException(status_code=404, detail="Zeiteintrag nicht mehr vorhanden")
 
@@ -510,9 +520,11 @@ def bulk_review_change_requests(
             ))
             succeeded += 1
         except HTTPException as exc:
-            # review_change_request already rolled back its transaction on
-            # raising; continue with the next item so the admin doesn't have
-            # to retry a 50-item batch after one stale row.
+            # N-4: each successful review_change_request commits before
+            # returning, so this rollback only discards the FAILED item's
+            # partial (un-committed) flush — earlier successes are already
+            # persisted. Continue so the admin doesn't have to retry a 50-item
+            # batch after one stale row.
             db.rollback()
             items.append(ChangeRequestBulkReviewItemResult(
                 request_id=request_id,

--- a/backend/app/routers/company_closures.py
+++ b/backend/app/routers/company_closures.py
@@ -195,7 +195,7 @@ def create_closure(
     Automatically creates vacation absences for all active employees.
     """
     if data.end_date < data.start_date:
-        raise HTTPException(status_code=400, detail="Enddatum muss nach dem Startdatum liegen")
+        raise HTTPException(status_code=400, detail="Enddatum darf nicht vor dem Startdatum liegen")
 
     # Create closure record
     closure = CompanyClosure(
@@ -264,7 +264,7 @@ def update_closure(
       absences is updated to match the new flag (#145).
     """
     if data.end_date < data.start_date:
-        raise HTTPException(status_code=400, detail="Enddatum muss nach dem Startdatum liegen")
+        raise HTTPException(status_code=400, detail="Enddatum darf nicht vor dem Startdatum liegen")
 
     # F-026: tenant-scoped lookup.
     closure = db.query(CompanyClosure).filter(

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -8,7 +8,7 @@ from openpyxl import Workbook
 from openpyxl.styles import Font, PatternFill, Alignment, Border, Side
 from openpyxl.utils import get_column_letter
 from app.models import User, TimeEntry, Absence, PublicHoliday, AbsenceType
-from app.services import calculation_service
+from app.services import calculation_service, special_days_service
 from app.services.arbzg_utils import is_night_work
 from app.services.date_filters import date_in_year, date_in_month, date_in_year_up_to_month
 from app.config import settings
@@ -119,6 +119,12 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
     ).all()
     holidays_by_date = {holiday.date: holiday for holiday in holidays}
 
+    # #146: configurable 24./31.12. handling — load once, apply per working day
+    # so the exported Soll column matches get_monthly_target() (half_day → ×0.5,
+    # free → ×0). N-1: previously the export showed the full daily target on a
+    # configured half/free day, diverging from the calculated monthly Soll.
+    special_day_config = special_days_service.get_special_day_config(db, user.tenant_id, year)
+
     # German weekday names
     weekday_names = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"]
 
@@ -186,6 +192,11 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
         # Per-day target using historical weekly hours
         weekly_hours = calculation_service.get_weekly_hours_for_date(db, user, current_date)
         daily_target = calculation_service.get_daily_target_for_date(user, current_date, weekly_hours=weekly_hours)
+        # #146: apply the special-day factor (only the working-day branch below
+        # consumes daily_target; the weekend/holiday/absence branches hardcode 0).
+        _sd_factor = special_days_service.special_day_target_factor(current_date, special_day_config)
+        if _sd_factor is not None:
+            daily_target = daily_target * _sd_factor
 
         # Target hours + Abwesenheit (col 9) – korrekte Labels für §9/§10/§6
         if is_weekend:
@@ -226,7 +237,8 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
                     "sick": "Krank",
                     "training": "Fortbildung",
                     "overtime": "Überstundenausgleich",
-                    "other": "Sonstiges"
+                    "other": "Sonstiges",
+                    "paid_leave": "Bez. Freistellung"
                 }
                 type_name = absence_type_map.get(absence.type.value, absence.type.value)
                 if absence.note:
@@ -624,6 +636,9 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
     ).all()
     holidays_by_date = {holiday.date: holiday for holiday in holidays}
 
+    # #146: configurable 24./31.12. handling (see _create_employee_sheet). N-1.
+    special_day_config = special_days_service.get_special_day_config(db, user.tenant_id, year)
+
     # German weekday names
     weekday_names = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"]
 
@@ -706,6 +721,9 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
 
         weekly_hours = calculation_service.get_weekly_hours_for_date(db, user, current_date)
         daily_target = calculation_service.get_daily_target_for_date(user, current_date, weekly_hours=weekly_hours)
+        _sd_factor = special_days_service.special_day_target_factor(current_date, special_day_config)
+        if _sd_factor is not None:
+            daily_target = daily_target * _sd_factor
 
         # Target hours + Abwesenheit (col 9) – korrekte Labels für §9/§10/§6
         if is_weekend:
@@ -744,7 +762,8 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
                     "sick": "Krank",
                     "training": "Fortbildung",
                     "overtime": "Überstundenausgleich",
-                    "other": "Sonstiges"
+                    "other": "Sonstiges",
+                    "paid_leave": "Bez. Freistellung"
                 }
                 type_name = absence_type_map.get(absence.type.value, absence.type.value)
                 if absence.note:
@@ -1125,7 +1144,7 @@ def generate_monthly_report_pdf(db: Session, year: int, month: int, include_heal
     # Landscape A4: 297mm − 30mm margins = 267mm usable
     col_widths = [22*mm, 10*mm, 13*mm, 13*mm, 15*mm, 16*mm, 14*mm, 16*mm, 74*mm, 74*mm]
     weekday_names = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"]
-    absence_type_map = {"vacation": "Urlaub", "sick": "Krank", "training": "Fortbildung", "overtime": "Überstundenausgleich", "other": "Sonstiges"}
+    absence_type_map = {"vacation": "Urlaub", "sick": "Krank", "training": "Fortbildung", "overtime": "Überstundenausgleich", "other": "Sonstiges", "paid_leave": "Bez. Freistellung"}
 
     story = []
 
@@ -1170,6 +1189,9 @@ def generate_monthly_report_pdf(db: Session, year: int, month: int, include_heal
             date_in_month(PublicHoliday.date, year, month),
         ).all()
         holidays_by_date = {h.date: h for h in holidays}
+
+        # #146: configurable 24./31.12. handling (see _create_employee_sheet). N-1.
+        special_day_config = special_days_service.get_special_day_config(db, user.tenant_id, year)
 
         # ── Build table ──
         headers = ['Datum', 'WT', 'Von', 'Bis', 'Pause\n(Min)', 'Netto\n(Std)', 'Soll\n(Std)', 'Diff.', 'Abwesenheit', 'Bemerkung']
@@ -1222,6 +1244,9 @@ def generate_monthly_report_pdf(db: Session, year: int, month: int, include_heal
             # Per-day target using historical weekly hours
             weekly_h = calculation_service.get_weekly_hours_for_date(db, user, cur)
             daily_target = calculation_service.get_daily_target_for_date(user, cur, weekly_hours=weekly_h)
+            _sd_factor = special_days_service.special_day_target_factor(cur, special_day_config)
+            if _sd_factor is not None:
+                daily_target = daily_target * _sd_factor
 
             if is_weekend:
                 target = Decimal('0.00')

--- a/backend/app/services/ods_export_service.py
+++ b/backend/app/services/ods_export_service.py
@@ -17,7 +17,7 @@ from odf.text import P
 from odf.table import Table, TableColumn, TableRow, TableCell
 
 from app.models import User, TimeEntry, Absence, PublicHoliday, AbsenceType
-from app.services import calculation_service
+from app.services import calculation_service, special_days_service
 from app.services.arbzg_utils import is_night_work
 from app.services.date_filters import date_in_month, date_in_year
 
@@ -37,6 +37,7 @@ ABSENCE_LABELS = {
     "training": "Fortbildung",
     "overtime": "Überstundenausgleich",
     "other": "Sonstiges",
+    "paid_leave": "Bez. Freistellung",
 }
 
 
@@ -171,6 +172,9 @@ def _monthly_sheet(doc, db, user, year, month, bold, normal, include_health_data
         ).all()
     }
 
+    # #146: configurable 24./31.12. handling (see export_service N-1).
+    special_day_config = special_days_service.get_special_day_config(db, user.tenant_id, year)
+
     total_net = Decimal("0.00")
     total_target = Decimal("0.00")
     night_work_count = 0
@@ -217,6 +221,9 @@ def _monthly_sheet(doc, db, user, year, month, bold, normal, include_health_data
         # Per-day target using historical weekly hours
         weekly_hours = calculation_service.get_weekly_hours_for_date(db, user, current_date)
         daily_target = calculation_service.get_daily_target_for_date(user, current_date, weekly_hours=weekly_hours)
+        _sd_factor = special_days_service.special_day_target_factor(current_date, special_day_config)
+        if _sd_factor is not None:
+            daily_target = daily_target * _sd_factor
 
         # Soll + Abwesenheit + Bemerkung
         if is_weekend:
@@ -472,6 +479,9 @@ def _yearly_employee_sheet(doc, db, user, year, bold):
         ).all()
     }
 
+    # #146: configurable 24./31.12. handling (see export_service N-1).
+    special_day_config = special_days_service.get_special_day_config(db, user.tenant_id, year)
+
     current_date = date(year, 1, 1)
     end_date = date(year, 12, 31)
     night_work_count = 0
@@ -485,6 +495,9 @@ def _yearly_employee_sheet(doc, db, user, year, bold):
         day_entries = entries_by_date.get(current_date, [])
         weekly_hours = calculation_service.get_weekly_hours_for_date(db, user, current_date)
         daily_target = calculation_service.get_daily_target_for_date(user, current_date, weekly_hours=weekly_hours)
+        _sd_factor = special_days_service.special_day_target_factor(current_date, special_day_config)
+        if _sd_factor is not None:
+            daily_target = daily_target * _sd_factor
 
         # Night work check (§6 / §2 Abs. 4 ArbZG)
         is_night_wrk = any(

--- a/backend/tests/test_break_waiver.py
+++ b/backend/tests/test_break_waiver.py
@@ -319,6 +319,85 @@ class TestBreakWaiverWithApproval:
         assert entry.break_minutes == 0
         assert str(cr.time_entry_id) == str(entry.id)
 
+    def test_admin_cannot_approve_own_break_waiver_cr(self, db, admin, admin_client):
+        """SEC-E (regression): the 4-eyes guard forbids an admin approving their
+        OWN documented break-exception. Previously only the cross-user happy
+        path was covered."""
+        cr = ChangeRequest(
+            user_id=admin.id,  # the approving admin is also the requester
+            tenant_id=DEFAULT_TENANT_ID,
+            request_type=ChangeRequestType.CREATE,
+            entry_kind="time_entry",
+            status=ChangeRequestStatus.PENDING,
+            proposed_date=date.today(),
+            proposed_start_time=time(8, 0),
+            proposed_end_time=time(15, 30),
+            proposed_break_minutes=0,
+            break_waiver_reason="Selbst dokumentiert",
+            reason="Selbst dokumentiert",
+        )
+        db.add(cr)
+        db.commit()
+        db.refresh(cr)
+
+        resp = admin_client.post(
+            f"/api/admin/change-requests/{cr.id}/review",
+            json={"action": "approve"},
+        )
+        assert resp.status_code == 403, resp.text
+        assert "selbst genehmigt" in resp.json()["detail"].lower()
+
+        # CR stays pending, no entry materialised.
+        db.refresh(cr)
+        assert cr.status == ChangeRequestStatus.PENDING
+        assert db.query(TimeEntry).filter(TimeEntry.user_id == admin.id).count() == 0
+
+    def test_approval_revalidates_section3_against_current_db(self, db, employee, admin, admin_client):
+        """C-1 (regression, TOCTOU): a CREATE CR that was valid in isolation must
+        be rejected at approval when other same-day entries have since pushed the
+        day over the §3 10h hard cap. The §3 ceiling is absolute and unwaivable."""
+        # An entry already exists on the day: 08:00–16:00, 30 min break → 7.5h net.
+        existing = TimeEntry(
+            user_id=employee.id,
+            tenant_id=DEFAULT_TENANT_ID,
+            date=date.today(),
+            start_time=time(8, 0),
+            end_time=time(16, 0),
+            break_minutes=30,
+        )
+        db.add(existing)
+        db.commit()
+
+        # Pending CREATE CR proposing a SECOND entry 16:30–22:00 (5.5h, no break).
+        # In isolation it is fine; combined with the existing 7.5h the day is 13h > 10h.
+        cr = ChangeRequest(
+            user_id=employee.id,
+            tenant_id=DEFAULT_TENANT_ID,
+            request_type=ChangeRequestType.CREATE,
+            entry_kind="time_entry",
+            status=ChangeRequestStatus.PENDING,
+            proposed_date=date.today(),
+            proposed_start_time=time(16, 30),
+            proposed_end_time=time(22, 0),
+            proposed_break_minutes=0,
+            reason="Zweiter Block",
+        )
+        db.add(cr)
+        db.commit()
+        db.refresh(cr)
+
+        resp = admin_client.post(
+            f"/api/admin/change-requests/{cr.id}/review",
+            json={"action": "approve"},
+        )
+        assert resp.status_code == 422, resp.text
+        assert "§3" in resp.json()["detail"]
+
+        # CR stays pending; the proposed entry was NOT materialised.
+        db.refresh(cr)
+        assert cr.status == ChangeRequestStatus.PENDING
+        assert db.query(TimeEntry).filter(TimeEntry.user_id == employee.id).count() == 1
+
 
 def _make_today_entry(db, user, break_minutes=45):
     """A compliant >6h entry for today (employees may only edit today's entries)."""

--- a/backend/tests/test_native_pg_lifecycle.py
+++ b/backend/tests/test_native_pg_lifecycle.py
@@ -20,7 +20,19 @@ from unittest.mock import patch
 import pytest
 
 # --- Load the hyphenated orchestrator script as a module ----------------------
+# Resolves to <repo>/praxiszeit-server.py on the host (backend/tests/ → repo
+# root). The docker backend image only copies the backend/ build context to
+# /app, so the orchestrator script is NOT present there — skip the whole module
+# rather than erroring 44× when it is unreachable (e.g. `docker compose exec
+# backend pytest`, which local-ci uses). These tests run on the host / native
+# build env, mirroring how test_tenant_rls/test_concurrency are env-scoped.
 _SERVER_PATH = Path(__file__).resolve().parents[2] / "praxiszeit-server.py"
+
+pytestmark = pytest.mark.skipif(
+    not _SERVER_PATH.exists(),
+    reason=f"praxiszeit-server.py not reachable at {_SERVER_PATH} "
+    "(native orchestrator not present, e.g. inside the docker backend container)",
+)
 
 
 @pytest.fixture(scope="module")

--- a/backend/tests/test_special_days.py
+++ b/backend/tests/test_special_days.py
@@ -249,6 +249,48 @@ def test_vacation_deduction_dates_excludes_weekend_and_holiday(db, test_user):
 
 
 # ---------------------------------------------------------------------------
+# N-1: the configured factor must reach the §16 export Soll column (xlsx/ods),
+# not just get_monthly_target — otherwise the export documentation diverges
+# from the calculated monthly target on a configured 24./31.12.
+# ---------------------------------------------------------------------------
+
+def _xlsx_soll_for_december_day(wb, sheet_name: str, day: int):
+    """Return the 'Soll (Std)' cell (column 7) for the given Dec-2025 day."""
+    ws = wb[sheet_name[:31]]
+    for row in ws.iter_rows(min_row=5):
+        c0 = row[0].value
+        if hasattr(c0, "month") and c0.year == 2025 and c0.month == 12 and c0.day == day:
+            return row[6].value
+    return None
+
+
+def test_monthly_xlsx_export_soll_reflects_half_day(db, test_user):
+    from openpyxl import load_workbook
+    from app.services.export_service import generate_monthly_report
+
+    _set_special_day(db, "special_day_dec24", "half_day")
+    wb = load_workbook(generate_monthly_report(db, 2025, 12))
+    sheet = f"{test_user.last_name} {test_user.first_name}"
+
+    # 24.12. (half_day, Wed) → 4.0; 17.12. (ordinary Wed) → 8.0 (sanity).
+    assert _xlsx_soll_for_december_day(wb, sheet, 24) == 4.0
+    assert _xlsx_soll_for_december_day(wb, sheet, 17) == 8.0
+
+
+def test_monthly_xlsx_export_soll_reflects_free(db, test_user):
+    from openpyxl import load_workbook
+    from app.services.export_service import generate_monthly_report
+
+    _set_special_day(db, "special_day_dec31", "free", counts_as_vacation=False)
+    wb = load_workbook(generate_monthly_report(db, 2025, 12))
+    sheet = f"{test_user.last_name} {test_user.first_name}"
+
+    # 31.12. (free, Wed) → 0.0; 30.12. (ordinary Tue) → 8.0 (sanity).
+    assert _xlsx_soll_for_december_day(wb, sheet, 31) == 0.0
+    assert _xlsx_soll_for_december_day(wb, sheet, 30) == 8.0
+
+
+# ---------------------------------------------------------------------------
 # Admin router: GET /settings/special-days + PUT validation
 # ---------------------------------------------------------------------------
 

--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -15,6 +15,11 @@ export const authTest = base.extend<AuthFixtures, { adminApi: ApiHelper }>({
     async ({}, use) => {
       const api = new ApiHelper();
       await api.login(ADMIN_USER, ADMIN_PASS);
+      // #132: ensure the onboarding modal (full-screen overlay) never blocks
+      // admin interactions on a fresh DB where the bootstrap admin still has
+      // onboarding_completed_at == null. Idempotent; best-effort.
+      await api.post('/auth/onboarding/complete').catch(() => {});
+      if (api.userData) api.userData.onboarding_completed_at = new Date().toISOString();
       await use(api);
     },
     { scope: 'worker' },

--- a/e2e/fixtures/test-data.fixture.ts
+++ b/e2e/fixtures/test-data.fixture.ts
@@ -87,6 +87,14 @@ export const testDataTest = authTest.extend<TestDataFixtures>({
   testEmployeeLogin: async ({ testEmployee }, use) => {
     const api = new ApiHelper();
     const loginData = await api.login(testEmployee.username, testEmployee.password);
+    // #132: the role-specific onboarding modal renders a full-screen overlay
+    // (bg-black/40, z-50) for users with onboarding_completed_at == null and
+    // intercepts ALL pointer events (logout button, forms, …). Fresh E2E users
+    // always hit it, which made every post-login interaction time out. Mark it
+    // complete server-side (idempotent — same call the modal's close button
+    // makes) and reflect it in the seeded user so the modal never renders.
+    await api.post('/auth/onboarding/complete').catch(() => {});
+    if (loginData.user) loginData.user.onboarding_completed_at = new Date().toISOString();
     await use({ api, access_token: loginData.access_token, user: loginData.user });
   },
 

--- a/e2e/tests/admin/absences.spec.ts
+++ b/e2e/tests/admin/absences.spec.ts
@@ -60,8 +60,14 @@ test.describe('Admin Absences', () => {
     await adminPage.goto('/admin/absences');
     await expect(adminPage.getByRole('heading', { name: 'Abwesenheiten verwalten' })).toBeVisible();
 
-    // Select the test employee
+    // Select the test employee. The <select> is populated by an async fetch —
+    // wait for the employee's option to attach before reading, else the loop
+    // races the fetch and finds nothing (CLAUDE.md <select> pattern → flake at
+    // `expect(targetValue).not.toBe('')`).
     const employeeSelect = adminPage.locator('select').first();
+    await expect(
+      employeeSelect.locator('option', { hasText: testEmployee.last_name }).first()
+    ).toBeAttached({ timeout: 10000 });
     const options = employeeSelect.locator('option');
     const count = await options.count();
     let targetValue = '';

--- a/e2e/tests/admin/settings.spec.ts
+++ b/e2e/tests/admin/settings.spec.ts
@@ -41,11 +41,19 @@ test.describe('Admin Einstellungen', () => {
   });
 
   test('Urlaubsgenehmigung-Toggle speichert Einstellung', async ({ adminPage, adminApi }) => {
-    const toggle = adminPage.locator('button[role="switch"]');
+    // #144 added a second role="switch" (Pflicht-Pause-Ausnahme) and a second
+    // "Speichern" button, so the page-wide `button[role="switch"]` and
+    // `Speichern.last()` locators became ambiguous (strict-mode violation /
+    // wrong button — the .last() Speichern is now the break-approval one).
+    // Target the unique toggle id and scope the save button to this section.
+    const section = adminPage.locator('div.bg-white').filter({
+      has: adminPage.getByRole('heading', { name: 'Urlaubsgenehmigung', exact: true }),
+    });
+    const toggle = adminPage.locator('#approval-toggle');
     await expect(toggle).toBeVisible();
     const isChecked = await toggle.getAttribute('aria-checked');
     await toggle.click();
-    const saveApprovalBtn = adminPage.locator('button', { hasText: 'Speichern' }).last();
+    const saveApprovalBtn = section.getByRole('button', { name: 'Speichern' });
     await expect(saveApprovalBtn).toBeEnabled();
     await saveApprovalBtn.click();
     await expect(

--- a/e2e/tests/employee/profile.spec.ts
+++ b/e2e/tests/employee/profile.spec.ts
@@ -48,8 +48,12 @@ test.describe('Employee Profile', () => {
   });
 
   test('change calendar color', async ({ employeePage }) => {
-    // Expand "Weitere Einstellungen" to reveal Kalenderfarbe section
-    await employeePage.getByRole('button', { name: 'Weitere Einstellungen' }).click();
+    // The "Weitere Einstellungen" accordion is open by default (DSGVO-Audit
+    // D-05 — Art. 12 Abs. 1 "leicht zugänglich"). Only toggle it open if it is
+    // currently collapsed, so clicking never accidentally collapses it.
+    if (!(await employeePage.getByText('Kalenderfarbe').isVisible().catch(() => false))) {
+      await employeePage.getByRole('button', { name: 'Weitere Einstellungen' }).click();
+    }
 
     // Check that "Kalenderfarbe" section is visible
     await expect(employeePage.getByText('Kalenderfarbe')).toBeVisible();
@@ -64,20 +68,24 @@ test.describe('Employee Profile', () => {
   });
 
   test('DSGVO data export', async ({ employeePage }) => {
-    // Expand "Weitere Einstellungen" to reveal DSGVO section
-    await employeePage.getByRole('button', { name: 'Weitere Einstellungen' }).click();
+    // Accordion is open by default (DSGVO-Audit D-05); only expand if collapsed.
+    const downloadButton = employeePage.getByRole('button', { name: 'JSON herunterladen' });
+    if (!(await downloadButton.isVisible().catch(() => false))) {
+      await employeePage.getByRole('button', { name: 'Weitere Einstellungen' }).click();
+    }
 
     // Check that the download button exists
-    const downloadButton = employeePage.getByRole('button', { name: 'JSON herunterladen' });
     await expect(downloadButton).toBeVisible();
 
     // Set up download event listener
     const downloadPromise = employeePage.waitForEvent('download', { timeout: 15000 });
     await downloadButton.click();
 
-    // Verify download started
+    // Verify download started. #119 self-service export names the file
+    // PraxisZeit_MeineDaten_<username>_<timestamp>.json (frontend-generated for
+    // the blob download); the old "Datenauszug" name no longer applies.
     const download = await downloadPromise;
-    expect(download.suggestedFilename()).toContain('PraxisZeit_Datenauszug');
+    expect(download.suggestedFilename()).toContain('PraxisZeit_MeineDaten');
   });
 
   test('Profilbild: Upload gültiges JPEG zeigt Erfolgsmeldung', async ({ employeePage }) => {

--- a/frontend/src/utils/arbzgWarnings.ts
+++ b/frontend/src/utils/arbzgWarnings.ts
@@ -7,12 +7,14 @@
  *
  * Warning-text after the colon (if any) contains localized details from the
  * server and is shown verbatim to the user so they see the concrete numbers.
+ *
+ * NF-3: toast duration is intentionally NOT passed — ToastContext applies the
+ * severity-based default (warning = 6s). Hardcoding a duration here overrode
+ * that default and violated the project rule (see CLAUDE.md "Toast-Dauer").
  */
 interface WarnToast {
   warning: (message: string, duration?: number) => void;
 }
-
-const WARNING_DURATION_MS = 8000;
 
 function splitCodeAndDetail(entry: string): { code: string; detail?: string } {
   const idx = entry.indexOf(':');
@@ -36,14 +38,10 @@ export function showArbzgWarnings(
       case 'REST_TIME_WARNING':
         toast.warning(
           detail ?? 'Zu kurze Ruhezeit seit letztem Arbeitsende (§5 ArbZG, min. 11h).',
-          WARNING_DURATION_MS,
         );
         break;
       case 'BREAK_WARNING':
-        toast.warning(
-          detail ?? 'Pausenregel verletzt (§4 ArbZG).',
-          WARNING_DURATION_MS,
-        );
+        toast.warning(detail ?? 'Pausenregel verletzt (§4 ArbZG).');
         break;
       case 'BREAK_WAIVER':
         // #144: entry saved with a documented "Pflicht-Pause nicht möglich"
@@ -52,7 +50,6 @@ export function showArbzgWarnings(
           detail
             ? `Pflicht-Pause-Ausnahme dokumentiert: ${detail}`
             : 'Pflicht-Pause-Ausnahme dokumentiert (§4 ArbZG).',
-          WARNING_DURATION_MS,
         );
         break;
       case 'BREAK_WAIVER_PENDING':
@@ -61,29 +58,22 @@ export function showArbzgWarnings(
           detail
             ? `Zur Genehmigung eingereicht: ${detail}`
             : 'Pflicht-Pause-Ausnahme zur Genehmigung eingereicht (§4 ArbZG).',
-          WARNING_DURATION_MS,
         );
         break;
       case 'DAILY_HOURS_WARNING':
-        toast.warning('Tagesarbeitszeit über 8 Stunden (§3 ArbZG).', WARNING_DURATION_MS);
+        toast.warning('Tagesarbeitszeit über 8 Stunden (§3 ArbZG).');
         break;
       case 'WEEKLY_HOURS_WARNING':
-        toast.warning('Wochenarbeitszeit über 48 Stunden (§3 ArbZG).', WARNING_DURATION_MS);
+        toast.warning('Wochenarbeitszeit über 48 Stunden (§3 ArbZG).');
         break;
       case 'SUNDAY_WORK':
-        toast.warning(
-          'Sonntagsarbeit eingetragen – bitte Ausnahmegrund angeben (§9 ArbZG).',
-          WARNING_DURATION_MS,
-        );
+        toast.warning('Sonntagsarbeit eingetragen – bitte Ausnahmegrund angeben (§9 ArbZG).');
         break;
       case 'HOLIDAY_WORK':
-        toast.warning(
-          'Feiertagsarbeit eingetragen – bitte Ausnahmegrund angeben (§9 ArbZG).',
-          WARNING_DURATION_MS,
-        );
+        toast.warning('Feiertagsarbeit eingetragen – bitte Ausnahmegrund angeben (§9 ArbZG).');
         break;
       default:
-        toast.warning(raw, WARNING_DURATION_MS);
+        toast.warning(raw);
     }
   }
 }

--- a/frontend/src/utils/breakValidation.test.ts
+++ b/frontend/src/utils/breakValidation.test.ts
@@ -56,4 +56,36 @@ describe('computeBreakError', () => {
     const error = computeBreakError(existing, '10:10', '17:30', 0, true);
     expect(error).toBeNull();
   });
+
+  // NF-1: a declared break < 15 min must NOT count toward the mandatory break
+  // (§4 Satz 2), mirroring the backend A-M2 fix. Single-entry net using the raw
+  // break would be 358 ≤ 360 and slip through; aggregate net (ignoring the
+  // sub-15 break) is 372 > 360 → 30-min error.
+  it('ignores a sub-15-min declared break when computing net time (§4 Satz 2)', () => {
+    // 08:00–14:12 = 372 min gross, 14 min "break" → backend net 372 > 6h.
+    const error = computeBreakError([], '08:00', '14:12', 14, false);
+    expect(error).toMatch(/30 Min/);
+  });
+
+  // NF-2: the over-threshold decision must be made on the AGGREGATE of all
+  // same-day blocks, not just the single new entry. Each block here is <6h net
+  // but the day in aggregate is >6h with a <15-min (ignored) gap.
+  it('checks the aggregate day even when the new entry alone is under 6h', () => {
+    // existing 08:00–12:00 (4h) + new 12:05–15:10 (3h05) → gross 7h05, 5-min
+    // gap ignored, net 7h05 > 6h, no break → 30-min error.
+    const existing = [{ start: 8 * 60, end: 12 * 60, brk: 0 }];
+    const error = computeBreakError(existing, '12:05', '15:10', 0, false);
+    expect(error).toMatch(/30 Min/);
+  });
+
+  // The new entry's own declared break, if 0 < x < 15, is itself a §4 Satz 2
+  // violation regardless of net time — the backend returns a (waiver-able)
+  // error here, so the client must surface it too (consistency with the
+  // break-waiver UI gate).
+  it('flags a sub-15-min break segment on a short day (§4 Satz 2)', () => {
+    // 08:00–10:00 = 2h, 10-min break → under 6h, but the 10-min segment is
+    // itself invalid.
+    const error = computeBreakError([], '08:00', '10:00', 10, false);
+    expect(error).toMatch(/15 Min/);
+  });
 });

--- a/frontend/src/utils/breakValidation.ts
+++ b/frontend/src/utils/breakValidation.ts
@@ -48,23 +48,24 @@ export function computeBreakError(
 
   const start = toMinutes(startTime);
   const end = toMinutes(endTime);
-  const grossMinutes = end - start;
-  const netMinutes = grossMinutes - breakMinutes;
 
-  if (netMinutes <= 360) return null;
-
-  // Combine the new entry with the other closed entries on the same day.
+  // Combine the new entry with the other closed entries on the same day, then
+  // decide everything on the AGGREGATE — never on the single new entry alone.
+  // (NF-2: a single <6h entry can still push an already-worked day over 6h.)
   const allBlocks: BreakBlock[] = [
     ...existingBlocks,
     { start, end, brk: breakMinutes },
   ];
   allBlocks.sort((a, b) => a.start - b.start);
 
-  const totalDeclared = allBlocks.reduce((s, b) => s + b.brk, 0);
+  // §4 Satz 2: only break SEGMENTS of at least 15 min count toward the
+  // mandatory break — applies to declared breaks (NF-1, mirrors backend A-M2)
+  // and to gaps between entries alike.
+  const totalDeclared = allBlocks.reduce((s, b) => s + (b.brk >= 15 ? b.brk : 0), 0);
   let totalGap = 0;
   for (let i = 1; i < allBlocks.length; i++) {
     const gap = allBlocks[i].start - allBlocks[i - 1].end;
-    if (gap >= 15) totalGap += gap; // §4 Satz 2: mind. 15 Min pro Abschnitt
+    if (gap >= 15) totalGap += gap;
   }
   const totalGross = allBlocks.reduce((s, b) => s + (b.end - b.start), 0);
   const totalNet = totalGross - totalDeclared;
@@ -75,6 +76,12 @@ export function computeBreakError(
   }
   if (totalNet > 360 && totalEffBreak < 30) {
     return 'Bei >6h Arbeitszeit sind mind. 30 Min. Pause erforderlich (ArbZG §4)';
+  }
+  // §4 Satz 2: a declared break of 1–14 min is itself an invalid segment. The
+  // backend returns a (waiver-able) error here even on short days, so surface
+  // it client-side too, so the break-waiver UI gate stays in sync.
+  if (breakMinutes > 0 && breakMinutes < 15) {
+    return 'Pausenabschnitte müssen mind. 15 Min. betragen (ArbZG §4 Satz 2)';
   }
   return null;
 }


### PR DESCRIPTION
Aufbauend auf dem bestehenden Gesamt-Review (`docs/specs/2026-05-28-gesamt-review.md`): drei parallele read-only Audits **verifizierten** die bereits gemergten Critical/High/Medium-Fixes als korrekt und fanden nur neue **≤Medium**-Punkte. Diese sind hier behoben, plus die durch die #140–#146-UI gebrochenen E2E-Tests.

## Backend — Korrektheit
- **N-1 (Medium):** Halbtag-/Frei-Faktor (24./31.12., #146) jetzt auch in **allen 5 Export-Loops** (xlsx Monat/Jahr/PDF + ods Monat/Jahr). Vorher zeigte die §16-Export-Soll-Spalte den vollen Tag → wich von `get_monthly_target()` ab.
- **N-2 (Low):** `PAID_LEAVE` → „Bez. Freistellung" in allen 4 Export-Label-Maps (vorher roher Enum-String).
- **N-3 (Low):** `with_for_update()` auf den TimeEntry-Refetch im CR-Approval-Pfad (TOCTOU, analog Update-Pfad).
- **Low:** `company_closures` Datums-Wording („darf nicht vor"); irreführender `bulk_review`-Rollback-Kommentar präzisiert.

## Frontend
- **NF-1/NF-2 (Medium):** `breakValidation.ts` spiegelt `validate_daily_break` jetzt vollständig (≥15-min-Segmente, Aggregat-Netto, Sub-15-Check) — kein Client/Server-Drift mehr (Client ließ §4-Verstöße durch → Server-400, Waiver-UI erschien nie).
- **NF-3 (Low):** hardcodierte Toast-Dauer in `arbzgWarnings.ts` entfernt (ToastContext-Default greift).

## Tests
- Neue Backend-Regressionstests: **SEC-E** (4-Augen-Negativ), **C-1** (§3-TOCTOU), 2× Export-Halbtag-Soll; 4× breakValidation-Drift (vitest).
- **E2E-Härtung** (Suite von Mass-Timeout-Cascade → grün): Onboarding-Modal (#132) blockierte als full-screen Overlay **alle** Post-Login-Interaktionen → Fixtures dismissen es jetzt serverseitig. Settings-Toggle-Locator eindeutig (#144 fügte 2. Switch hinzu). Profile-Akkordeon (D-05 offen-by-default) konditional. DSGVO-Export-Dateiname (#119) angepasst. `delete-absence` `<select>`-Race stabilisiert.
- **`test_native_pg_lifecycle.py`:** `skipif` wenn `praxiszeit-server.py` unerreichbar (Container) → 44 errors → 44 skips; entblockt `scripts/local-ci.sh` (war seit 1.5.1 am Backend-Schritt rot).

## Verifikation — `scripts/local-ci.sh` vollständig grün
| Gate | Ergebnis |
|--|--|
| Backend pytest | 763 passed, 44 skipped |
| Postgres (RLS + Concurrency) | 21 passed |
| TypeScript (tsc) | clean |
| Vitest | 59 passed |
| ESLint | 0 errors |
| Vite build | ✓ |
| E2E (Playwright) | 115 passed (1 flaky→retry-grün) |

**Bewusst nicht angefasst** (Design-/Aufwands-ISSUEs > „bis medium"): F-H3 Code-Splitting, A-H1 Nachtschicht, A-H2 §3-Ausgleichsreport, B-M3 Perf, F-M User-Typ-Dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)