### PR TITLE
fix(review): HIGH+MEDIUM aus Code-/Security-/UX-Review der Feedback-Features

### DIFF
--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -96,12 +96,16 @@ def get_absence_calendar(
             and absence.user_id != current_user.id
         ):
             display_type = "absent"
+        # DSGVO-Minimierung: die Abteilung (Org-Zuordnung) wird nur Admins
+        # ausgeliefert (Filter-Use-Case). Kolleg:innen erhalten den Team-Kalender
+        # ohne Abteilungsmerkmal → kein tenant-weites Org-Chart-Broadcast.
+        entry_department = department if current_user.role == UserRole.ADMIN else None
         calendar_entries.append(AbsenceCalendarEntry(
             date=absence.date,
             user_first_name=first_name,
             user_last_name=last_name,
             user_color=calendar_color,
-            department=department,
+            department=entry_department,
             type=display_type,
             hours=absence.hours
         ))

--- a/backend/tests/test_absence_calendar.py
+++ b/backend/tests/test_absence_calendar.py
@@ -89,11 +89,23 @@ def test_masked_sick_still_carries_user_color(db, test_user, default_tenant):
     assert row["user_color"] == "#AB12CD"
 
 
-def test_calendar_includes_department(db, test_user):
+def test_calendar_department_visible_to_admin(db, test_user, test_admin):
+    """#162 + DSGVO: admins see the department (for the filter)."""
     test_user.department = "Verwaltung"
     db.commit()
     _mk_absence(db, test_user, date(2026, 3, 6), AbsenceType.VACATION)
-    resp = _client(db, test_user).get("/api/absences/calendar?month=2026-03")
+    resp = _client(db, test_admin).get("/api/absences/calendar?month=2026-03")
     assert resp.status_code == 200, resp.text
     row = next(r for r in resp.json() if r["user_color"] == test_user.calendar_color)
     assert row["department"] == "Verwaltung"
+
+
+def test_calendar_department_hidden_from_non_admin(db, test_user):
+    """DSGVO-Minimierung: Kolleg:innen erhalten die Abteilung NICHT broadcastet."""
+    test_user.department = "Verwaltung"
+    db.commit()
+    _mk_absence(db, test_user, date(2026, 3, 7), AbsenceType.VACATION)
+    resp = _client(db, test_user).get("/api/absences/calendar?month=2026-03")
+    assert resp.status_code == 200, resp.text
+    row = next(r for r in resp.json() if r["user_color"] == test_user.calendar_color)
+    assert row["department"] is None

--- a/docs/specs/dsgvo/verarbeitungsverzeichnis.md
+++ b/docs/specs/dsgvo/verarbeitungsverzeichnis.md
@@ -49,6 +49,9 @@
 | Kontaktdaten | E-Mail-Adresse (optional) | Art. 6 Abs. 1 lit. b DSGVO |
 | Zugangs­daten | Passwort-Hash (bcrypt), JWT-Token-Version, TOTP-Secret (verschlüsselt, optional) | Art. 6 Abs. 1 lit. b DSGVO |
 | Vertrags­daten | Wochenstunden, Arbeitstage, Urlaubstage, Kalenderfarbe | Art. 6 Abs. 1 lit. b DSGVO |
+| Organisations­daten | Abteilung/Bereich (optional, Freitext; #162) | Art. 6 Abs. 1 lit. f DSGVO (Organisation/Dienstplanung) |
+
+> **Abteilung (#162):** optionales Gruppierungsmerkmal. Im Team-Abwesenheitskalender wird die Abteilung aus Datenminimierungsgründen **nur Administrator:innen** ausgeliefert (Filter-Use-Case); Kolleg:innen erhalten die Kalenderansicht ohne Abteilungsmerkmal.
 
 ### 4.2 Zeiterfassungsdaten
 

--- a/frontend/src/components/AbsenceBadge.tsx
+++ b/frontend/src/components/AbsenceBadge.tsx
@@ -1,4 +1,4 @@
-import { useTypeColorsStore } from '../stores/typeColorsStore';
+import { useTypeColorsStore, pickTextColor } from '../stores/typeColorsStore';
 
 interface AbsenceBadgeProps {
   /** Absence type key ("vacation" … or masked "absent"). */
@@ -23,6 +23,10 @@ export default function AbsenceBadge({ type, userColor, initials, title, size = 
   const colors = useTypeColorsStore((s) => s.colors);
   const centre = (colors as Record<string, string>)[type] ?? '#6B7280';
   const ring = Math.max(2, Math.round(size * 0.1)); // 10 % of diameter = 20 % of radius
+  // Contrast-safe text + matching contour so initials stay legible on any
+  // admin-chosen centre colour (Review HIGH: no white-on-yellow).
+  const textColor = pickTextColor(centre);
+  const contour = textColor === '#FFFFFF' ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.85)';
 
   return (
     <span
@@ -42,15 +46,15 @@ export default function AbsenceBadge({ type, userColor, initials, title, size = 
         fontWeight: 700,
         lineHeight: 1,
         letterSpacing: '-0.02em',
-        color: '#fff',
-        WebkitTextStroke: '0.6px rgba(0,0,0,0.7)',
+        color: textColor,
+        WebkitTextStroke: `0.6px ${contour}`,
         // Fallback contour for engines without -webkit-text-stroke.
-        textShadow: '0 0 1px rgba(0,0,0,0.55)',
+        textShadow: `0 0 1px ${contour}`,
         userSelect: 'none',
         flexShrink: 0,
       }}
     >
-      {initials}
+      {initials || '?'}
     </span>
   );
 }

--- a/frontend/src/pages/AbsenceCalendarPage.tsx
+++ b/frontend/src/pages/AbsenceCalendarPage.tsx
@@ -285,8 +285,11 @@ export default function AbsenceCalendarPage() {
   const departments = Array.from(
     new Set(calendarEntries.map((e) => e.department).filter(Boolean)),
   ).sort() as string[];
-  const visibleEntries = departmentFilter
-    ? calendarEntries.filter((e) => e.department === departmentFilter)
+  // Wenn die gewählte Abteilung im aktuellen Zeitraum nicht (mehr) vorkommt,
+  // auf "Alle" zurückfallen, statt eine leere Ansicht zu zeigen (Review M-C3).
+  const effectiveDepartmentFilter = departments.includes(departmentFilter) ? departmentFilter : '';
+  const visibleEntries = effectiveDepartmentFilter
+    ? calendarEntries.filter((e) => e.department === effectiveDepartmentFilter)
     : calendarEntries;
 
   // Generate calendar days
@@ -660,7 +663,7 @@ export default function AbsenceCalendarPage() {
         {/* #162: Abteilungs-Filter */}
         {departments.length > 0 && (
           <select
-            value={departmentFilter}
+            value={effectiveDepartmentFilter}
             onChange={(e) => setDepartmentFilter(e.target.value)}
             className="px-3 py-1.5 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary"
             aria-label="Nach Abteilung filtern"
@@ -856,6 +859,10 @@ export default function AbsenceCalendarPage() {
                       const dayAbsences = monthAbsences.filter(e => e.date === dateStr);
                       const dayHoliday = holidays.find((h) => h.date === dateStr);
                       const isWeekend = day.getDay() === 0 || day.getDay() === 6;
+                      // Review M-U1: type-coloured dots + descriptive title + overflow.
+                      const dotTitle = dayAbsences
+                        .map(a => `${a.user_first_name} ${a.user_last_name?.[0] ?? ''}. – ${absenceTypeLabel(a.type)}`)
+                        .join(', ');
 
                       return (
                         <div
@@ -868,16 +875,23 @@ export default function AbsenceCalendarPage() {
                           className={`aspect-square flex flex-col items-center justify-center rounded text-xs cursor-pointer hover:ring-1 hover:ring-primary ${
                             isWeekend || dayHoliday ? 'bg-gray-100' : 'bg-white'
                           }`}
-                          title={dayHoliday ? dayHoliday.name : 'Klicken um Abwesenheit einzutragen'}
+                          title={dayHoliday ? dayHoliday.name : (dotTitle || 'Klicken um Abwesenheit einzutragen')}
                         >
                           <div className={`font-medium ${dayHoliday ? 'text-gray-500' : 'text-gray-700'}`}>
                             {format(day, 'd')}
                           </div>
                           {dayAbsences.length > 0 && (
-                            <div className="flex space-x-0.5 mt-0.5">
-                              {dayAbsences.slice(0, 3).map((_, idx) => (
-                                <div key={idx} className="w-1 h-1 rounded-full bg-blue-500"></div>
+                            <div className="flex items-center space-x-0.5 mt-0.5">
+                              {dayAbsences.slice(0, 3).map((a, idx) => (
+                                <div
+                                  key={idx}
+                                  className="w-1.5 h-1.5 rounded-full"
+                                  style={{ backgroundColor: (absColors as Record<string, string>)[a.type] ?? '#6B7280' }}
+                                ></div>
                               ))}
+                              {dayAbsences.length > 3 && (
+                                <span className="text-[9px] leading-none text-gray-500">+{dayAbsences.length - 3}</span>
+                              )}
                             </div>
                           )}
                         </div>
@@ -898,7 +912,11 @@ export default function AbsenceCalendarPage() {
           Im Kalender: <strong>Ring</strong> = Mitarbeiterfarbe, <strong>Mitte</strong> = Art der Abwesenheit.
         </p>
         <div className="flex flex-wrap gap-4">
-          {Object.entries(typeLabels).map(([key, label]) => (
+          {([
+            ['work', 'Arbeit'],
+            ...Object.entries(typeLabels),
+            ['absent', 'Abwesend (maskiert)'],
+          ] as [string, string][]).map(([key, label]) => (
             <div key={key} className="flex items-center space-x-2">
               <div
                 className="w-4 h-4 rounded-full border border-gray-300"

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -12,7 +12,7 @@ import LoadingSpinner from '../components/LoadingSpinner';
 import EmptyState from '../components/EmptyState';
 import { useAuthStore } from '../stores/authStore';
 import { ABSENCE_TYPE_LABELS } from '../constants/absenceTypes';
-import { useTypeColorsStore } from '../stores/typeColorsStore';
+import { useTypeColorsStore, pickTextColor } from '../stores/typeColorsStore';
 
 interface DashboardData {
   year: number;
@@ -833,9 +833,12 @@ export default function Dashboard() {
                                   {dayAbsences.map((absence, idx) => (
                                     <div
                                       key={idx}
-                                      className="text-xs px-1 py-0.5 rounded-sm text-white"
-                                      style={{ backgroundColor: absColors[absence.type] ?? absence.user_color }}
-                                      title={`${absence.user_first_name} ${absence.user_last_name} - ${typeLabels[absence.type]}${absence.note ? ': ' + absence.note : ''}`}
+                                      className="text-xs px-1 py-0.5 rounded-sm"
+                                      style={{
+                                        backgroundColor: absColors[absence.type] ?? '#6B7280',
+                                        color: pickTextColor(absColors[absence.type] ?? '#6B7280'),
+                                      }}
+                                      title={`${absence.user_first_name} ${absence.user_last_name} - ${typeLabels[absence.type] ?? 'Abwesend'}${absence.note ? ': ' + absence.note : ''}`}
                                     >
                                       {absence.user_first_name?.[0]}. {absence.user_last_name}
                                     </div>
@@ -878,13 +881,13 @@ export default function Dashboard() {
                                     >
                                       <span
                                         className="w-3 h-3 rounded-full mr-2 shrink-0"
-                                        style={{ backgroundColor: absColors[absence.type] ?? absence.user_color }}
+                                        style={{ backgroundColor: absColors[absence.type] ?? '#6B7280' }}
                                       ></span>
                                       <span className="font-medium text-gray-900">
                                         {absence.user_first_name} {absence.user_last_name}
                                       </span>
                                       <span className="text-gray-500 mx-1">-</span>
-                                      <span className="text-gray-600">{typeLabels[absence.type]}</span>
+                                      <span className="text-gray-600">{typeLabels[absence.type] ?? 'Abwesend'}</span>
                                       {absence.note && (
                                         <span className="text-gray-500 text-xs ml-1">({absence.note})</span>
                                       )}

--- a/frontend/src/pages/admin/AdminAbsences.tsx
+++ b/frontend/src/pages/admin/AdminAbsences.tsx
@@ -252,6 +252,17 @@ export default function AdminAbsences() {
     ? absences.filter(a => a.date.startsWith(currentMonth) || (a.end_date && a.end_date >= currentMonth + '-01' && a.date <= currentMonth + '-31'))
     : [];
 
+  // #162 / Review M-C2+M-C3: department filter at component scope (so it also
+  // narrows the all-employees overview), with fallback when the selected
+  // department no longer exists.
+  const departments = Array.from(
+    new Set(employees.map(e => e.department).filter(Boolean)),
+  ).sort() as string[];
+  const effectiveDepartmentFilter = departments.includes(departmentFilter) ? departmentFilter : '';
+  const visibleEmployees = effectiveDepartmentFilter
+    ? employees.filter(e => e.department === effectiveDepartmentFilter)
+    : employees;
+
   return (
     <div>
       <ConfirmDialog
@@ -470,48 +481,36 @@ export default function AdminAbsences() {
       {/* Filters */}
       <div className="bg-white rounded-xl shadow-xs border border-gray-200 p-4 mb-6">
         <div className="flex flex-wrap items-center gap-4">
-          {(() => {
-            const departments = Array.from(
-              new Set(employees.map(e => e.department).filter(Boolean)),
-            ).sort() as string[];
-            const visibleEmployees = departmentFilter
-              ? employees.filter(e => e.department === departmentFilter)
-              : employees;
-            return (
-              <>
-                {departments.length > 0 && (
-                  <div className="min-w-40">
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Abteilung</label>
-                    <select
-                      value={departmentFilter}
-                      onChange={e => { setDepartmentFilter(e.target.value); setSelectedEmployee(''); setShowForm(false); }}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
-                    >
-                      <option value="">Alle Abteilungen</option>
-                      {departments.map(d => (
-                        <option key={d} value={d}>{d}</option>
-                      ))}
-                    </select>
-                  </div>
-                )}
-                <div className="flex-1 min-w-48">
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Mitarbeiter</label>
-                  <select
-                    value={selectedEmployee}
-                    onChange={e => { setSelectedEmployee(e.target.value); setShowForm(false); }}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
-                  >
-                    <option value="">Alle Mitarbeiter</option>
-                    {visibleEmployees.map(emp => (
-                      <option key={emp.id} value={emp.id}>
-                        {emp.first_name} {emp.last_name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </>
-            );
-          })()}
+          {departments.length > 0 && (
+            <div className="min-w-40">
+              <label className="block text-sm font-medium text-gray-700 mb-1">Abteilung</label>
+              <select
+                value={effectiveDepartmentFilter}
+                onChange={e => { setDepartmentFilter(e.target.value); setSelectedEmployee(''); setShowForm(false); }}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
+              >
+                <option value="">Alle Abteilungen</option>
+                {departments.map(d => (
+                  <option key={d} value={d}>{d}</option>
+                ))}
+              </select>
+            </div>
+          )}
+          <div className="flex-1 min-w-48">
+            <label className="block text-sm font-medium text-gray-700 mb-1">Mitarbeiter</label>
+            <select
+              value={selectedEmployee}
+              onChange={e => { setSelectedEmployee(e.target.value); setShowForm(false); }}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
+            >
+              <option value="">Alle Mitarbeiter</option>
+              {visibleEmployees.map(emp => (
+                <option key={emp.id} value={emp.id}>
+                  {emp.first_name} {emp.last_name}
+                </option>
+              ))}
+            </select>
+          </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Monat</label>
             <MonthSelector value={currentMonth} onChange={setCurrentMonth} />
@@ -676,7 +675,7 @@ export default function AdminAbsences() {
       ) : (
         /* All employees overview */
         <div className="space-y-3">
-          {employees.map(emp => {
+          {visibleEmployees.map(emp => {
             const empAbsences = allAbsences[emp.id] || [];
             const isExpanded = expandedEmployees[emp.id];
             return (

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -405,20 +405,29 @@ export default function AdminDashboard() {
               size={24}
             />
           </div>
-          <p className={`text-3xl font-bold ${avgBalance >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-            {avgBalance >= 0 ? '+' : ''}
-            {avgBalance.toFixed(2)} h
-          </p>
+          {avgRows.length === 0 ? (
+            <p className="text-3xl font-bold text-gray-400" title="Keine Mitarbeitenden in der Berechnung">—</p>
+          ) : (
+            <p className={`text-3xl font-bold ${avgBalance >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+              {avgBalance >= 0 ? '+' : ''}
+              {avgBalance.toFixed(2)} h
+            </p>
+          )}
           {exemptCount > 0 && (
-            <label className="mt-2 flex items-center gap-2 text-xs text-gray-500 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={includeExemptInAvg}
-                onChange={(e) => setIncludeExemptInAvg(e.target.checked)}
-                className="w-3.5 h-3.5 rounded-sm border-gray-300 text-primary focus:ring-primary"
-              />
-              Leitende MA einrechnen ({exemptCount})
-            </label>
+            <>
+              <p className="text-xs text-gray-400 mt-0.5">
+                {includeExemptInAvg ? 'inkl. leitende MA' : 'ohne leitende MA'}
+              </p>
+              <label className="mt-2 flex items-center gap-2 text-xs text-gray-500 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={includeExemptInAvg}
+                  onChange={(e) => setIncludeExemptInAvg(e.target.checked)}
+                  className="w-3.5 h-3.5 rounded-sm border-gray-300 text-primary focus:ring-primary"
+                />
+                Leitende MA einrechnen ({exemptCount})
+              </label>
+            </>
           )}
         </div>
 

--- a/frontend/src/pages/admin/Settings.tsx
+++ b/frontend/src/pages/admin/Settings.tsx
@@ -6,7 +6,7 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 import { getErrorMessage } from '../../utils/errorMessage';
 import { useConfirm } from '../../hooks/useConfirm';
 import ConfirmDialog from '../../components/ConfirmDialog';
-import { useTypeColorsStore } from '../../stores/typeColorsStore';
+import { useTypeColorsStore, pickTextColor } from '../../stores/typeColorsStore';
 
 // #157: Reihenfolge + Labels der konfigurierbaren Typ-Farben.
 const COLOR_TYPE_ORDER: { key: string; label: string }[] = [
@@ -766,14 +766,27 @@ export default function Settings() {
                 <label htmlFor={`color-${key}`} className="text-sm font-medium text-gray-700">
                   {label}
                 </label>
-                <input
-                  id={`color-${key}`}
-                  type="color"
-                  value={typeColors[key] ?? '#000000'}
-                  onChange={(e) => setTypeColors({ ...typeColors, [key]: e.target.value })}
-                  className="h-8 w-14 rounded border border-gray-300 cursor-pointer"
-                  aria-label={`Farbe ${label}`}
-                />
+                <div className="flex items-center gap-2">
+                  {/* Lesbarkeits-Vorschau: zeigt, ob die Schrift auf der Farbe lesbar bleibt */}
+                  <span
+                    className="inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold border border-gray-300"
+                    style={{
+                      backgroundColor: typeColors[key] ?? '#000000',
+                      color: pickTextColor(typeColors[key] ?? '#000000'),
+                    }}
+                    aria-hidden="true"
+                  >
+                    Aa
+                  </span>
+                  <input
+                    id={`color-${key}`}
+                    type="color"
+                    value={typeColors[key] ?? '#000000'}
+                    onChange={(e) => setTypeColors({ ...typeColors, [key]: e.target.value })}
+                    className="h-8 w-14 rounded border border-gray-300 cursor-pointer"
+                    aria-label={`Farbe ${label}`}
+                  />
+                </div>
               </div>
             ))}
           </div>

--- a/frontend/src/pages/admin/users/UserForm.tsx
+++ b/frontend/src/pages/admin/users/UserForm.tsx
@@ -72,7 +72,6 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
     overtime_carryover: 0, // #158: Anfangssaldo Überstunden (kein User-Feld, separater Carryover-Call)
   });
   // #158: vorhandener Vortrag zum Startjahr — wird beim Speichern erhalten.
-  const [existingVacationCarryover, setExistingVacationCarryover] = useState(0);
   const [hadCarryover, setHadCarryover] = useState(false);
 
   useEffect(() => {
@@ -108,7 +107,6 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
   // laden, damit das Feld den aktuellen Wert zeigt und der Urlaubs-Vortrag erhalten bleibt.
   useEffect(() => {
     if (!editUser) {
-      setExistingVacationCarryover(0);
       setHadCarryover(false);
       return;
     }
@@ -123,7 +121,6 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
         const row = res.data.find((c) => c.year === startYear);
         if (row) {
           setFormData((prev) => ({ ...prev, overtime_carryover: row.overtime_hours }));
-          setExistingVacationCarryover(row.vacation_days ?? 0);
           setHadCarryover(true);
         }
       } catch {
@@ -157,8 +154,21 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
         ? new Date(formData.first_work_day).getFullYear()
         : new Date().getFullYear();
 
-      const writeCarryover = async (userId: string, vacationDays: number) => {
+      // Review M-C1: always preserve the *target year's* own vacation carryover
+      // (fetch it fresh) so editing first_work_day can never copy another year's
+      // value or clobber an existing one.
+      const writeCarryover = async (userId: string) => {
         try {
+          let vacationDays = 0;
+          try {
+            const res = await apiClient.get<Array<{ year: number; vacation_days: number }>>(
+              `/admin/users/${userId}/carryovers`,
+            );
+            const row = res.data.find((c) => c.year === startYear);
+            if (row) vacationDays = row.vacation_days ?? 0;
+          } catch {
+            /* no existing carryover for the target year — keep 0 */
+          }
           await apiClient.put(`/admin/users/${userId}/carryovers/${startYear}`, {
             overtime_hours: overtime_carryover,
             vacation_days: vacationDays,
@@ -176,7 +186,7 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
         // #158: nur schreiben, wenn ein Saldo gesetzt ist oder bereits einer existierte
         // (verhindert leere 0/0-Carryover-Zeilen für unberührte User).
         if (overtime_carryover !== 0 || hadCarryover) {
-          await writeCarryover(editUser.id, existingVacationCarryover);
+          await writeCarryover(editUser.id);
         }
         // If the admin edited themselves, refresh the auth store so Dashboard/Layout update
         if (currentUser && editUser.id === currentUser.id) {
@@ -188,7 +198,7 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
         const res = await apiClient.post('/admin/users', payload);
         const newId: string | undefined = res.data?.user?.id;
         if (newId && overtime_carryover !== 0) {
-          await writeCarryover(newId, 0);
+          await writeCarryover(newId);
         }
         toast.success('Benutzer erfolgreich erstellt');
       }

--- a/frontend/src/stores/typeColorsStore.test.ts
+++ b/frontend/src/stores/typeColorsStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { DEFAULT_TYPE_COLORS, chipStyle, useTypeColorsStore } from './typeColorsStore';
+import { DEFAULT_TYPE_COLORS, pickTextColor, useTypeColorsStore } from './typeColorsStore';
 
 describe('typeColorsStore defaults', () => {
   it('has all seven type keys', () => {
@@ -15,12 +15,19 @@ describe('typeColorsStore defaults', () => {
   });
 });
 
-describe('chipStyle', () => {
-  it('derives a tinted background, coloured text and border from a hex', () => {
-    const s = chipStyle('#2563EB');
-    expect(s.color).toBe('#2563EB');
-    expect(s.backgroundColor).toBe('#2563EB1A');
-    expect(s.borderColor).toBe('#2563EB55');
+describe('pickTextColor', () => {
+  it('returns dark text on a light background', () => {
+    expect(pickTextColor('#FFEB3B')).toBe('#111827'); // yellow → dark
+    expect(pickTextColor('#FFFFFF')).toBe('#111827');
+  });
+
+  it('returns white text on a dark background', () => {
+    expect(pickTextColor('#2563EB')).toBe('#FFFFFF'); // blue → white
+    expect(pickTextColor('#111827')).toBe('#FFFFFF');
+  });
+
+  it('falls back to dark for malformed input', () => {
+    expect(pickTextColor('nope')).toBe('#111827');
   });
 });
 

--- a/frontend/src/stores/typeColorsStore.ts
+++ b/frontend/src/stores/typeColorsStore.ts
@@ -49,13 +49,20 @@ export const useTypeColorsStore = create<TypeColorsState>((set, get) => ({
 }));
 
 /**
- * Inline-Style für einen Typ-Chip aus einem konfigurierten Hex-Wert:
- * leichter Hintergrund + kräftige Schrift/Border in derselben Farbe.
+ * Liefert eine gut lesbare Textfarbe (#111827 dunkel oder #FFFFFF weiß) für eine
+ * gegebene Hintergrundfarbe — basierend auf WCAG-Relativhelligkeit. Verhindert
+ * weiße Schrift auf hellen (z. B. gelben) Admin-Farben (Review-Finding HIGH).
  */
-export function chipStyle(hex: string): React.CSSProperties {
-  return {
-    backgroundColor: `${hex}1A`, // ~10% Deckkraft
-    color: hex,
-    borderColor: `${hex}55`,
+export function pickTextColor(hex: string): string {
+  const h = (hex || '').replace('#', '');
+  if (h.length !== 6) return '#111827';
+  const toLin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
   };
+  const r = toLin(parseInt(h.slice(0, 2), 16));
+  const g = toLin(parseInt(h.slice(2, 4), 16));
+  const b = toLin(parseInt(h.slice(4, 6), 16));
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return luminance > 0.5 ? '#111827' : '#FFFFFF';
 }


### PR DESCRIPTION
Behebt alle **HIGH + MEDIUM** Findings aus dem intensiven Code-/Security-/UX-Review von PR #163 + #164.

## Verifikation
- Frontend: `tsc` 0 Fehler · lint 0 Fehler · vitest **68** · `vite build` ✓.
- Backend: betroffene Suites **76 grün** (calendar, type-colors, cross-tenant, reports, endpoints).

## HIGH — Kontrast (UX)
Admin-wählbare Farben hatten **keinen Lesbarkeitsschutz** → weiße Schrift wurde auf hellen Farben (z. B. Gelb) unlesbar. Neuer `pickTextColor()` (WCAG-Relativhelligkeit) wählt dunkle/weiße Schrift passend zur Hintergrundfarbe:
- `AbsenceBadge`-Initialen + contrast-korrekte Kontur.
- Dashboard-Team-Kalender-Text (statt fix `text-white`).
- `chipStyle` (ungenutzte Kontrast-Falle) entfernt.

## MEDIUM
| # | Fix |
|---|-----|
| M-C1 | #158-Anfangssaldo schreibt den Carryover des **Zieljahres** (frisch geladen) → kein Verfälschen/Clobbern beim Ändern des ersten Arbeitstags |
| M-C2 | AdminAbsences-Abteilungsfilter wirkt jetzt auch auf die **Alle-MA-Übersicht** |
| M-C3 | Abteilungsfilter fällt auf „Alle" zurück, wenn die Abteilung im Zeitraum fehlt (kein leerer Dead-End) |
| M-S1 | **DSGVO:** `department` im Team-Kalender nur an Admins (Datenminimierung) statt tenant-weitem Broadcast; VVT ergänzt |
| M-U1 | Jahresansicht-Marker nach **Typ** eingefärbt + Tooltip + `+N`-Overflow (statt fix blau, max 3, ohne Titel) |
| M-U2 | maskierte Krank-Abwesenheit im Dashboard neutral **grau** + „Abwesend"-Label (konsistent mit Badge) |
| M-U3 | Legende ergänzt um „Arbeit" + „Abwesend (maskiert)" |
| M-U4 | Farb-Einstellungen mit **Lesbarkeits-Vorschau** (Aa auf der Farbe) |
| M-U5 | Ø-Saldo-Tile: „ohne/inkl. leitende MA" + „—" wenn keine MA im Schnitt |

LOW-Findings (leere Initialen → „?", lange Abteilungsnamen, Doppel-Label) teils mitgenommen, Rest bewusst offen gelassen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
