### PR TITLE
feat(#167): Halbe Urlaubstage — konsistenter Buchungsweg (beide Pfade)

### DIFF
--- a/backend/alembic/versions/2026_05_29_1500-046_add_vr_half_day.py
+++ b/backend/alembic/versions/2026_05_29_1500-046_add_vr_half_day.py
@@ -1,0 +1,28 @@
+"""Add vacation_requests.half_day (#167 — halbe Urlaubstage im Antrags-Workflow).
+
+Nullable Boolean, Default false. Markiert einen Urlaubsantrag als halben Tag;
+bei Genehmigung wird die Abwesenheit mit 0,5 × Tagessoll gebucht.
+
+Revision ID: 046_add_vr_half_day
+Revises: 045_add_user_department
+Create Date: 2026-05-29
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '046_add_vr_half_day'
+down_revision = '045_add_user_department'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'vacation_requests',
+        sa.Column('half_day', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('vacation_requests', 'half_day')

--- a/backend/app/models/vacation_request.py
+++ b/backend/app/models/vacation_request.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Date, Numeric, Text, DateTime, String, ForeignKey
+from sqlalchemy import Column, Date, Numeric, Text, DateTime, String, ForeignKey, Boolean
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 import uuid
@@ -25,6 +25,7 @@ class VacationRequest(Base):
     end_date = Column(Date, nullable=True)
     hours = Column(Numeric(5, 2), nullable=False)
     absence_type = Column(String(20), nullable=False, default="vacation")
+    half_day = Column(Boolean, nullable=False, default=False, server_default='false')  # #167
     note = Column(Text, nullable=True)
     status = Column(String(20), nullable=False, default=VacationRequestStatus.PENDING.value, index=True)
     rejection_reason = Column(Text, nullable=True)

--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -319,10 +319,11 @@ def create_absence(
             dates_by_year.setdefault(d.year, []).append(d)
         for check_year, year_dates in dates_by_year.items():
             vacation_account = calculation_service.get_vacation_account(db, target_user, check_year)
-            # #156/T2 — Tagesprinzip: each booked full working day consumes exactly
-            # one vacation day; compare the day COUNT against the remaining DAYS,
-            # not hours (hours-based checks mis-block uneven schedules / part-time).
-            days_needed = len(year_dates)
+            # #156/T2 — Tagesprinzip: each booked working day consumes one vacation
+            # day (0,5 for a half day, #167); compare the day COUNT against the
+            # remaining DAYS, not hours (hours-based checks mis-block uneven
+            # schedules / part-time).
+            days_needed = len(year_dates) * (0.5 if absence_data.half_day else 1.0)
             if days_needed > vacation_account["remaining_days"] + 1e-9:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
@@ -387,6 +388,10 @@ def create_absence(
             hours_for_day = float(calculation_service.get_daily_target_for_date(target_user, date, weekly_hours=weekly))
             if hours_for_day == 0:
                 continue  # Skip days with 0 scheduled hours
+            # #167: halber Tag = 0,5 × Tagessoll → zählt diskriminierungsfrei als 0,5
+            # Urlaubstag (8h-Tag: 4h; 3h-Tag: 1,5h — je 0,5 Tag). Nicht für OVERTIME.
+            if absence_data.half_day:
+                hours_for_day = round(hours_for_day / 2, 2)
         else:
             hours_for_day = absence_data.hours
 

--- a/backend/app/routers/admin_vacations.py
+++ b/backend/app/routers/admin_vacations.py
@@ -232,14 +232,9 @@ def review_vacation_request(
             dates_by_year.setdefault(d.year, []).append(d)
         for check_year, year_dates in dates_by_year.items():
             vacation_account = calculation_service.get_vacation_account(db, target_user, check_year)
-            year_hours_needed = sum(
-                float(calculation_service.get_daily_target_for_date(
-                    target_user, d,
-                    weekly_hours=calculation_service.get_weekly_hours_for_date(db, target_user, d),
-                ))
-                for d in year_dates
-            )
-            if float(vacation_account['remaining_hours']) - year_hours_needed < 0:
+            # #156/T2 + #167: tagebasiert (jeder Tag = 1, Halbtag = 0,5).
+            days_needed = len(year_dates) * (0.5 if vr.half_day else 1.0)
+            if days_needed > vacation_account["remaining_days"] + 1e-9:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"Nicht genügend Urlaubstage für {check_year} ({vacation_account['remaining_days']:.1f} Tage verfügbar)",
@@ -263,13 +258,15 @@ def review_vacation_request(
 
     # Create absence entries
     for d in dates_to_create:
-        if getattr(target_user, 'use_daily_schedule', False):
-            weekly = calculation_service.get_weekly_hours_for_date(db, target_user, d)
-            hours_for_day = float(calculation_service.get_daily_target_for_date(target_user, d, weekly_hours=weekly))
-            if hours_for_day == 0:
-                continue
-        else:
-            hours_for_day = float(vr.hours)
+        # #156/T1 + #167: ein voller Urlaubstag wird immer mit dem Tagessoll des
+        # Tages gebucht (Tagesprinzip), nicht mit vr.hours (das den 8h-Default
+        # tragen kann). Halber Tag = 0,5 × Tagessoll.
+        weekly = calculation_service.get_weekly_hours_for_date(db, target_user, d)
+        hours_for_day = float(calculation_service.get_daily_target_for_date(target_user, d, weekly_hours=weekly))
+        if hours_for_day == 0:
+            continue
+        if vr.half_day:
+            hours_for_day = round(hours_for_day / 2, 2)
 
         absence = Absence(
             user_id=target_user.id,

--- a/backend/app/routers/vacation_requests.py
+++ b/backend/app/routers/vacation_requests.py
@@ -302,6 +302,7 @@ def create_vacation_request(
         end_date=data.end_date,
         hours=data.hours,
         absence_type=absence_type,
+        half_day=data.half_day,
         note=data.note,
         status=VacationRequestStatus.PENDING.value,
     )

--- a/backend/app/schemas/absence.py
+++ b/backend/app/schemas/absence.py
@@ -20,6 +20,7 @@ class AbsenceCreate(AbsenceBase):
     user_id: Optional[str] = None  # Admin only: create absence for another user
     refund_vacation: bool = False  # If sick: refund overlapping vacation days
     keep_time_entries: bool = False  # Don't delete existing time entries (mixed days)
+    half_day: bool = False  # #167: half vacation day (0.5 × Tagessoll, diskriminierungsfrei)
 
 
 class AbsenceResponse(AbsenceBase):

--- a/backend/app/schemas/vacation_request.py
+++ b/backend/app/schemas/vacation_request.py
@@ -11,6 +11,7 @@ class VacationRequestCreate(BaseModel):
     hours: float
     note: Optional[str] = None
     absence_type: Optional[str] = "vacation"
+    half_day: bool = False  # #167: halber Urlaubstag
 
     @field_validator('absence_type')
     @classmethod
@@ -72,6 +73,7 @@ class VacationRequestResponse(BaseModel):
     hours: float
     days: Optional[float] = None  # Number of workdays (excluding weekends/holidays)
     absence_type: str = "vacation"
+    half_day: bool = False  # #167
     note: Optional[str] = None
     status: str
     rejection_reason: Optional[str] = None

--- a/backend/tests/test_absence_request_approval.py
+++ b/backend/tests/test_absence_request_approval.py
@@ -552,3 +552,19 @@ class TestAdminListEndpoint:
         types = {r["absence_type"] for r in data}
         assert "training" in types
         assert "vacation" in types
+
+
+def test_approve_half_day_vacation_deducts_half(db, employee, admin_client):
+    """#167: ein als Halbtag markierter Urlaubsantrag verbraucht bei Genehmigung
+    genau 0,5 Tage (Tagessoll ÷ 2, diskriminierungsfrei)."""
+    from app.services import calculation_service
+    vr = _create_pending_request(db, employee, absence_type="vacation",
+                                 req_date=date(2025, 3, 12), hours=8.0)
+    vr.half_day = True
+    db.commit()
+    resp = admin_client.post(
+        f"/api/admin/vacation-requests/{vr.id}/review", json={"action": "approve"}
+    )
+    assert resp.status_code == 200, resp.text
+    acc = calculation_service.get_vacation_account(db, employee, 2025)
+    assert acc["used_days"] == 0.5

--- a/backend/tests/test_vacation_day_principle.py
+++ b/backend/tests/test_vacation_day_principle.py
@@ -114,3 +114,33 @@ def test_full_week_equals_number_of_workdays(db, default_tenant):
     )
     assert r.status_code == 201, r.text
     assert _used(db, u) == 5.0
+
+
+# ── #167: Halbe Urlaubstage (konsistent, diskriminierungsfrei) ──────────────
+
+def test_half_day_vacation_costs_half(db, default_tenant):
+    u = _mk(db, weekly_hours=40.0, work_days_per_week=5)  # 8h/Tag
+    r = _client(db, u).post(
+        "/api/absences", json={"date": MON, "type": "vacation", "hours": 8, "half_day": True}
+    )
+    assert r.status_code == 201, r.text
+    assert _used(db, u) == 0.5
+
+
+def test_half_day_uneven_schedule_is_consistent(db, default_tenant):
+    """Halbtag muss diskriminierungsfrei sein: Mo (8h) und Di (3h) je 0,5 Tag."""
+    sched = dict(
+        weekly_hours=20.0, work_days_per_week=5, use_daily_schedule=True,
+        hours_monday=8, hours_tuesday=3, hours_wednesday=3, hours_thursday=3, hours_friday=3,
+    )
+    u_mon = _mk(db, **sched)
+    assert _client(db, u_mon).post(
+        "/api/absences", json={"date": MON, "type": "vacation", "hours": 8, "half_day": True}
+    ).status_code == 201
+    assert _used(db, u_mon) == 0.5
+
+    u_tue = _mk(db, **sched)
+    assert _client(db, u_tue).post(
+        "/api/absences", json={"date": TUE, "type": "vacation", "hours": 3, "half_day": True}
+    ).status_code == 201
+    assert _used(db, u_tue) == 0.5

--- a/frontend/src/pages/AbsenceCalendarPage.tsx
+++ b/frontend/src/pages/AbsenceCalendarPage.tsx
@@ -114,6 +114,7 @@ export default function AbsenceCalendarPage() {
     type: 'vacation' as 'vacation' | 'sick' | 'training' | 'overtime' | 'other',
     hours: getHoursForDate(currentUser, format(new Date(), 'yyyy-MM-dd')) || 8,
     note: '',
+    half_day: false,
   });
   const { confirmState, confirm, handleConfirm, handleCancel } = useConfirm();
   const [editingRequest, setEditingRequest] = useState<VacationRequest | null>(null);
@@ -201,12 +202,13 @@ export default function AbsenceCalendarPage() {
           hours: formData.hours,
           absence_type: formData.type,
           note: formData.note || null,
+          half_day: !isDateRange && formData.half_day,
         });
         toast.success('Antrag gestellt – wartet auf Genehmigung');
         fetchMyVacationRequests();
         setShowForm(false);
         setIsDateRange(false);
-        setFormData({ date: format(new Date(), 'yyyy-MM-dd'), end_date: '', type: 'vacation', hours: getHoursForDate(currentUser, format(new Date(), 'yyyy-MM-dd')) || 8, note: '' });
+        setFormData({ date: format(new Date(), 'yyyy-MM-dd'), end_date: '', type: 'vacation', hours: getHoursForDate(currentUser, format(new Date(), 'yyyy-MM-dd')) || 8, note: '', half_day: false });
         setActiveTab('requests');
         return;
       }
@@ -218,6 +220,7 @@ export default function AbsenceCalendarPage() {
         hours: formData.hours,
         note: formData.note || null,
         refund_vacation: refundVacation,
+        half_day: !isDateRange && formData.half_day,
       };
       await apiClient.post('/absences', submitData);
       const msg = refundVacation
@@ -227,7 +230,7 @@ export default function AbsenceCalendarPage() {
       fetchData();
       setShowForm(false);
       setIsDateRange(false);
-      setFormData({ date: format(new Date(), 'yyyy-MM-dd'), end_date: '', type: 'vacation', hours: getHoursForDate(currentUser, format(new Date(), 'yyyy-MM-dd')) || 8, note: '' });
+      setFormData({ date: format(new Date(), 'yyyy-MM-dd'), end_date: '', type: 'vacation', hours: getHoursForDate(currentUser, format(new Date(), 'yyyy-MM-dd')) || 8, note: '', half_day: false });
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Speichern'));
     } finally {
@@ -509,6 +512,22 @@ export default function AbsenceCalendarPage() {
                 Zeitraum (mehrere Tage)
               </label>
             </div>
+
+            {/* #167: halber Tag (nur Einzeltag, nicht für Überstunden/Krank) */}
+            {!isDateRange && formData.type !== 'overtime' && formData.type !== 'sick' && (
+              <div className="flex items-center space-x-2 p-3 bg-gray-50 rounded-lg">
+                <input
+                  type="checkbox"
+                  id="halfDay"
+                  checked={formData.half_day}
+                  onChange={(e) => setFormData({ ...formData, half_day: e.target.checked })}
+                  className="w-4 h-4 text-primary border-gray-300 rounded-sm focus:ring-primary"
+                />
+                <label htmlFor="halfDay" className="text-sm font-medium text-gray-700 cursor-pointer">
+                  Halber Tag (zählt als 0,5 Tag)
+                </label>
+              </div>
+            )}
 
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
               <div>

--- a/frontend/src/pages/admin/AdminAbsences.tsx
+++ b/frontend/src/pages/admin/AdminAbsences.tsx
@@ -59,6 +59,7 @@ export default function AdminAbsences() {
     type: 'vacation' as 'vacation' | 'sick' | 'training' | 'overtime' | 'other' | 'paid_leave',
     hours: 8,
     note: '',
+    half_day: false,
   });
 
   const typeLabels = ABSENCE_TYPE_LABELS;
@@ -209,11 +210,12 @@ export default function AdminAbsences() {
         type: formData.type,
         hours: formData.hours,
         note: formData.note || null,
+        half_day: !isDateRange && formData.half_day,
       });
       toast.success('Abwesenheit erfolgreich eingetragen');
       setShowForm(false);
       setIsDateRange(false);
-      setFormData({ date: format(new Date(), 'yyyy-MM-dd'), end_date: '', type: 'vacation', hours: 8, note: '' });
+      setFormData({ date: format(new Date(), 'yyyy-MM-dd'), end_date: '', type: 'vacation', hours: 8, note: '', half_day: false });
       loadAbsences(targetId);
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Speichern'));
@@ -539,6 +541,22 @@ export default function AdminAbsences() {
                 Zeitraum (mehrere Tage)
               </label>
             </div>
+
+            {/* #167: halber Tag (nur Einzeltag, nicht für Überstunden/Krank) */}
+            {!isDateRange && formData.type !== 'overtime' && formData.type !== 'sick' && (
+              <div className="flex items-center space-x-2 p-3 bg-gray-50 rounded-lg">
+                <input
+                  type="checkbox"
+                  id="admin-halfDay"
+                  checked={formData.half_day}
+                  onChange={e => setFormData(p => ({ ...p, half_day: e.target.checked }))}
+                  className="w-4 h-4 text-primary border-gray-300 rounded-sm focus:ring-primary"
+                />
+                <label htmlFor="admin-halfDay" className="text-sm font-medium text-gray-700 cursor-pointer">
+                  Halber Tag (zählt als 0,5 Tag)
+                </label>
+              </div>
+            )}
 
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
               <div>


### PR DESCRIPTION
Closes #167. Halbe Urlaubstage als konsistenter, diskriminierungsfreier Buchungsweg — passend zum Tagesprinzip aus #156.

## Verifikation
Backend: SQLite **818 passed / 0 failed**, Postgres-Gruppe **21 passed**. Frontend: tsc 0 Fehler · lint 0 Fehler · build ✓. Migration 046 gegen echtes Postgres geprüft.

## Mechanik
Halber Tag = **0,5 × Tagessoll des Tages** → zählt immer als **0,5 Urlaubstag**, unabhängig von der Tageslänge (8h-Tag → 4h; 3h-Tag → 1,5h; beide 0,5 Tag).

## Beide Buchungspfade
- **Direkt** (`/absences`, create_absence): `half_day`-Flag → 0,5 × Tagessoll; Budget-Check tagebasiert mit 0,5-Faktor.
- **Antrags-Workflow** (`/vacation-requests` → Genehmigung): `VacationRequest.half_day` (Migration 046). Die Genehmigung bucht jetzt das **Tagessoll** statt `vr.hours` (schließt den 8h-Default-Bug aus #156/T1 auch im Approval-Pfad) und 0,5 × Tagessoll bei `half_day`; Budget-Check tagebasiert (T2-Parität).

## Frontend
„**Halber Tag (zählt als 0,5 Tag)**"-Checkbox im Erfassungsdialog (Mitarbeiter `AbsenceCalendarPage` + Admin `AdminAbsences`), nur bei Einzeltag, nicht für Überstunden/Krank. Wird an `/absences` und `/vacation-requests` übergeben.

## Tests
Halbtag direkt (Vollzeit + ungleichmäßiger Tagesplan je 0,5) + Halbtag über VR-Genehmigung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
