### PR TITLE
docs(#156): Urlaubsberechnung (Tagesprinzip) in Handbüchern, In-App-Hilfe und UI erklären

### DIFF
--- a/docs/handbuch/CHEATSHEET-ADMIN.md
+++ b/docs/handbuch/CHEATSHEET-ADMIN.md
@@ -19,7 +19,9 @@
 - Vorname / Nachname, E-Mail (optional)
 - Wochenstunden, Arbeitstage/Woche, Urlaubstage
 - Rolle: Mitarbeiter:in oder Admin
-- Optional: ArbZG-Prüfungen aussetzen (§18), Nachtarbeitnehmer (§6)
+- Optional: ArbZG-Prüfungen aussetzen (§18), Nachtarbeitnehmer (§6), Abteilung/Bereich, Anfangssaldo Überstunden
+
+> **Urlaub (Tagesprinzip):** 1 freier Arbeitstag = 1 Urlaubstag (unabhängig von Tagesstunden/Wochentag). Anspruch anteilig: `30 × Arbeitstage/5`. Verbrauch tagebasiert, Stunden nur intern.
 
 ### Stundenänderung (Teilzeit etc.)
 **Benutzer öffnen** → neue Wochenstunden + **Wirkungsdatum** eintragen

--- a/docs/handbuch/CHEATSHEET-MITARBEITER.md
+++ b/docs/handbuch/CHEATSHEET-MITARBEITER.md
@@ -95,6 +95,10 @@ Zurückziehen: Button **Zurückziehen** bei offenen Anträgen
 - Tab **„Meine Anträge"** zeigt Status
 - Offene Anträge können zurückgezogen werden
 
+### Urlaubsberechnung
+- **1 freier Arbeitstag = 1 Urlaubstag** (egal wie viele Stunden der Tag hat)
+- Freie Woche = Anzahl Ihrer Arbeitstage; Konto zeigt Resttage
+
 ---
 
 ## Dashboard verstehen

--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -144,9 +144,9 @@ Klicken Sie auf **„Neuer Mitarbeiter:in"** und füllen Sie das Formular aus:
 | **Benutzername** | Eindeutiger Login-Name (z. B. `m.hoffmann`) |
 | **Passwort** | Initiales Passwort (mind. 10 Zeichen, Groß-/Kleinbuchstabe, Ziffer) |
 | **Rolle** | Mitarbeiter:in oder Admin |
-| **Wochenstunden** | Vertraglich vereinbarte Wochenstunden (Standard: 40) |
-| **Arbeitstage pro Woche** | Anzahl der Arbeitstage 1–7 (Standard: 5) |
-| **Urlaubstage** | Jährlicher Urlaubsanspruch (Standard: 30) |
+| **Wochenstunden** | Vertraglich vereinbarte Wochenstunden (Standard: 40). Viertelstunden (0,25/0,75) bei individuellen Tagesstunden möglich. |
+| **Arbeitstage pro Woche** | Anzahl der Arbeitstage 1–7 (Standard: 5). Bestimmt den anteiligen Urlaubsvorschlag. |
+| **Urlaubstage** | Jährlicher Urlaubsanspruch in **Tagen**. Vorschlag anteilig nach Arbeitstagen: `30 × Arbeitstage ÷ 5` (5 Tage → 30, 3 Tage → 18). Überschreibbar. |
 
 **Optionale Felder:**
 | Feld | Beschreibung |
@@ -158,8 +158,12 @@ Klicken Sie auf **„Neuer Mitarbeiter:in"** und füllen Sie das Formular aus:
 | **Nachtarbeitnehmer** | § 6 ArbZG – 8h-Tageslimit bei Nachtarbeit |
 | **Erster / Letzter Arbeitstag** | Eintrittsdatum und ggf. geplantes Austrittsdatum |
 | **Individuelle Tagesstunden** | Abweichende Stundenverteilung Mo–Fr statt einheitlich |
+| **Abteilung/Bereich** | Optionale Zuordnung (Freitext); ermöglicht Filterung im Abwesenheitskalender |
+| **Anfangssaldo Überstunden** | Übernommener Überstundensaldo zum Startjahr (kann +/- sein) |
 
 > **Rechtlicher Hinweis (§18 ArbZG):** Leitende Angestellte können von ArbZG-Beschränkungen ausgenommen werden. Aktivieren Sie dieses Flag nur für Personen, die tatsächlich unter § 18 ArbZG fallen.
+
+> **So wird Urlaub berechnet (Tagesprinzip, § 3 BUrlG / BAG):** Der Urlaub wird **nach Arbeitstagen** geführt, nicht nach Stunden. Ein freier Arbeitstag verbraucht **genau 1 Urlaubstag**, unabhängig von der Tagesstundenzahl – ein langer Tag (z. B. 9 h) kostet so viel wie ein kurzer (z. B. 4 h): einen Tag. Auch bei **individuellen Tagesstunden** kostet jeder Arbeitstag gleich viel (Montag = Dienstag). Der Jahresanspruch wird anteilig nach Arbeitstagen vorgeschlagen. Intern speichert das System Stunden (für die Soll-/Ist-Berechnung); der **Verbrauch wird tagebasiert** gezählt und im Urlaubskonto in Tagen angezeigt.
 
 ### Mitarbeiter bearbeiten
 

--- a/docs/handbuch/HANDBUCH-MITARBEITER.md
+++ b/docs/handbuch/HANDBUCH-MITARBEITER.md
@@ -284,6 +284,19 @@ In der Listenansicht Ihrer Abwesenheiten befindet sich der Button **Löschen**. 
 
 ---
 
+### 4.4 So wird Ihr Urlaub berechnet
+
+PraxisZeit führt Urlaub **nach Arbeitstagen** (Tagesprinzip nach § 3 BUrlG) – **nicht** nach Stunden:
+
+- **Ein freier Arbeitstag = genau 1 Urlaubstag**, unabhängig davon, wie viele Stunden Sie an diesem Tag arbeiten würden. Ein 9-Stunden-Tag kostet genauso viel Urlaub wie ein 4-Stunden-Tag: **einen Tag**.
+- Eine **freie Woche** kostet so viele Urlaubstage, wie Sie Arbeitstage in der Woche haben (5-Tage-Woche → 5 Tage, 3-Tage-Woche → 3 Tage).
+- Ihr **Jahresanspruch** richtet sich nach der Zahl Ihrer Arbeitstage pro Woche (z. B. 5 Tage → 30 Tage, 3 Tage → anteilig 18 Tage). Den genauen Wert legt Ihr Administrator fest.
+- Das **Urlaubskonto** auf dem Dashboard zeigt jederzeit Budget, genommene und verbleibende Tage.
+
+> Intern rechnet das System mit Stunden (für die Soll-/Ist-Berechnung), Ihr Urlaubsverbrauch wird Ihnen aber immer in **ganzen Tagen** angezeigt.
+
+---
+
 ## 5. Profil & Passwort
 
 Klicken Sie in der Navigation auf **Profil**.

--- a/docs/specs/features/vacation-requests.md
+++ b/docs/specs/features/vacation-requests.md
@@ -103,9 +103,11 @@ CREATE INDEX ix_vacation_requests_date    ON vacation_requests(date);
 **Approve-Logik** (identisch mit `create_absence()`):
 1. Werktage im Zeitraum bestimmen (Feiertage via `PublicHoliday` ausschließen)
 2. Auf doppelte vacation-Einträge prüfen
-3. Urlaubsbudget prüfen (`calculation_service.get_vacation_account()`)
-4. `use_daily_schedule`-Stunden pro Tag berücksichtigen
+3. Urlaubsbudget prüfen — **tagebasiert** (`days_needed` vs. `remaining_days`)
+4. Stunden je Tag = **individuelles Tagessoll des Tages** (`get_daily_target_for_date`), nie ein 8h-Default
 5. `Absence`-Einträge erstellen, `VacationRequest.status = approved`
+
+> **Berechnung (Tagesprinzip, § 3 BUrlG / BAG — #156):** Urlaub wird **nach Arbeitstagen** geführt. Ein freier Arbeitstag verbraucht genau **1 Urlaubstag**, unabhängig von Tagesstunden und Wochentag. `get_vacation_account` zählt den Verbrauch als `Σ (gebuchte Stunden ÷ Tagessoll des Tages)` (voller Tag = 1,0; Halbtag = 0,5), **nicht** als `Stundensumme ÷ Durchschnitts-Tagessoll`. Damit kostet ein Montag-Urlaub bei ungleichmäßigem Tagesplan genauso viel wie ein Dienstag-Urlaub. Jahresanspruch anteilig: `30 × Arbeitstage ÷ 5`. Stunden bleiben intern für Soll/Ist; der Urlaubsverbrauch ist tagebasiert.
 
 ### Frontend (React/TypeScript)
 

--- a/frontend/src/components/DocViewer.tsx
+++ b/frontend/src/components/DocViewer.tsx
@@ -297,6 +297,7 @@ export const handbuchMitarbeiterSections: AccordionItem[] = [
         <p>Navigieren Sie zu <strong>Abwesenheiten</strong> und klicken Sie auf <strong>+ Abwesenheit eintragen</strong>. Wählen Sie den Typ (Urlaub, Krank, Fortbildung, Sonstiges) und das Datum.</p>
         <p>Für Zeiträume aktivieren Sie die Checkbox <strong>„Zeitraum"</strong> und geben ein Enddatum an. Wochenenden und Feiertage werden automatisch ausgeschlossen.</p>
         <p>Wenn Urlaubsgenehmigungspflicht aktiv ist, wechselt die App nach dem Absenden automatisch zum Tab <strong>„Meine Anträge"</strong>.</p>
+        <p className="text-gray-700"><strong>So wird Urlaub berechnet:</strong> nach dem Tagesprinzip (§3 BUrlG) – <strong>ein freier Arbeitstag = genau 1 Urlaubstag</strong>, egal wie viele Stunden Sie an dem Tag arbeiten. Eine freie Woche kostet so viele Tage, wie Sie Arbeitstage haben. Ihr Urlaubskonto zeigt die verbleibenden Tage.</p>
       </div>
     ),
   },
@@ -354,6 +355,7 @@ export const handbuchAdminSections: AccordionItem[] = [
       <div className="space-y-2">
         <p><strong>Urlaubsanträge:</strong> Toggle „Genehmigungspflicht" aktiviert den Workflow. Anträge erscheinen als „Offen" → Genehmigen (grün) oder Ablehnen (rot, optional Grund).</p>
         <p><strong>Betriebsferien:</strong> Abwesenheiten → Tab „Betriebsferien" → Neue Betriebsferien. Alle aktiven Mitarbeiter erhalten automatisch Abwesenheitseinträge (kein Urlaubsabzug). Beim Löschen werden alle Einträge entfernt.</p>
+        <p className="text-gray-700"><strong>Urlaubsberechnung (Tagesprinzip, §3 BUrlG):</strong> Urlaub wird nach Arbeitstagen geführt – ein freier Arbeitstag = <strong>1 Urlaubstag</strong>, unabhängig von Tagesstunden und Wochentag (auch bei individuellen Tagesstunden). Jahresanspruch anteilig: <code>30 × Arbeitstage ÷ 5</code> (überschreibbar beim Anlegen). Verbrauch wird tagebasiert gezählt, intern gespeicherte Stunden dienen nur der Soll-/Ist-Berechnung.</p>
       </div>
     ),
   },

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -549,6 +549,9 @@ export default function Dashboard() {
                   <span className="font-medium">{vacationAccount.used_days.toFixed(1)} Tage</span>
                 </div>
               </div>
+              <p className="mt-2 text-xs text-gray-400">
+                Ein freier Arbeitstag = 1 Urlaubstag (unabhängig von den Tagesstunden).
+              </p>
               {vacationAccount.has_carryover_warning && vacationAccount.carryover_deadline && (
                 <div className="mt-3 p-2 bg-amber-50 border border-amber-200 rounded-lg">
                   <p className="text-xs text-amber-800 font-medium">


### PR DESCRIPTION
Macht für Nutzer:innen direkt sichtbar, **wie Urlaub berechnet wird** (Tagesprinzip aus PR #166). Reine Dokumentations-/Texte — kein Logikänderung.

## Stellen
- **Mitarbeiter-Handbuch** — neue Sektion „4.4 So wird Ihr Urlaub berechnet".
- **Admin-Handbuch** — Callout zur Tagesprinzip-Berechnung + anteiligem Anspruch; `Urlaubstage`-Feld präzisiert; neue Optionsfelder (Abteilung/Bereich, Anfangssaldo Überstunden) ergänzt.
- **Cheatsheets** (MA + Admin) — Kurzhinweis „1 Arbeitstag = 1 Urlaubstag".
- **In-App-Hilfe** (`DocViewer.tsx`) — Erläuterung in den Urlaubs-Abschnitten (MA „Abwesenheiten eintragen", Admin „Urlaubsanträge & Betriebsferien").
- **Dashboard-Urlaubskonto** — Inline-Hinweis „Ein freier Arbeitstag = 1 Urlaubstag (unabhängig von den Tagesstunden)".
- **Feature-Spec** `vacation-requests.md` — tagebasierte Berechnung + Tagessoll-Buchung dokumentiert.

Kernbotschaft überall einheitlich: **1 freier Arbeitstag = 1 Urlaubstag**, Jahresanspruch anteilig `30 × Arbeitstage/5`, Stunden nur intern.

**Verifikation:** Frontend `tsc` 0 Fehler · `vite build` ✓ (nur statische Texte geändert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
