### PR TITLE
feat(#156): Urlaub nach Tagesprinzip — Sofortmaßnahme (8h-Default) + tagebasierte Zählung

### DIFF
--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -319,7 +319,15 @@ def create_absence(
             dates_by_year.setdefault(d.year, []).append(d)
         for check_year, year_dates in dates_by_year.items():
             vacation_account = calculation_service.get_vacation_account(db, target_user, check_year)
-            year_hours_needed = float(absence_data.hours) * len(year_dates)
+            # #156: budget check must match what is actually booked — the per-day
+            # scheduled target, not the caller-supplied (default-8h) value.
+            year_hours_needed = sum(
+                float(calculation_service.get_daily_target_for_date(
+                    target_user, d,
+                    weekly_hours=calculation_service.get_weekly_hours_for_date(db, target_user, d),
+                ))
+                for d in year_dates
+            )
             if year_hours_needed > vacation_account["remaining_hours"]:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
@@ -372,10 +380,14 @@ def create_absence(
     # Create absences for all dates
     created_absences = []
     for date in dates_to_create:
-        # §3 EntgFG: for sick leave always credit the employee's scheduled daily hours,
-        # not a caller-supplied value. For daily-schedule users, use their per-weekday
-        # target; for standard users, derive from weekly_hours / work_days_per_week.
-        if absence_data.type == AbsenceType.SICK or getattr(target_user, 'use_daily_schedule', False):
+        # #156 Sofortmaßnahme: a full-day absence is always credited with the
+        # employee's *own* scheduled daily target — never a caller-supplied value
+        # (which the booking form defaults to 8h). That guarantees one absent
+        # working day == exactly one day for everyone, regardless of contracted
+        # daily hours (Teilzeit). §3 EntgFG requires this for SICK anyway.
+        # Only OVERTIME compensation keeps its explicit hours (the amount of
+        # overtime being drawn down), unless a per-weekday schedule applies.
+        if absence_data.type != AbsenceType.OVERTIME or getattr(target_user, 'use_daily_schedule', False):
             weekly = calculation_service.get_weekly_hours_for_date(db, target_user, date)
             hours_for_day = float(calculation_service.get_daily_target_for_date(target_user, date, weekly_hours=weekly))
             if hours_for_day == 0:

--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -319,16 +319,11 @@ def create_absence(
             dates_by_year.setdefault(d.year, []).append(d)
         for check_year, year_dates in dates_by_year.items():
             vacation_account = calculation_service.get_vacation_account(db, target_user, check_year)
-            # #156: budget check must match what is actually booked — the per-day
-            # scheduled target, not the caller-supplied (default-8h) value.
-            year_hours_needed = sum(
-                float(calculation_service.get_daily_target_for_date(
-                    target_user, d,
-                    weekly_hours=calculation_service.get_weekly_hours_for_date(db, target_user, d),
-                ))
-                for d in year_dates
-            )
-            if year_hours_needed > vacation_account["remaining_hours"]:
+            # #156/T2 — Tagesprinzip: each booked full working day consumes exactly
+            # one vacation day; compare the day COUNT against the remaining DAYS,
+            # not hours (hours-based checks mis-block uneven schedules / part-time).
+            days_needed = len(year_dates)
+            if days_needed > vacation_account["remaining_days"] + 1e-9:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"Nicht genügend Urlaubstage für {check_year} ({vacation_account['remaining_days']:.1f} Tage verfügbar)"

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -655,15 +655,27 @@ def get_vacation_account(db: Session, user: User, year: int) -> Dict:
         date_in_year(Absence.date, year),
     ).all()
 
-    used_hours = sum((Decimal(str(a.hours)) for a in vacation_absences), start=Decimal('0'))
+    # #156/T2 — Tagesprinzip (§3 BUrlG, BAG): der Urlaubsverbrauch wird in
+    # TAGEN gezählt, nicht als Stundensumme ÷ Durchschnitts-Tagessoll. Jeder
+    # Urlaubstag zählt als Anteil seines EIGENEN Tagessolls (voller Tag = 1,0;
+    # Halbtag = 0,5) — unabhängig vom Wochentag. Das verhindert, dass ein
+    # Montag-Urlaub (z. B. 8h) mehr kostet als ein Dienstag-Urlaub (z. B. 3h)
+    # bei ungleichmäßigem Tagesplan. Die Stundensumme bleibt nur informativ.
+    used_hours = Decimal('0')
+    used_days = Decimal('0')
+    for a in vacation_absences:
+        h = Decimal(str(a.hours))
+        used_hours += h
+        dt_day = get_daily_target_for_date(user, a.date, get_weekly_hours_for_date(db, user, a.date))
+        if dt_day > 0:
+            used_days += (h / Decimal(str(dt_day)))
 
     # #146: a special day (24./31.12.) configured as `free` + counts_as_vacation
     # consumes one vacation day too. We account for it non-invasively here
-    # (no generated Absence rows): add the per-day target of each such date to
-    # the used vacation, unless the employee already has a real VACATION
-    # absence on that day (which is already summed above — avoid double count)
-    # or the day falls outside their employment window. Weekends / existing
-    # holidays are excluded inside vacation_deduction_dates_for_year.
+    # (no generated Absence rows): each such day is one full vacation day,
+    # unless the employee already has a real VACATION absence on that day
+    # (already counted above) or it falls outside their employment window.
+    # Weekends / existing holidays are excluded inside the helper.
     holiday_dates_year = {
         h.date for h in db.query(PublicHoliday).filter(
             date_in_year(PublicHoliday.date, year),
@@ -682,14 +694,15 @@ def get_vacation_account(db: Session, user: User, year: int) -> Dict:
         if user.last_work_day and d > user.last_work_day:
             continue
         weekly_hours = get_weekly_hours_for_date(db, user, d)
-        used_hours += get_daily_target_for_date(user, d, weekly_hours)
-    # daily_target guaranteed > 0 here (early return above handles the
-    # zero case). Division is therefore always safe.
-    used_days = used_hours / daily_target
+        dt_day = get_daily_target_for_date(user, d, weekly_hours)
+        if dt_day <= 0:
+            continue
+        used_hours += Decimal(str(dt_day))
+        used_days += Decimal('1')  # ein freier Sondertag = 1 Urlaubstag
 
-    # Calculate remaining
+    # Calculate remaining — days are authoritative (Tagesprinzip); hours informativ.
+    remaining_days = budget_days - used_days
     remaining_hours = budget_hours - used_hours
-    remaining_days = remaining_hours / daily_target
 
     return {
         "budget_hours": float(budget_hours.quantize(Decimal('0.01'))),

--- a/backend/tests/test_absence_full_day_hours.py
+++ b/backend/tests/test_absence_full_day_hours.py
@@ -1,0 +1,85 @@
+"""#156 Sofortmaßnahme: ein voller Abwesenheitstag wird immer mit dem
+individuellen Tagessoll gebucht — nicht mit dem Formular-Default (8h).
+Damit kostet ein freier Arbeitstag für Teilzeitkräfte genau 1,0 Urlaubstag."""
+import uuid
+from datetime import date
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.middleware.auth import get_current_user
+from app.models import User, UserRole, Absence, AbsenceType
+from app.services import calculation_service
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _app() -> FastAPI:
+    from app.routers import absences
+    from app.core.limiter import limiter
+    from slowapi import _rate_limit_exceeded_handler
+    from slowapi.errors import RateLimitExceeded
+
+    app = FastAPI()
+    limiter.enabled = False
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.include_router(absences.router)
+    return app
+
+
+_APP = _app()
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    yield
+    _APP.dependency_overrides.clear()
+
+
+def _client(db, user):
+    def odb():
+        yield db
+    _APP.dependency_overrides[get_db] = odb
+    _APP.dependency_overrides[get_current_user] = lambda: user
+    return TestClient(_APP)
+
+
+def _parttimer(db, weekly=20.0, days=5, overtime=False):
+    u = User(
+        id=uuid.uuid4(), username=f"pt{uuid.uuid4().hex[:6]}", email=f"{uuid.uuid4().hex[:6]}@t.l",
+        password_hash="x", first_name="Teil", last_name="Zeit", role=UserRole.EMPLOYEE,
+        weekly_hours=weekly, work_days_per_week=days, vacation_days=30,
+        track_hours=True, use_daily_schedule=False, is_active=True, tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def test_single_day_vacation_stores_daily_target_not_8(db, default_tenant):
+    # 20h / 5 days = 4h/day. Booking form sends the default 8h.
+    u = _parttimer(db)
+    resp = _client(db, u).post("/api/absences", json={
+        "date": "2026-03-03", "type": "vacation", "hours": 8,  # client default
+    })
+    assert resp.status_code == 201, resp.text
+    rows = resp.json()
+    assert len(rows) == 1
+    assert rows[0]["hours"] == 4.0  # the day's target, NOT the 8 we sent
+
+    acc = calculation_service.get_vacation_account(db, u, 2026)
+    assert acc["used_days"] == 1.0  # exactly one day for one free working day
+
+
+def test_overtime_compensation_keeps_explicit_hours(db, default_tenant):
+    # Überstundenausgleich darf die explizite Stundenzahl behalten (Teil-Abbau).
+    u = _parttimer(db)
+    resp = _client(db, u).post("/api/absences", json={
+        "date": "2026-03-04", "type": "overtime", "hours": 2.5,
+    })
+    assert resp.status_code == 201, resp.text
+    rows = resp.json()
+    assert rows[0]["hours"] == 2.5  # overtime keeps the explicit amount

--- a/backend/tests/test_vacation_day_principle.py
+++ b/backend/tests/test_vacation_day_principle.py
@@ -1,0 +1,116 @@
+"""#156 / T2+T5: Tagesprinzip — ein freier Arbeitstag kostet GENAU 1 Urlaubstag,
+unabhängig von Wochenstunden, Arbeitstagen/Woche und (wichtig!) der konkreten
+Tagesverteilung. Insbesondere darf ein Montag-Urlaub nicht mehr kosten als ein
+Dienstag-Urlaub (ungleichmäßiger Tagesplan)."""
+import uuid
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.middleware.auth import get_current_user
+from app.models import User, UserRole
+from app.services import calculation_service
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _app() -> FastAPI:
+    from app.routers import absences
+    from app.core.limiter import limiter
+    from slowapi import _rate_limit_exceeded_handler
+    from slowapi.errors import RateLimitExceeded
+
+    app = FastAPI()
+    limiter.enabled = False
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.include_router(absences.router)
+    return app
+
+
+_APP = _app()
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    yield
+    _APP.dependency_overrides.clear()
+
+
+def _client(db, user):
+    def odb():
+        yield db
+    _APP.dependency_overrides[get_db] = odb
+    _APP.dependency_overrides[get_current_user] = lambda: user
+    return TestClient(_APP)
+
+
+def _mk(db, **kw):
+    base = dict(
+        id=uuid.uuid4(), username=f"u{uuid.uuid4().hex[:6]}", email=f"{uuid.uuid4().hex[:6]}@t.l",
+        password_hash="x", first_name="A", last_name="B", role=UserRole.EMPLOYEE,
+        weekly_hours=40.0, work_days_per_week=5, vacation_days=30, track_hours=True,
+        use_daily_schedule=False, is_active=True, tenant_id=DEFAULT_TENANT_ID,
+    )
+    base.update(kw)
+    u = User(**base)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _book(db, u, d, hours=8):
+    return _client(db, u).post("/api/absences", json={"date": d, "type": "vacation", "hours": hours})
+
+
+def _used(db, u):
+    return calculation_service.get_vacation_account(db, u, 2026)["used_days"]
+
+
+MON, TUE = "2026-03-02", "2026-03-03"  # Mo / Di
+
+
+def test_fulltime_one_day_is_one_day(db, default_tenant):
+    u = _mk(db)  # 40h / 5 Tage
+    assert _book(db, u, MON).status_code == 201
+    assert _used(db, u) == 1.0
+
+
+def test_uniform_parttime_one_day_is_one_day(db, default_tenant):
+    u = _mk(db, weekly_hours=20.0, work_days_per_week=5)  # 4h/Tag
+    assert _book(db, u, MON).status_code == 201
+    assert _used(db, u) == 1.0
+
+
+def test_three_day_week_one_day_is_one_day(db, default_tenant):
+    u = _mk(db, weekly_hours=27.0, work_days_per_week=3, vacation_days=18)  # 9h/Tag
+    assert _book(db, u, MON).status_code == 201
+    assert _used(db, u) == 1.0
+
+
+def test_uneven_schedule_monday_equals_tuesday(db, default_tenant):
+    """Kernfall des Prüfers: Mo 8h, Di–Fr 3h. Ein Montag-Urlaub und ein
+    Dienstag-Urlaub müssen beide GENAU 1,0 Tag kosten."""
+    sched = dict(
+        weekly_hours=20.0, work_days_per_week=5, use_daily_schedule=True,
+        hours_monday=8, hours_tuesday=3, hours_wednesday=3, hours_thursday=3, hours_friday=3,
+    )
+    u_mon = _mk(db, **sched)
+    assert _book(db, u_mon, MON).status_code == 201
+    assert _used(db, u_mon) == 1.0  # darf NICHT 2,0 sein
+
+    u_tue = _mk(db, **sched)
+    assert _book(db, u_tue, TUE).status_code == 201
+    assert _used(db, u_tue) == 1.0  # darf NICHT 0,75 sein
+
+
+def test_full_week_equals_number_of_workdays(db, default_tenant):
+    u = _mk(db, weekly_hours=20.0, work_days_per_week=5)  # 4h/Tag, 5 Tage
+    r = _client(db, u).post(
+        "/api/absences",
+        json={"date": "2026-03-02", "end_date": "2026-03-06", "type": "vacation", "hours": 8},
+    )
+    assert r.status_code == 201, r.text
+    assert _used(db, u) == 5.0

--- a/docs/specs/2026-05-29-urlaubsberechnung-pruefvorlage.md
+++ b/docs/specs/2026-05-29-urlaubsberechnung-pruefvorlage.md
@@ -1,0 +1,110 @@
+# Urlaubsberechnung in PraxisZeit — Sachverhaltsdarstellung zur fachlichen Prüfung
+
+**Stand:** 29.05.2026
+**Erstellt für:** Vorlage an Steuerberatung / arbeitsrechtliche Beratung (im Folgenden „Prüfer")
+**Betrifft:** Methode der Urlaubsverrechnung in der Zeiterfassungs-Software PraxisZeit
+**Interne Referenz:** Issue #156
+
+> Dieses Dokument beschreibt **rein den Sachverhalt** — wie die Software Urlaub berechnet und welche Frage sich daraus ergibt. Es enthält **keine rechtliche Bewertung**; diese obliegt dem Prüfer. Die genannten Gesetzes-/Tarifbezüge dienen nur der Einordnung.
+
+---
+
+## 1. Worum geht es?
+
+Die Praxis beschäftigt Mitarbeitende mit **sehr unterschiedlicher Tagesaufteilung** bei gleicher Wochenarbeitszeit-Logik, u. a.:
+
+- **Mitarbeiterin A:** 20 Std./Woche, verteilt auf **5 Tage à 4 Std.**
+- **Mitarbeiterin B:** 27 Std./Woche, verteilt auf **3 Tage à 9 Std.**
+
+Es besteht die Sorge, dass die Software Urlaub **stundenbasiert/dezimal** verrechnet und dadurch Mitarbeitende mit kurzen Tagen gegenüber Mitarbeitenden mit langen Tagen **ungleich** behandelt. Zu klären ist, ob die aktuelle Berechnungsmethode zulässig ist oder auf eine **tagebasierte** Zählung (ganze/halbe Tage unabhängig von der Stundenzahl) umgestellt werden sollte.
+
+Die Praxis ist **nicht tarifgebunden**; der MFA-Tarifvertrag rechnet Urlaub üblicherweise **in Tagen** ab, nicht dezimal in Stunden.
+
+---
+
+## 2. Wie die Software Urlaub aktuell berechnet (Mechanismus)
+
+PraxisZeit führt das Urlaubskonto **intern in Stunden** und rechnet für die Anzeige in „Tage" um. Maßgeblich sind drei Größen:
+
+1. **Tagessoll** (Stunden, die an einem Arbeitstag zu leisten sind)
+   `Tagessoll = Wochenstunden ÷ Arbeitstage pro Woche`
+   - A: 20 ÷ 5 = **4 Std./Tag**
+   - B: 27 ÷ 3 = **9 Std./Tag**
+
+2. **Urlaubsbudget** (Jahresanspruch)
+   - In Tagen: ein konfigurierbarer Wert je Mitarbeiter:in. Die Software **schlägt** einen anteiligen Wert vor: `30 × Arbeitstage ÷ 5` (also 30 Tage bei 5-Tage-Woche, **18 Tage** bei 3-Tage-Woche). Dieser Vorschlag kann vom Administrator überschrieben werden.
+   - Intern in Stunden: `Budget-Stunden = Budget-Tage × Tagessoll`.
+
+3. **Verbrauch**
+   - Jeder gebuchte Urlaubstag wird mit einer **Stundenzahl** gespeichert.
+   - Die Anzeige „verbrauchte Tage" / „Resttage" entsteht durch Division:
+     `verbrauchte Tage = verbrauchte Stunden ÷ Tagessoll` (Tagessoll **der jeweiligen Person**).
+
+**Kernpunkt:** Der Umrechnungsteiler ist das **individuelle Tagessoll** der jeweiligen Person (4 Std. bzw. 9 Std.) — **nicht** ein fester 8-Stunden-Standardtag.
+
+---
+
+## 3. Konkrete Berechnungsergebnisse (in der Software gemessen)
+
+Die folgenden Werte wurden direkt mit der Berechnungslogik der Software ermittelt (Jahresbudget anteilig: A = 30 Tage, B = 18 Tage):
+
+| Buchung | Mitarbeiterin A (4 Std./Tag) | Mitarbeiterin B (9 Std./Tag) |
+|---|---|---|
+| **1 Urlaubstag, gebucht mit dem korrekten Tagessoll** (4 bzw. 9 Std.) | **1,0 Tag** abgezogen | **1,0 Tag** abgezogen |
+| **1 ganze Urlaubswoche** (= alle Arbeitstage der Woche) | **5,0 Tage** (5 Arbeitstage) | **3,0 Tage** (3 Arbeitstage) |
+| **1 Urlaubstag, gebucht mit dem Formular-Standardwert 8 Std.** | **2,0 Tage** abgezogen | **0,9 Tage** abgezogen |
+
+**Interpretation:**
+
+- **Solange ein Urlaubstag mit dem tatsächlichen Tagessoll der Person gebucht wird, ist die Verrechnung sachgerecht:** ein freier Arbeitstag kostet genau **einen** Urlaubstag, eine freie Woche kostet so viele Urlaubstage, wie die Person Arbeitstage hat. Bezogen auf den Jahresanspruch ist das anteilig gleich (A: 5 von 30 = ⅙ Woche; B: 3 von 18 = ⅙ Woche).
+- **Verzerrung entsteht, wenn ein einzelner Tag mit einem abweichenden Stundenwert gebucht wird** — insbesondere mit dem **Formular-Standardwert von 8 Stunden**: Dann „kostet" ein freier Tag bei A **2,0** Urlaubstage und bei B **0,9** Urlaubstage. Dieser 8-Std.-Standard greift in der Einzeltag-Erfassung bei Mitarbeitenden, für die **kein individueller Tagesplan** hinterlegt ist (Mehrtages-/Wochenbuchungen verwenden dagegen automatisch das korrekte Tagessoll je Tag).
+
+> **Hinweis zur Wahrnehmung:** Die in der Praxis genannten Werte „0,5 bzw. 1,125 Urlaubstage je freiem Tag" entsprechen einer Betrachtung **Tagesstunden ÷ 8** (4÷8 = 0,5; 9÷8 = 1,125). Die Software selbst teilt jedoch durch das **individuelle Tagessoll**, nicht durch 8. Die tatsächliche Verzerrung rührt daher nicht aus der Division durch 8, sondern aus dem **8-Std.-Standardwert beim Buchen eines Einzeltags**. Beide Phänomene führen zum selben Kernanliegen: die „Tage"-Verrechnung ist nicht in allen Konstellationen ein sauberer Ganz-/Halbtag.
+
+---
+
+## 4. Wo genau die Ungleichbehandlung entsteht
+
+1. **Einzeltag-Buchung mit 8-Std.-Standard** (Hauptursache): siehe Tabelle oben. Betrifft Teilzeitkräfte ohne hinterlegten individuellen Tagesplan.
+2. **Ungleichmäßige Tagesaufteilung:** Ist ein individueller Tagesplan hinterlegt (z. B. Mo 8 Std., Di–Fr je 3 Std.), wird ein Urlaubstag mit den **Stunden des konkreten Wochentags** gebucht, der Umrechnungsteiler bleibt aber das **Durchschnitts-Tagessoll**. Ein Montag-Urlaub kostet dann mehr als ein Dienstag-Urlaub.
+3. **Nicht-anteiliges Budget:** Wird der vorgeschlagene anteilige Jahresanspruch (z. B. 18 Tage bei B) vom Administrator durch einen pauschalen Wert (z. B. 30) ersetzt, ist der **Vergleich der Resttage** zwischen Voll- und Teilzeit irreführend.
+
+In Summe ist die „Tage"-Darstellung **nur dann durchgängig ein sauberer Ganz-/Halbtag**, wenn (a) mit dem korrekten Tagessoll gebucht wird, (b) keine ungleichmäßigen Tagespläne vorliegen und (c) das Budget anteilig gesetzt ist.
+
+---
+
+## 5. Rechtlicher Rahmen (nur zur Einordnung — Bewertung durch den Prüfer)
+
+- **§ 3 Abs. 1 BUrlG** bemisst den Mindesturlaub in **Werktagen** (24 Werktage bei 6-Tage-Woche). Bei abweichender Verteilung der Arbeitstage wird der Anspruch nach ständiger BAG-Rechtsprechung **anteilig nach der Zahl der wöchentlichen Arbeitstage** umgerechnet — also tagebasiert, **unabhängig von der Stundenzahl je Tag**.
+- **Übliche Praxis / MFA-Tarif:** Abrechnung in **ganzen bzw. halben Tagen**, unabhängig davon, wie viele Stunden an dem Tag gearbeitet würden.
+- Eine **stundenbasierte/dezimale** Verrechnung kann sachgerecht sein, **solange sie im Ergebnis** zur tagebasierten Betrachtung passt (1 freier Arbeitstag = 1 Urlaubstag). Sie wird problematisch, sobald sie — wie unter Ziff. 3/4 gezeigt — von der reinen Tageszählung abweicht.
+
+---
+
+## 6. Fragen an den Prüfer
+
+1. Ist die **tagebasierte Zählung** (1 freier Arbeitstag = 1 Urlaubstag, unabhängig von den Tagesstunden; Jahresanspruch anteilig nach Arbeitstagen) für unsere Konstellation die rechtlich gebotene Methode?
+2. Ist eine **stundenbasierte/dezimale** Verrechnung zulässig, solange sie im Regelfall dasselbe Ergebnis liefert — und ist die unter Ziff. 3/4 beschriebene Abweichung (Einzeltag mit 8 Std., ungleiche Tagespläne) **rechtlich unkritisch oder zu beheben**?
+3. Gibt es Vorgaben zur **Behandlung von Halbtagen** und zur **Rundung** (z. B. kaufmännisch, immer zugunsten der/des Beschäftigten)?
+4. Wie ist mit **Bestandsdaten** umzugehen, falls die Methode umgestellt wird (rückwirkend vs. ab Stichtag)?
+
+---
+
+## 7. Mögliche Lösungswege in der Software (zur Information)
+
+- **Sofortmaßnahme (geringer Aufwand):** Einzeltag-Buchungen verwenden künftig **immer das individuelle Tagessoll** statt des 8-Std.-Standards. Damit entspricht jeder volle freie Tag exakt 1 Urlaubstag (siehe Tabelle Ziff. 3, obere Zeile).
+- **Option A — stundenbasiert (Status quo, korrigiert):** beibehalten, aber mit der Sofortmaßnahme; geeignet, wenn auch **stundenweise** Freistellungen sauber abgebildet werden sollen.
+- **Option B — tagebasiert (konfigurierbar):** Urlaub wird ausschließlich in **ganzen/halben Tagen** geführt, unabhängig von den Tagesstunden — entspricht der üblichen MFA-Praxis. Größerer Umbau; als **pro-Praxis-Einstellung** umsetzbar, sodass beide Methoden wählbar sind.
+
+Die Entscheidung zwischen A und B hängt von der rechtlichen Bewertung (Ziff. 6) ab.
+
+---
+
+## Anhang — Technische Fundstellen (für Rückfragen)
+
+- Tagessoll: `backend/app/services/calculation_service.py → get_daily_target()` (`Wochenstunden ÷ Arbeitstage`).
+- Urlaubskonto / Tage-Umrechnung: `get_vacation_account()` — `verbrauchte Tage = verbrauchte Stunden ÷ Tagessoll`, `Budget-Stunden = Budget-Tage × Tagessoll`.
+- Anteiliger Budgetvorschlag: `backend/app/models/user.py → suggested_vacation_days` (`round(30 × Arbeitstage ÷ 5)`).
+- 8-Std.-Standard bei Einzeltag-Erfassung: Frontend-Formular (`getHoursForDate` → 8 ohne individuellen Tagesplan); Mehrtagesbuchung verwendet `get_daily_target_for_date()` je Tag.
+
+*Erstellt mit Unterstützung einer KI-gestützten Code-Analyse; die zugrundeliegenden Zahlen wurden direkt mit der Berechnungslogik der Software gemessen.*

--- a/docs/specs/feedback_urlaub.md
+++ b/docs/specs/feedback_urlaub.md
@@ -1,0 +1,265 @@
+Inhaltlich spricht sehr viel dafür, dass eure Analyse korrekt ist — und dass die aktuelle Implementierung in bestimmten Konstellationen arbeitsrechtlich angreifbar sein kann.
+
+Die entscheidende juristische Leitlinie lautet:
+
+> Urlaub wird im deutschen Urlaubsrecht grundsätzlich nach **Arbeitstagen**, nicht nach Arbeitsstunden bemessen.
+
+Das zieht sich durch:
+
+* § 3 BUrlG,
+* BAG-Rechtsprechung,
+* IHK/Haufe-Fachliteratur,
+* und die übliche arbeitsrechtliche Praxis. ([Haufe.de News und Fachwissen][1])
+
+---
+
+# Juristische Kernaussage
+
+## 1. Das „Tagesprinzip“ ist der zentrale Maßstab
+
+Die Rechtsprechung betrachtet Urlaub primär als:
+
+* Freistellung von der Arbeitspflicht an einem Arbeitstag,
+* nicht als Stundenkontingent.
+
+Haufe formuliert das sehr deutlich:
+
+> „Das Urlaubsrecht geht vom Tagesprinzip aus.“ ([Haufe.de News und Fachwissen][2])
+
+Ebenso:
+
+* Für die Urlaubsdauer kommt es auf die Zahl der Arbeitstage an,
+* nicht auf die Länge der täglichen Arbeitszeit. ([Haufe.de News und Fachwissen][1])
+
+Das bestätigt exakt eure Grundannahme im PDF.
+
+---
+
+# 2. Eure anteilige Umrechnung nach Arbeitstagen ist korrekt
+
+Die Berechnung:
+
+[
+30 \times \frac{\text{Arbeitstage}}{5}
+]
+
+entspricht der üblichen BAG-konformen Teilzeitumrechnung. ([Haufe.de News und Fachwissen][1])
+
+Beispiele:
+
+* 5 Tage/Woche → 30 Urlaubstage
+* 3 Tage/Woche → 18 Urlaubstage
+
+Das ist arbeitsrechtlich Standard.
+
+Der relevante Punkt:
+Nicht die Wochenstunden sind entscheidend,
+sondern die Anzahl der Arbeitstage. ([Arbeitsrechte][3])
+
+---
+
+# 3. Eure „korrigierte Stundenlogik“ ist wahrscheinlich zulässig
+
+Der wichtige Unterschied:
+
+## Wahrscheinlich zulässig
+
+Wenn intern zwar mit Stunden gerechnet wird, aber:
+
+* jeder freie Arbeitstag exakt 1 Urlaubstag verbraucht,
+* eine freie Woche proportional gleich behandelt wird,
+* keine Benachteiligung entsteht,
+
+dann dürfte das juristisch meist akzeptabel sein.
+
+Das entspricht faktisch nur einer technischen Speicherform.
+
+Genau das macht eure „Sofortmaßnahme“:
+
+* individueller Tagessollwert statt 8h-Default.
+
+Dadurch wird:
+
+* 1 Arbeitstag Urlaub = 1 Urlaubstag Verbrauch.
+
+Das ist der entscheidende Punkt.
+
+---
+
+# 4. Der 8-Stunden-Default ist das eigentliche Risiko
+
+Das ist vermutlich eure stärkste juristische Erkenntnis.
+
+Denn hier entsteht tatsächlich eine Ungleichbehandlung:
+
+| Person   | Tatsächlicher Arbeitstag | Gebuchter Urlaub |
+| -------- | ------------------------ | ---------------- |
+| 4h-Kraft | 1 freier Tag             | 2 Urlaubstage    |
+| 9h-Kraft | 1 freier Tag             | 0,9 Urlaubstage  |
+
+Das widerspricht dem Tagesprinzip massiv.
+
+Denn:
+
+* derselbe freie Arbeitstag
+* verbraucht unterschiedlich viel Urlaub.
+
+Das dürfte sehr schwer zu rechtfertigen sein. ([Haufe.de News und Fachwissen][2])
+
+---
+
+# 5. Ungleichmäßige Tagespläne sind juristisch heikel
+
+Das ist der schwierigste Punkt.
+
+Beispiel:
+
+* Montag 8h
+* Dienstag 3h
+
+Wenn:
+
+* Montag mehr Urlaub „kostet“ als Dienstag,
+* obwohl beides jeweils ein Arbeitstag ist,
+
+kollidiert das mit dem klassischen Tagesprinzip.
+
+Haufe beschreibt genau dieses Problem:
+
+* bei ungleich verteilten Arbeitszeiten,
+* unabhängig von den Stunden,
+* bleibt grundsätzlich der Arbeitstag entscheidend. ([Haufe.de News und Fachwissen][2])
+
+Das spricht eher gegen:
+
+* unterschiedliche „Kosten“ einzelner Arbeitstage.
+
+---
+
+# 6. Halbe Urlaubstage
+
+Das BUrlG kennt eigentlich nur Urlaubstage.
+
+Halbe Tage sind:
+
+* betriebliche Praxis,
+* tarifliche oder arbeitsvertragliche Gestaltung,
+* aber kein gesetzlicher Grundmechanismus.
+
+Eure Frage dazu ist juristisch absolut berechtigt.
+
+Wichtig:
+Wenn halbe Tage zugelassen werden,
+muss die Logik konsistent und diskriminierungsfrei sein.
+
+---
+
+# 7. Was ein Arbeitsrechtler wahrscheinlich empfehlen wird
+
+Mit hoher Wahrscheinlichkeit etwa Folgendes:
+
+## Empfehlung A (wahrscheinlich bevorzugt)
+
+### Tagebasierte Führung
+
+* Urlaub in Tagen
+* optional halbe Tage
+* unabhängig von Stunden pro Tag
+
+Das ist:
+
+* rechtlich am robustesten,
+* am verständlichsten,
+* BAG-nah,
+* MFA-praxisnah.
+
+---
+
+## Empfehlung B (wahrscheinlich noch zulässig)
+
+### Stundenbasiert intern — aber nur vollständig äquivalent
+
+Also nur wenn:
+
+* jeder freie Arbeitstag exakt 1 Urlaubstag kostet,
+* keine Verzerrung durch Defaults entsteht,
+* keine Benachteiligung bei Teilzeit,
+* keine Unterschiede zwischen langen/kurzen Tagen.
+
+Dann ist die Stundenführung wohl eher ein technisches Detail.
+
+---
+
+# 8. Meine fachliche Einschätzung zur Softwarearchitektur
+
+## Sofortmaßnahme
+
+Die solltet ihr wahrscheinlich unabhängig von der Rechtsprüfung umsetzen:
+
+> Kein 8h-Default mehr bei Einzeltagen.
+
+Denn:
+
+* das ist technisch klar fehleranfällig,
+* arbeitsrechtlich schwer verteidigbar,
+* und erzeugt reale Verzerrungen.
+
+---
+
+# 9. Wahrscheinlich kritischster Satz für eine Prüfung
+
+Der juristisch gefährlichste Befund ist:
+
+> „Ein Montag-Urlaub kostet mehr als ein Dienstag-Urlaub.“
+
+Denn genau das widerspricht sehr wahrscheinlich:
+
+* dem Gleichbehandlungsgrundsatz,
+* dem Tagesprinzip,
+* und der üblichen BAG-Logik.
+
+---
+
+# 10. Zusammenfassende Bewertung wie ein Steuerberater/Prüfer
+
+## Wahrscheinlich rechtlich unkritisch:
+
+* anteilige Urlaubstage nach Arbeitstagen,
+* interne Stundenführung,
+* Durchschnitts-Tagessoll,
+* sofern Ergebnis immer tageäquivalent bleibt.
+
+## Wahrscheinlich problematisch:
+
+* 8h-Standardwert,
+* unterschiedliche Urlaubskosten einzelner Arbeitstage,
+* jede Logik, bei der ein freier Arbeitstag nicht exakt „1 Urlaubstag“ entspricht.
+
+---
+
+# Mein fachliches Fazit
+
+Eure Analyse ist:
+
+* technisch sauber,
+* arbeitsrechtlich gut durchdacht,
+* und identifiziert wahrscheinlich korrekt die eigentliche Schwachstelle.
+
+Der entscheidende Punkt ist nicht:
+
+> „stundenbasiert vs tagebasiert“
+
+sondern:
+
+> Entsteht im Ergebnis eine vom Tagesprinzip abweichende Benachteiligung?
+
+Und genau das scheint:
+
+* beim 8h-Default
+* und bei ungleichen Tagesplänen
+
+tatsächlich der Fall zu sein.
+
+[1]: https://www.haufe.de/personal/haufe-personal-office-platin/urlaub-berechnung-teilzeit-sonderfaelle-3-teilzeit_idesk_PI42323_HI2713475.html?utm_source=chatgpt.com "Urlaub: Sonderfälle / 1 Teilzeittätigkeit | Haufe"
+[2]: https://www.haufe.de/id/beitrag/5-urlaub-ii-sonderfaelle-in-teilzeitverhaeltnissen-HI16702686.html?utm_source=chatgpt.com "§ 5 Urlaub / II. Sonderfälle in Teilzeitverhältnissen | Haufe"
+[3]: https://www.arbeitsrechte.de/urlaubsanspruch-teilzeit/?utm_source=chatgpt.com "Urlaubsanspruch bei Teilzeit: Was Ihnen 2026 zusteht"


### PR DESCRIPTION
Setzt die arbeitsrechtliche Prüfer-Einschätzung zu #156 um (§3 BUrlG / BAG **Tagesprinzip**: *ein freier Arbeitstag = genau 1 Urlaubstag*, unabhängig von Stunden/Wochentag).

## Verifikation
Backend: **SQLite-Suite 815 passed / 44 skipped / 0 failed**, Postgres-Gruppe (RLS + Concurrency) **21 passed**.

## T1 — Sofortmaßnahme (8h-Default beseitigt) · Commit `713bdeb`
`create_absence` buchte für Nicht-Tagesplan-Mitarbeitende einen Einzeltag mit der Formular-Stundenzahl (Default **8h**) → ein freier Tag konnte **2,0 statt 1,0** Urlaubstage kosten (Teilzeit). Jetzt: alle Voll-Tag-Typen (VACATION/TRAINING/OTHER/PAID_LEAVE) buchen das **individuelle Tagessoll des Tages**; nur OVERTIME behält die explizite Stundenzahl. §3-EntgFG-Logik für SICK unverändert.

## T2 — Tagebasierte Urlaubszählung · Commit `97e0dc1`
`get_vacation_account` zählt den Verbrauch in **Tagen**: jeder Urlaubstag = `Stunden ÷ Tagessoll DES TAGES` (voller Tag 1,0; Halbtag 0,5) statt `Stundensumme ÷ Durchschnitts-Tagessoll`. Behebt den vom Prüfer als kritischsten markierten Fall („Montag-Urlaub kostet mehr als Dienstag-Urlaub" bei ungleichmäßigem Tagesplan):

| Tagesplan Mo 8h / Di 3h | vorher | nachher |
|---|---|---|
| Montag-Urlaub | 2,0 Tage | **1,0 Tag** |
| Dienstag-Urlaub | 0,75 Tage | **1,0 Tag** |

Rest-Anzeige + Budget-Prüfung in `create_absence` sind tagebasiert; Stundenwerte bleiben informativ (Soll/Ist).

## T5 — Test-Matrix
`test_vacation_day_principle.py`: 1 Arbeitstag = 1,0 Tag für **Vollzeit, uniforme Teilzeit, 3-Tage-Woche und ungleichmäßigen Tagesplan**; Woche = Anzahl Arbeitstage. Plus `test_absence_full_day_hours.py` (Sofortmaßnahme + OVERTIME behält explizite Stunden).

## Doku (Audit-Trail)
`docs/specs/2026-05-29-urlaubsberechnung-pruefvorlage.md` (Sachverhalt) + `docs/specs/feedback_urlaub.md` (arbeitsrechtliche Einschätzung).

## Offen (Follow-ups, nicht in diesem PR)
- **T3:** Halbe Urlaubstage als konsistentes, diskriminierungsfreies Modell (BUrlG kennt nur ganze Tage; halbe = betriebliche Gestaltung). Die Mechanik (0,5) wird durch T2 bereits unterstützt — fehlt: UI/Buchungsweg.
- **T4:** Zielbild „Empfehlung A (tagebasiert)" final dokumentieren; ggf. expliziter Schalter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
