### PR TITLE
feat: Absenz-Kalender-Badges, Dashboard-Filter leitende MA, Abteilungen (#157-Folge, #159, #162)

### DIFF
--- a/backend/alembic/versions/2026_05_29_1200-045_add_user_department.py
+++ b/backend/alembic/versions/2026_05_29_1200-045_add_user_department.py
@@ -1,0 +1,26 @@
+"""Add users.department (optional free-text Abteilung/Bereich, #162).
+
+Nullable VARCHAR(100). No backfill, no RLS change — ``users`` is already
+tenant-scoped, this is just an additional optional attribute used for grouping
+and filtering in absence overviews.
+
+Revision ID: 045_add_user_department
+Revises: 044_widen_audit_action
+Create Date: 2026-05-29
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '045_add_user_department'
+down_revision = '044_widen_audit_action'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('department', sa.String(length=100), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'department')

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -42,6 +42,7 @@ class User(Base):
     token_version = Column(Integer, default=0, nullable=False, server_default='0')  # Increment to invalidate all tokens
     exempt_from_arbzg = Column(Boolean, default=False, nullable=False, server_default='false')  # §18 ArbZG: leitende Angestellte
     is_night_worker = Column(Boolean, default=False, nullable=False, server_default='false')  # §6 Abs. 2 ArbZG: reduziertes Tageslimit 8h
+    department = Column(String(100), nullable=True)  # #162: Abteilung/Bereich (Freitext, optional)
     totp_secret = Column(String(64), nullable=True)  # F-019: TOTP secret (None if 2FA not set up)
     totp_enabled = Column(Boolean, default=False, nullable=False, server_default='false')  # F-019: 2FA active
     last_totp_counter = Column(BigInteger, nullable=True)  # Highest counter value already accepted (replay guard)

--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -76,7 +76,7 @@ def get_absence_calendar(
         raise HTTPException(status_code=400, detail="Ungültiges Monatsformat (YYYY-MM erwartet)")
 
     # Get all absences for the month, fetching User columns in the same query
-    rows = db.query(Absence, User.first_name, User.last_name).join(User).filter(
+    rows = db.query(Absence, User.first_name, User.last_name, User.calendar_color).join(User).filter(
         User.is_active == True,
         User.is_hidden == False,
         date_in_month(Absence.date, year, month_num)
@@ -86,7 +86,7 @@ def get_absence_calendar(
     # DSGVO Art. 9: Krankheitsdaten sind besonders schützenswert.
     # Nicht-Admins sehen fremde Krankmeldungen nur als "absent".
     calendar_entries = []
-    for absence, first_name, last_name in rows:
+    for absence, first_name, last_name, calendar_color in rows:
         display_type = absence.type.value
         if (
             absence.type == AbsenceType.SICK
@@ -98,6 +98,7 @@ def get_absence_calendar(
             date=absence.date,
             user_first_name=first_name,
             user_last_name=last_name,
+            user_color=calendar_color,
             type=display_type,
             hours=absence.hours
         ))

--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -76,7 +76,9 @@ def get_absence_calendar(
         raise HTTPException(status_code=400, detail="Ungültiges Monatsformat (YYYY-MM erwartet)")
 
     # Get all absences for the month, fetching User columns in the same query
-    rows = db.query(Absence, User.first_name, User.last_name, User.calendar_color).join(User).filter(
+    rows = db.query(
+        Absence, User.first_name, User.last_name, User.calendar_color, User.department
+    ).join(User).filter(
         User.is_active == True,
         User.is_hidden == False,
         date_in_month(Absence.date, year, month_num)
@@ -86,7 +88,7 @@ def get_absence_calendar(
     # DSGVO Art. 9: Krankheitsdaten sind besonders schützenswert.
     # Nicht-Admins sehen fremde Krankmeldungen nur als "absent".
     calendar_entries = []
-    for absence, first_name, last_name, calendar_color in rows:
+    for absence, first_name, last_name, calendar_color, department in rows:
         display_type = absence.type.value
         if (
             absence.type == AbsenceType.SICK
@@ -99,6 +101,7 @@ def get_absence_calendar(
             user_first_name=first_name,
             user_last_name=last_name,
             user_color=calendar_color,
+            department=department,
             type=display_type,
             hours=absence.hours
         ))

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -323,6 +323,7 @@ def create_user(user_data: UserCreate, db: Session = Depends(get_db), current_us
         is_night_worker=user_data.is_night_worker,
         first_work_day=user_data.first_work_day,
         last_work_day=user_data.last_work_day,
+        department=user_data.department,
         tenant_id=current_user.tenant_id,
     )
 

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -109,7 +109,8 @@ def get_monthly_report(
             balance=float(balance),
             overtime_cumulative=float(overtime),
             vacation_used_hours=vacation_hours,
-            sick_hours=sick_hours if include_health_data else 0.0
+            sick_hours=sick_hours if include_health_data else 0.0,
+            exempt_from_arbzg=bool(user.exempt_from_arbzg),
         ))
 
     return reports

--- a/backend/app/schemas/absence.py
+++ b/backend/app/schemas/absence.py
@@ -43,6 +43,7 @@ class AbsenceCalendarEntry(BaseModel):
     user_first_name: str
     user_last_name: str
     user_color: str  # #157: Mitarbeiterfarbe für den Badge-Ring im Kalender
+    department: Optional[str] = None  # #162: Abteilung/Bereich (für Filter)
     type: str  # str statt AbsenceType: DSGVO Art. 9 — "sick" wird ggf. zu "absent" maskiert
     hours: float
 

--- a/backend/app/schemas/absence.py
+++ b/backend/app/schemas/absence.py
@@ -42,6 +42,7 @@ class AbsenceCalendarEntry(BaseModel):
     date: date
     user_first_name: str
     user_last_name: str
+    user_color: str  # #157: Mitarbeiterfarbe für den Badge-Ring im Kalender
     type: str  # str statt AbsenceType: DSGVO Art. 9 — "sick" wird ggf. zu "absent" maskiert
     hours: float
 

--- a/backend/app/schemas/reports.py
+++ b/backend/app/schemas/reports.py
@@ -64,6 +64,7 @@ class EmployeeMonthlyReport(BaseModel):
     overtime_cumulative: float
     vacation_used_hours: float
     sick_hours: float
+    exempt_from_arbzg: bool = False  # #159: leitende Angestellte (§18) — Filter im Dashboard-Schnitt
 
 
 class PublicHolidayResponse(BaseModel):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -48,6 +48,7 @@ class UserBase(BaseModel):
     is_night_worker: bool = False  # §6 Abs. 2 ArbZG: Nachtarbeitnehmer (8h-Tageslimit)
     first_work_day: Optional[date] = None  # Erster Arbeitstag
     last_work_day: Optional[date] = None   # Letzter Arbeitstag
+    department: Optional[str] = Field(None, max_length=100)  # #162: Abteilung/Bereich
 
     @model_validator(mode='after')
     def check_work_day_order(self):
@@ -91,6 +92,7 @@ class UserUpdate(BaseModel):
     is_night_worker: Optional[bool] = None  # §6 Abs. 2 ArbZG
     first_work_day: Optional[date] = None   # Erster Arbeitstag
     last_work_day: Optional[date] = None    # Letzter Arbeitstag
+    department: Optional[str] = Field(None, max_length=100)  # #162: Abteilung/Bereich
 
     @model_validator(mode='after')
     def check_work_day_order(self):
@@ -147,6 +149,7 @@ class UserListResponse(BaseModel):
     is_night_worker: bool = False
     first_work_day: Optional[date] = None
     last_work_day: Optional[date] = None
+    department: Optional[str] = None  # #162: Abteilung/Bereich
     totp_enabled: bool = False
     deactivated_at: Optional[datetime] = None
     created_at: datetime

--- a/backend/tests/test_absence_calendar.py
+++ b/backend/tests/test_absence_calendar.py
@@ -87,3 +87,13 @@ def test_masked_sick_still_carries_user_color(db, test_user, default_tenant):
     row = next(r for r in resp.json() if r["user_color"] == "#AB12CD")
     assert row["type"] == "absent"  # DSGVO masking intact
     assert row["user_color"] == "#AB12CD"
+
+
+def test_calendar_includes_department(db, test_user):
+    test_user.department = "Verwaltung"
+    db.commit()
+    _mk_absence(db, test_user, date(2026, 3, 6), AbsenceType.VACATION)
+    resp = _client(db, test_user).get("/api/absences/calendar?month=2026-03")
+    assert resp.status_code == 200, resp.text
+    row = next(r for r in resp.json() if r["user_color"] == test_user.calendar_color)
+    assert row["department"] == "Verwaltung"

--- a/backend/tests/test_absence_calendar.py
+++ b/backend/tests/test_absence_calendar.py
@@ -1,0 +1,89 @@
+"""Calendar endpoint exposes per-employee colour for the badge ring (#157),
+while DSGVO Art. 9 sick-masking stays intact."""
+import uuid
+from datetime import date
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.middleware.auth import get_current_user
+from app.models import Absence, AbsenceType, User, UserRole
+from app.services import auth_service
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _app() -> FastAPI:
+    from app.routers import absences
+    from app.core.limiter import limiter
+    from slowapi import _rate_limit_exceeded_handler
+    from slowapi.errors import RateLimitExceeded
+
+    app = FastAPI()
+    limiter.enabled = False
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.include_router(absences.router)
+    return app
+
+
+_APP = _app()
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    yield
+    _APP.dependency_overrides.clear()
+
+
+def _client(db, current):
+    def odb():
+        yield db
+    _APP.dependency_overrides[get_db] = odb
+    _APP.dependency_overrides[get_current_user] = lambda: current
+    return TestClient(_APP)
+
+
+def _mk_absence(db, user, d, typ):
+    a = Absence(user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d, type=typ, hours=8.0)
+    db.add(a)
+    db.commit()
+    return a
+
+
+def _mk_employee(db, color):
+    u = User(
+        id=uuid.uuid4(), username=f"u_{uuid.uuid4().hex[:6]}",
+        email=f"{uuid.uuid4().hex[:6]}@t.local",
+        password_hash=auth_service.hash_password("Test2025!Password"),
+        first_name="Erika", last_name="Muster", role=UserRole.EMPLOYEE,
+        weekly_hours=40.0, vacation_days=30, work_days_per_week=5,
+        is_active=True, tenant_id=DEFAULT_TENANT_ID, calendar_color=color,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def test_calendar_includes_user_color(db, test_user):
+    _mk_absence(db, test_user, date(2026, 3, 2), AbsenceType.VACATION)
+    resp = _client(db, test_user).get("/api/absences/calendar?month=2026-03")
+    assert resp.status_code == 200, resp.text
+    rows = resp.json()
+    assert len(rows) == 1
+    assert rows[0]["user_color"] == test_user.calendar_color
+    assert rows[0]["type"] == "vacation"
+
+
+def test_masked_sick_still_carries_user_color(db, test_user, default_tenant):
+    # A different employee's SICK absence, viewed by a non-admin non-owner:
+    # type is masked to "absent", but the ring colour must still be present.
+    other = _mk_employee(db, "#AB12CD")
+    _mk_absence(db, other, date(2026, 3, 4), AbsenceType.SICK)
+    resp = _client(db, test_user).get("/api/absences/calendar?month=2026-03")
+    assert resp.status_code == 200, resp.text
+    row = next(r for r in resp.json() if r["user_color"] == "#AB12CD")
+    assert row["type"] == "absent"  # DSGVO masking intact
+    assert row["user_color"] == "#AB12CD"

--- a/backend/tests/test_cross_tenant_api.py
+++ b/backend/tests/test_cross_tenant_api.py
@@ -467,3 +467,18 @@ def test_journal_holidays_exclude_tenant_b(_db_session, employee_a, two_tenants)
     by_date = {d["date"]: d for d in result["days"]}
     assert by_date["2026-06-01"]["is_holiday"] is True   # own tenant holiday
     assert by_date["2026-06-02"]["is_holiday"] is False  # other tenant must not leak
+
+
+def test_create_user_persists_department(_db_session, client_as_admin_a):
+    """#162: department (Abteilung) round-trips through create_user + user list."""
+    resp = client_as_admin_a.post("/api/admin/users", json={
+        "username": "dept_user", "email": "dept@test.local",
+        "password": "Test2025!Password", "first_name": "D", "last_name": "U",
+        "role": "employee", "weekly_hours": 40.0, "vacation_days": 30,
+        "work_days_per_week": 5, "department": "Reinigung",
+    })
+    assert resp.status_code == 201, resp.text
+    lst = client_as_admin_a.get("/api/admin/users")
+    assert lst.status_code == 200, lst.text
+    u = next(x for x in lst.json() if x["username"] == "dept_user")
+    assert u["department"] == "Reinigung"

--- a/backend/tests/test_paid_leave_reports.py
+++ b/backend/tests/test_paid_leave_reports.py
@@ -197,3 +197,40 @@ def test_24_week_average_excludes_holidays_and_absences(db, test_user, test_admi
         assert after_row["scheduled_work_days"] == base_days - 2
     finally:
         _app.dependency_overrides.clear()
+
+
+def test_monthly_report_includes_exempt_flag(db, test_user, test_admin):
+    """#159: jede Report-Zeile trägt exempt_from_arbzg, damit das Dashboard
+    leitende MA aus dem Ø-Saldo filtern kann."""
+    import uuid as _uuid
+    from app.models import User, UserRole
+    from app.services import auth_service as _auth
+
+    boss = User(
+        id=_uuid.uuid4(), username="boss", email="boss@t.local",
+        password_hash=_auth.hash_password("Test2025!Password"),
+        first_name="Boss", last_name="Chef", role=UserRole.EMPLOYEE,
+        weekly_hours=40.0, vacation_days=30, work_days_per_week=5,
+        is_active=True, tenant_id=DEFAULT_TENANT_ID, exempt_from_arbzg=True,
+    )
+    db.add(boss)
+    db.commit()
+
+    def override_db():
+        yield db
+
+    _app.dependency_overrides[get_db] = override_db
+    _app.dependency_overrides[get_current_user] = lambda: test_admin
+    _app.dependency_overrides[require_admin] = lambda: test_admin
+    try:
+        client = TestClient(_app)
+        resp = client.get(f"/api/admin/reports/monthly?month={YEAR}-03")
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()
+    finally:
+        _app.dependency_overrides.clear()
+
+    boss_row = next(r for r in rows if r["user_id"] == str(boss.id))
+    assert boss_row["exempt_from_arbzg"] is True
+    non_exempt = [r for r in rows if r["user_id"] != str(boss.id)]
+    assert non_exempt and all(r["exempt_from_arbzg"] is False for r in non_exempt)

--- a/frontend/src/components/AbsenceBadge.test.tsx
+++ b/frontend/src/components/AbsenceBadge.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import AbsenceBadge from './AbsenceBadge';
+
+describe('AbsenceBadge', () => {
+  it('renders the initials and a circular badge with a ring + tooltip', () => {
+    render(
+      <AbsenceBadge type="vacation" userColor="#AB12CD" initials="EM" title="Erika Muster – Urlaub" />,
+    );
+    const el = screen.getByText('EM');
+    expect(el).toHaveAttribute('title', 'Erika Muster – Urlaub');
+    const style = el.getAttribute('style') || '';
+    expect(style).toContain('border-radius'); // circle
+    expect(style).toContain('border'); // employee-colour ring
+  });
+
+  it('uses a neutral centre for the masked "absent" type', () => {
+    render(<AbsenceBadge type="absent" userColor="#000000" initials="XY" />);
+    const el = screen.getByText('XY');
+    const style = (el.getAttribute('style') || '').toLowerCase();
+    // #6B7280 fallback (rgb(107, 114, 128)) — accept hex or rgb serialisation
+    expect(style).toMatch(/6b7280|107, ?114, ?128/);
+  });
+});

--- a/frontend/src/components/AbsenceBadge.tsx
+++ b/frontend/src/components/AbsenceBadge.tsx
@@ -1,0 +1,56 @@
+import { useTypeColorsStore } from '../stores/typeColorsStore';
+
+interface AbsenceBadgeProps {
+  /** Absence type key ("vacation" … or masked "absent"). */
+  type: string;
+  /** Employee colour — rendered as the ring. */
+  userColor: string;
+  /** Initials shown in outline (Konturschrift), e.g. "EM". */
+  initials: string;
+  /** Tooltip / aria text (employee + type). */
+  title?: string;
+  /** Diameter in px. */
+  size?: number;
+}
+
+/**
+ * #157: per-employee absence badge for the team calendar.
+ * - ring  = employee colour (~20 % of the radius)
+ * - centre = absence-type colour (admin-configurable; neutral grey for masked "absent")
+ * - initials in white with a thin dark contour so they stay legible on any centre colour.
+ */
+export default function AbsenceBadge({ type, userColor, initials, title, size = 26 }: AbsenceBadgeProps) {
+  const colors = useTypeColorsStore((s) => s.colors);
+  const centre = (colors as Record<string, string>)[type] ?? '#6B7280';
+  const ring = Math.max(2, Math.round(size * 0.1)); // 10 % of diameter = 20 % of radius
+
+  return (
+    <span
+      title={title}
+      aria-label={title}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        backgroundColor: centre,
+        border: `${ring}px solid ${userColor}`,
+        boxSizing: 'border-box',
+        fontSize: Math.round(size * 0.4),
+        fontWeight: 700,
+        lineHeight: 1,
+        letterSpacing: '-0.02em',
+        color: '#fff',
+        WebkitTextStroke: '0.6px rgba(0,0,0,0.7)',
+        // Fallback contour for engines without -webkit-text-stroke.
+        textShadow: '0 0 1px rgba(0,0,0,0.55)',
+        userSelect: 'none',
+        flexShrink: 0,
+      }}
+    >
+      {initials}
+    </span>
+  );
+}

--- a/frontend/src/pages/AbsenceCalendarPage.tsx
+++ b/frontend/src/pages/AbsenceCalendarPage.tsx
@@ -7,6 +7,12 @@ import { useToast } from '../contexts/ToastContext';
 import { useConfirm } from '../hooks/useConfirm';
 import ConfirmDialog from '../components/ConfirmDialog';
 import { AbsenceType, ABSENCE_TYPE_LABELS, ABSENCE_TYPE_COLORS } from '../constants/absenceTypes';
+import AbsenceBadge from '../components/AbsenceBadge';
+import { useTypeColorsStore } from '../stores/typeColorsStore';
+
+// Label helper that tolerates the DSGVO-masked "absent" pseudo-type.
+const absenceTypeLabel = (t: string): string =>
+  t === 'absent' ? 'Abwesend' : (ABSENCE_TYPE_LABELS[t as AbsenceType] ?? t);
 import Badge from '../components/Badge';
 import { getErrorMessage } from '../utils/errorMessage';
 import { parseHours } from '../utils/formatters';
@@ -44,7 +50,9 @@ interface CalendarEntry {
   date: string;
   user_first_name: string;
   user_last_name: string;
-  type: 'vacation' | 'sick' | 'training' | 'overtime' | 'other';
+  user_color: string;
+  // May be a masked value ("absent") for non-admins viewing others' sick days.
+  type: string;
   hours: number;
 }
 
@@ -270,6 +278,7 @@ export default function AbsenceCalendarPage() {
   // Use shared constants
   const typeLabels = ABSENCE_TYPE_LABELS;
   const typeColors = ABSENCE_TYPE_COLORS;
+  const absColors = useTypeColorsStore((s) => s.colors);
 
   // Generate calendar days
   const [year, month] = currentMonth.split('-').map(Number);
@@ -689,15 +698,20 @@ export default function AbsenceCalendarPage() {
                           {dayHoliday.name}
                         </div>
                       )}
-                      {/* Absence Entries */}
-                      {dayEntries.map((entry, idx) => (
-                        <div
-                          key={idx}
-                          className={`text-xs px-2 py-1 rounded-sm border ${typeColors[entry.type]}`}
-                        >
-                          {entry.user_first_name} {entry.user_last_name?.[0]}.
+                      {/* Absence Entries — per-employee badge (ring = MA-Farbe, Mitte = Typ) */}
+                      {dayEntries.length > 0 && (
+                        <div className="flex flex-wrap gap-1">
+                          {dayEntries.map((entry, idx) => (
+                            <AbsenceBadge
+                              key={idx}
+                              type={entry.type}
+                              userColor={entry.user_color}
+                              initials={`${entry.user_first_name?.[0] ?? ''}${entry.user_last_name?.[0] ?? ''}`.toUpperCase()}
+                              title={`${entry.user_first_name} ${entry.user_last_name} – ${absenceTypeLabel(entry.type)}`}
+                            />
+                          ))}
                         </div>
-                      ))}
+                      )}
                     </div>
                   </div>
                 );
@@ -750,14 +764,22 @@ export default function AbsenceCalendarPage() {
                       {dayEntries.map((entry, idx) => (
                         <div
                           key={idx}
-                          className={`px-3 py-2 rounded-lg border ${typeColors[entry.type]}`}
+                          className="px-3 py-2 rounded-lg border border-gray-200 flex items-center gap-2"
                         >
-                          <p className="text-sm font-medium">
-                            {entry.user_first_name} {entry.user_last_name}
-                          </p>
-                          <p className="text-xs text-gray-600 mt-0.5">
-                            {typeLabels[entry.type]}
-                          </p>
+                          <AbsenceBadge
+                            type={entry.type}
+                            userColor={entry.user_color}
+                            initials={`${entry.user_first_name?.[0] ?? ''}${entry.user_last_name?.[0] ?? ''}`.toUpperCase()}
+                            title={`${entry.user_first_name} ${entry.user_last_name}`}
+                          />
+                          <div>
+                            <p className="text-sm font-medium">
+                              {entry.user_first_name} {entry.user_last_name}
+                            </p>
+                            <p className="text-xs text-gray-600 mt-0.5">
+                              {absenceTypeLabel(entry.type)}
+                            </p>
+                          </div>
                         </div>
                       ))}
                       {/* Placeholder for days without content */}
@@ -849,10 +871,16 @@ export default function AbsenceCalendarPage() {
       {/* Legend */}
       <div className="bg-white rounded-xl shadow-xs border border-gray-200 p-6 mb-6" key="legend">
         <h3 className="font-semibold mb-3">Legende</h3>
+        <p className="text-xs text-gray-500 mb-3">
+          Im Kalender: <strong>Ring</strong> = Mitarbeiterfarbe, <strong>Mitte</strong> = Art der Abwesenheit.
+        </p>
         <div className="flex flex-wrap gap-4">
           {Object.entries(typeLabels).map(([key, label]) => (
             <div key={key} className="flex items-center space-x-2">
-              <div className={`w-4 h-4 rounded-sm border ${typeColors[key as AbsenceType]}`}></div>
+              <div
+                className="w-4 h-4 rounded-full border border-gray-300"
+                style={{ backgroundColor: (absColors as Record<string, string>)[key] ?? '#6B7280' }}
+              ></div>
               <span className="text-sm">{label}</span>
             </div>
           ))}

--- a/frontend/src/pages/AbsenceCalendarPage.tsx
+++ b/frontend/src/pages/AbsenceCalendarPage.tsx
@@ -9,10 +9,6 @@ import ConfirmDialog from '../components/ConfirmDialog';
 import { AbsenceType, ABSENCE_TYPE_LABELS, ABSENCE_TYPE_COLORS } from '../constants/absenceTypes';
 import AbsenceBadge from '../components/AbsenceBadge';
 import { useTypeColorsStore } from '../stores/typeColorsStore';
-
-// Label helper that tolerates the DSGVO-masked "absent" pseudo-type.
-const absenceTypeLabel = (t: string): string =>
-  t === 'absent' ? 'Abwesend' : (ABSENCE_TYPE_LABELS[t as AbsenceType] ?? t);
 import Badge from '../components/Badge';
 import { getErrorMessage } from '../utils/errorMessage';
 import { parseHours } from '../utils/formatters';
@@ -20,6 +16,10 @@ import MonthSelector from '../components/MonthSelector';
 import EmptyState from '../components/EmptyState';
 import { useAuthStore } from '../stores/authStore';
 import VacationRequestEditModal from '../components/VacationRequestEditModal';
+
+// Label helper that tolerates the DSGVO-masked "absent" pseudo-type.
+const absenceTypeLabel = (t: string): string =>
+  t === 'absent' ? 'Abwesend' : (ABSENCE_TYPE_LABELS[t as AbsenceType] ?? t);
 
 interface VacationRequest {
   id: string;
@@ -51,6 +51,7 @@ interface CalendarEntry {
   user_first_name: string;
   user_last_name: string;
   user_color: string;
+  department?: string | null;
   // May be a masked value ("absent") for non-admins viewing others' sick days.
   type: string;
   hours: number;
@@ -102,6 +103,7 @@ export default function AbsenceCalendarPage() {
   const [currentYear, setCurrentYear] = useState(new Date().getFullYear());
   const [viewMode, setViewMode] = useState<'month' | 'year'>('month');
   const [calendarEntries, setCalendarEntries] = useState<CalendarEntry[]>([]);
+  const [departmentFilter, setDepartmentFilter] = useState<string>(''); // #162
   const [myAbsences, setMyAbsences] = useState<Absence[]>([]);
   const [holidays, setHolidays] = useState<PublicHoliday[]>([]);
   const [showForm, setShowForm] = useState(false);
@@ -279,6 +281,13 @@ export default function AbsenceCalendarPage() {
   const typeLabels = ABSENCE_TYPE_LABELS;
   const typeColors = ABSENCE_TYPE_COLORS;
   const absColors = useTypeColorsStore((s) => s.colors);
+  // #162: Abteilungs-Filter für den Team-Kalender.
+  const departments = Array.from(
+    new Set(calendarEntries.map((e) => e.department).filter(Boolean)),
+  ).sort() as string[];
+  const visibleEntries = departmentFilter
+    ? calendarEntries.filter((e) => e.department === departmentFilter)
+    : calendarEntries;
 
   // Generate calendar days
   const [year, month] = currentMonth.split('-').map(Number);
@@ -648,6 +657,20 @@ export default function AbsenceCalendarPage() {
             </button>
           </div>
         )}
+        {/* #162: Abteilungs-Filter */}
+        {departments.length > 0 && (
+          <select
+            value={departmentFilter}
+            onChange={(e) => setDepartmentFilter(e.target.value)}
+            className="px-3 py-1.5 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary"
+            aria-label="Nach Abteilung filtern"
+          >
+            <option value="">Alle Abteilungen</option>
+            {departments.map((d) => (
+              <option key={d} value={d}>{d}</option>
+            ))}
+          </select>
+        )}
       </div>
 
       {/* Calendar */}
@@ -671,7 +694,7 @@ export default function AbsenceCalendarPage() {
               {/* Calendar days */}
               {days.map((day) => {
                 const dateStr = format(day, 'yyyy-MM-dd');
-                const dayEntries = calendarEntries.filter((e) => e.date === dateStr);
+                const dayEntries = visibleEntries.filter((e) => e.date === dateStr);
                 const dayHoliday = holidays.find((h) => h.date === dateStr);
                 const isWeekend = day.getDay() === 0 || day.getDay() === 6;
 
@@ -725,7 +748,7 @@ export default function AbsenceCalendarPage() {
               .filter((day) => day.getDay() !== 0 && day.getDay() !== 6) // show all weekdays
               .map((day) => {
                 const dateStr = format(day, 'yyyy-MM-dd');
-                const dayEntries = calendarEntries.filter((e) => e.date === dateStr);
+                const dayEntries = visibleEntries.filter((e) => e.date === dateStr);
                 const dayHoliday = holidays.find((h) => h.date === dateStr);
                 const hasContent = dayEntries.length > 0 || !!dayHoliday;
 
@@ -802,7 +825,7 @@ export default function AbsenceCalendarPage() {
               const days = eachDayOfInterval({ start: monthStart, end: monthEnd });
 
               // Get absences for this month
-              const monthAbsences = calendarEntries.filter(entry => {
+              const monthAbsences = visibleEntries.filter(entry => {
                 const entryDate = parseISO(entry.date);
                 return entryDate >= monthStart && entryDate <= monthEnd;
               });

--- a/frontend/src/pages/admin/AdminAbsences.tsx
+++ b/frontend/src/pages/admin/AdminAbsences.tsx
@@ -25,6 +25,7 @@ interface Employee {
   first_name: string;
   last_name: string;
   is_active: boolean;
+  department?: string | null;
 }
 
 interface Absence {
@@ -45,6 +46,7 @@ export default function AdminAbsences() {
   const [submitting, setSubmitting] = useState(false);
   const [employees, setEmployees] = useState<Employee[]>([]);
   const [selectedEmployee, setSelectedEmployee] = useState<string>('');
+  const [departmentFilter, setDepartmentFilter] = useState<string>(''); // #162
   const [currentMonth, setCurrentMonth] = useState(format(new Date(), 'yyyy-MM'));
   const [absences, setAbsences] = useState<Absence[]>([]);
   const [showForm, setShowForm] = useState(false);
@@ -468,21 +470,48 @@ export default function AdminAbsences() {
       {/* Filters */}
       <div className="bg-white rounded-xl shadow-xs border border-gray-200 p-4 mb-6">
         <div className="flex flex-wrap items-center gap-4">
-          <div className="flex-1 min-w-48">
-            <label className="block text-sm font-medium text-gray-700 mb-1">Mitarbeiter</label>
-            <select
-              value={selectedEmployee}
-              onChange={e => { setSelectedEmployee(e.target.value); setShowForm(false); }}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
-            >
-              <option value="">Alle Mitarbeiter</option>
-              {employees.map(emp => (
-                <option key={emp.id} value={emp.id}>
-                  {emp.first_name} {emp.last_name}
-                </option>
-              ))}
-            </select>
-          </div>
+          {(() => {
+            const departments = Array.from(
+              new Set(employees.map(e => e.department).filter(Boolean)),
+            ).sort() as string[];
+            const visibleEmployees = departmentFilter
+              ? employees.filter(e => e.department === departmentFilter)
+              : employees;
+            return (
+              <>
+                {departments.length > 0 && (
+                  <div className="min-w-40">
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Abteilung</label>
+                    <select
+                      value={departmentFilter}
+                      onChange={e => { setDepartmentFilter(e.target.value); setSelectedEmployee(''); setShowForm(false); }}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
+                    >
+                      <option value="">Alle Abteilungen</option>
+                      {departments.map(d => (
+                        <option key={d} value={d}>{d}</option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+                <div className="flex-1 min-w-48">
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Mitarbeiter</label>
+                  <select
+                    value={selectedEmployee}
+                    onChange={e => { setSelectedEmployee(e.target.value); setShowForm(false); }}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
+                  >
+                    <option value="">Alle Mitarbeiter</option>
+                    {visibleEmployees.map(emp => (
+                      <option key={emp.id} value={emp.id}>
+                        {emp.first_name} {emp.last_name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </>
+            );
+          })()}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Monat</label>
             <MonthSelector value={currentMonth} onChange={setCurrentMonth} />

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -22,6 +22,7 @@ interface EmployeeReport {
   overtime_cumulative: number;
   vacation_used_hours: number;
   sick_hours: number;
+  exempt_from_arbzg?: boolean;
 }
 
 interface TimeEntry {
@@ -66,6 +67,8 @@ interface UserDetails {
 
 export default function AdminDashboard() {
   const [report, setReport] = useState<EmployeeReport[]>([]);
+  // #159: leitende MA (§18) verzerren den Schnitt — standardmäßig aus dem Ø ausschließen.
+  const [includeExemptInAvg, setIncludeExemptInAvg] = useState(false);
   const [yearlyAbsences, setYearlyAbsences] = useState<YearlyAbsences[]>([]);
   const [loading, setLoading] = useState(true);
   const [yearlyLoading, setYearlyLoading] = useState(true);
@@ -363,8 +366,12 @@ export default function AdminDashboard() {
     });
 
   const totalEmployees = report.length;
-  const avgBalance = report.length > 0
-    ? report.reduce((sum, emp) => sum + emp.balance, 0) / report.length
+  // #159: Ø Saldo wahlweise ohne leitende Angestellte (Default) — verhindert
+  // dass wenige MA mit vielen Stunden den Schnitt verzerren.
+  const exemptCount = report.filter((emp) => emp.exempt_from_arbzg).length;
+  const avgRows = includeExemptInAvg ? report : report.filter((emp) => !emp.exempt_from_arbzg);
+  const avgBalance = avgRows.length > 0
+    ? avgRows.reduce((sum, emp) => sum + emp.balance, 0) / avgRows.length
     : 0;
 
   return (
@@ -402,6 +409,17 @@ export default function AdminDashboard() {
             {avgBalance >= 0 ? '+' : ''}
             {avgBalance.toFixed(2)} h
           </p>
+          {exemptCount > 0 && (
+            <label className="mt-2 flex items-center gap-2 text-xs text-gray-500 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={includeExemptInAvg}
+                onChange={(e) => setIncludeExemptInAvg(e.target.checked)}
+                className="w-3.5 h-3.5 rounded-sm border-gray-300 text-primary focus:ring-primary"
+              />
+              Leitende MA einrechnen ({exemptCount})
+            </label>
+          )}
         </div>
 
         <div className="bg-white rounded-xl shadow-xs border border-gray-200 p-6">

--- a/frontend/src/pages/admin/users/UserForm.tsx
+++ b/frontend/src/pages/admin/users/UserForm.tsx
@@ -29,6 +29,7 @@ interface User {
   hours_friday: number | null;
   first_work_day: string | null;
   last_work_day: string | null;
+  department?: string | null;
   is_active: boolean;
   is_hidden: boolean;
   deactivated_at: string | null;
@@ -61,6 +62,7 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
     is_night_worker: false,
     first_work_day: '',
     last_work_day: '',
+    department: '',
     use_daily_schedule: false,
     hours_monday: 8,
     hours_tuesday: 8,
@@ -90,6 +92,7 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
         is_night_worker: editUser.is_night_worker ?? false,
         first_work_day: editUser.first_work_day || '',
         last_work_day: editUser.last_work_day || '',
+        department: editUser.department || '',
         use_daily_schedule: editUser.use_daily_schedule ?? false,
         hours_monday: editUser.hours_monday ?? 8,
         hours_tuesday: editUser.hours_tuesday ?? 8,
@@ -148,6 +151,7 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
         ...userFields,
         first_work_day: formData.first_work_day || null,
         last_work_day: formData.last_work_day || null,
+        department: formData.department.trim() || null,
       };
       const startYear = formData.first_work_day
         ? new Date(formData.first_work_day).getFullYear()
@@ -411,6 +415,18 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
               value={formData.last_work_day}
               onChange={(e) => setFormData({ ...formData, last_work_day: e.target.value })}
               className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-primary focus:border-transparent"
+            />
+          </div>
+          <div>
+            <label htmlFor="f-department" className="block text-sm font-medium text-gray-700 mb-1">Abteilung/Bereich (optional)</label>
+            <input
+              id="f-department"
+              type="text"
+              maxLength={100}
+              value={formData.department}
+              onChange={(e) => setFormData({ ...formData, department: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
+              placeholder="z. B. Praxis, Verwaltung, Reinigung"
             />
           </div>
 


### PR DESCRIPTION
Feedback-Batch 2. Closes #159, closes #162 (und die #157-Kalender-Folge).

## Verifikation
- **Backend:** SQLite-Suite **807 passed / 44 skipped / 0 failed**, Postgres-Gruppe (RLS+Concurrency) **21 passed**. Migration 045 upgrade gegen echtes Postgres geprüft.
- **Frontend:** `tsc` 0 Fehler · lint 0 Fehler · vitest **66** · `vite build` ✓.

## Absenz-Kalender-Badges (#157-Folge)
Pro Mitarbeiter ein **Kreis-Badge** im Team-Abwesenheitskalender (`AbsenceCalendarPage`):
- **Ring** = Mitarbeiterfarbe (~10 % des Durchmessers = 20 % Radius)
- **Mitte** = Abwesenheitstyp-Farbe (admin-konfigurierbar; **neutrales Grau** für DSGVO-maskierte `sick`→`absent`)
- **Initialen** in Konturschrift (weiß + `-webkit-text-stroke`, `text-shadow`-Fallback)
- Neue `AbsenceBadge`-Komponente; Grid + Mobile-Liste + Legende umgestellt; Backend liefert `user_color` im `/absences/calendar`-Endpoint.

## #159 — Dashboard-Schnitt mit/ohne leitende MA
`exempt_from_arbzg` jetzt pro Report-Zeile. Im Admin-Dashboard werden leitende MA **standardmäßig aus dem Ø-Saldo ausgeschlossen** (verhindert Verzerrung); Toggle „Leitende MA einrechnen (N)" am Ø-Saldo-Tile, nur sichtbar wenn es welche gibt.

## #162 — Abteilungen/Bereiche + Filter
- Neues optionales `User.department` (Migration 045, `nullable varchar(100)`; `users` ist bereits tenant-scoped → keine neue Tabelle/RLS).
- Feld „Abteilung/Bereich" im MA-Formular (Freitext).
- `department` in `UserBase`/`UserUpdate`/`UserListResponse` + `AbsenceCalendarEntry`.
- **Filter** nach Abteilung im Team-Abwesenheitskalender (`AbsenceCalendarPage`) und im Admin-Abwesenheits-Mitarbeiterpicker (`AdminAbsences`).

## Hinweise
- Migration 045 ist additiv/nicht-destruktiv (nullable Spalte) — vor Deploy gemäß Projektregel gegen Prod-DB-Kopie testen.
- UI-Darstellung der Badges/Filter bitte einmal visuell prüfen (in dieser Umgebung nicht visuell verifizierbar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
