### PR TITLE
release: 1.7.0 — Export-§16-Korrektheit, §4-Pausen-Parität, Dependency-Security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-05-28
+
+### 🧮 Korrekte Soll-Stunden in den Berichten an Sondertagen
+- Sind der 24.12. oder 31.12. als **halber Tag** oder **frei** konfiguriert,
+  zeigen jetzt **alle** Berichte (Monats-/Jahres-Excel, PDF, ODS) in der
+  Soll-Spalte den reduzierten Wert — vorher stand dort der volle Tag, wodurch
+  die Soll-Summe im Export von der berechneten Monats-Soll abwich (§16-relevant).
+- **Bezahlte Freistellung** wird in den Tageszeilen der Exporte jetzt mit
+  Klartext-Label „Bez. Freistellung" ausgewiesen.
+
+### ⏱️ Pflicht-Pause (§4 ArbZG): Eingabe und Server urteilen identisch
+- Die clientseitige Pausenprüfung spiegelt jetzt die Server-Logik exakt
+  (nur Pausenabschnitte ab 15 Min zählen, Bewertung über den ganzen Tag) —
+  zuvor ließ die Eingabemaske manche §4-Verstöße durch und der Begründungs-
+  Dialog (Pflicht-Pause-Ausnahme) erschien dadurch nicht.
+
+### 🔒 Sicherheit / Wartung
+- Abhängigkeiten der internen Handbuch-/Screenshot-Werkzeuge auf sichere
+  Versionen aktualisiert (behebt alle gemeldeten Schwachstellen; betrifft nur
+  das Build-Tooling, nicht die ausgelieferte Anwendung).
+- Härtung des Änderungsantrag-Genehmigungspfads (Sperre gegen gleichzeitige
+  Bearbeitung) und kleinere Korrektheits-/Wortlaut-Fixes aus dem Review.
+
 ## [1.6.0] - 2026-05-27
 
 ### ✨ Fehler/Feedback direkt aus der App melden

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.6.0 (Stand 2026-05-27)
+**Aktuelle Version:** 1.7.0 (Stand 2026-05-28)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.6.0"
+APP_VERSION = "1.7.0"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "axios": "^1.15.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.6.0"
+APP_VERSION="1.7.0"
 PYTHON_VERSION="3.13.3"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 PYTHON_STANDALONE_TAG="20250529"


### PR DESCRIPTION
Version-Bump auf **1.7.0** (alle 3 Code-Stellen + Lock + CLAUDE.md + CHANGELOG). Build-Script-Konsistenzcheck grün.

Bündelt die bereits gemergten Inhalte:
- **#152** — Export-Soll an konfigurierten Sondertagen (24./31.12. Halbtag/Frei) korrekt in xlsx/PDF/ODS; PAID_LEAVE-Label; §4-Pausen Client/Server-Parität (Break-Waiver-UI); CR-Approval-Härtung.
- **#138** — Dependency-Security-Fixes im Handbuch-/Screenshot-Build-Tooling (0 offene Dependabot-Alerts; dev-only, nicht im Release-Artefakt).

`scripts/local-ci.sh` war auf dem Inhalts-Stand (master `cc9e62c`) vollständig grün; dieser PR ändert nur Versionsstrings + Doku. Nach Merge: Linux-1.7.0-Build + `validate-release.sh`, Windows via separates Builder-Issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)