### PR TITLE
Release 1.8.0 — Native-Härtung (A–E), Docker-Bundle, Review-Fixes, Dependency-Bumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ import_celine.py
 docs/generated/
 .worktrees/
 .superpowers/
+
+# Raw user feedback inputs (may contain personal data) — never commit
+feedback/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.7.0 (Stand 2026-05-28)
+**Aktuelle Version:** 1.8.0 (Stand 2026-05-29)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---
@@ -27,6 +27,7 @@ ssh manuel@192.168.178.44 "cd /opt/praxiszeit/praxiszeit && sudo ./deploy.sh"
 bash tools/build-release.sh                    # Release-Pakete bauen (Linux/Windows/macOS)
 bash tools/build-release.sh --linux-only       # Nur Linux
 bash tools/build-release.sh --windows-only --skip-download   # Rebuild mit Cache
+bash tools/build-release.sh --docker-only      # Nur Docker-Bundle (compose + Build-Kontext)
 bash tools/validate-release.sh                 # Linux-Tarball: Docker-Smoke gegen 4 Distros
 # macOS-Validierung läuft als GitHub-Actions-Workflow (validate-macos.yml)
 # auf macos-15-intel + macos-14 — manuell triggerbar via gh workflow run.
@@ -144,7 +145,8 @@ Nach nginx.conf / Frontend-Änderungen: `docker compose build frontend && docker
 - **Native-Build verlangt `pg_env()`-Helper** in `praxiszeit-server.py` — alle 7 PG-Subprocess-Aufrufe (initdb, postgres, pg_ctl, psql, pg_dump) bekommen `env=pg_env()`, das `LD_LIBRARY_PATH=$BIN_DIR/postgresql/lib` (Linux/macOS) bzw. `PATH`-Prepend (Windows) setzt. Plus `PGHOST` auf `DATA_DIR/run/`, damit psql den umgezogenen Socket findet.
 - **`unix_socket_directories` in `pg_init()`** muss auf `DATA_DIR/run/` zeigen (nicht `/var/run/postgresql`), weil systemd `ProtectSystem=strict` das default Verzeichnis read-only macht. Detail-Postmortem in #125.
 - **`installer/linux/install.sh` installiert Runtime-Libs automatisch** (`libxml2 libssl3 libgssapi-krb5-2 libzstd1 liblz4-1 libreadline8 libbrotli1` via apt-get/dnf/zypper). Auf Ubuntu-Minimal-Images sind die nicht alle da, theseus' postgres-Binary linkt aber dagegen.
-- **`install.sh` / systemd-Unit (Debian-Cloud-Stolpersteine, Feedback 2026-05-29):** Native-Service läuft als **non-root** (`User=<svc>`, `NoNewPrivileges=yes`) → privilegierte Ports (<1024, z. B. 443) brauchen `AmbientCapabilities=CAP_NET_BIND_SERVICE` in der Unit, sonst `bind … permission denied`. Tägliches Backup wird per `crontab` eingerichtet → cron fehlt auf Minimal-Images (Debian-13-Cloud: `crontab: command not found`) → nachinstallieren oder systemd-Timer. Linux-Tarball entpackt **flach** (`build-release.sh`: `tar -czf … -C "$LINUX_DIR" .`, kein Top-Level-Ordner) → das `cd praxiszeit` in `INSTALL-NATIVE.md` schlägt fehl.
+- **`install.sh` / systemd-Unit (Debian-Cloud-Härtung, ab 1.8.0):** Native-Service läuft als **non-root** (`User=<svc>`, `NoNewPrivileges=yes`). Privilegierte Ports (<1024, z. B. 443) → `install.sh` vergibt für `PORT < 1024` automatisch `AmbientCapabilities=CAP_NET_BIND_SERVICE` + `CapabilityBoundingSet=…` (sonst `bind … permission denied`, Feldreport). Tägliches Backup läuft jetzt über einen **systemd-Timer** (`praxiszeit-backup.timer/.service`) statt `crontab` — cron fehlt auf Minimal-Images (Debian-13-Cloud: `crontab: command not found`). Zusätzliche Hardening-Direktiven in der Unit (`ProtectKernel*`, `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX`, `RestrictNamespaces` …) — `RestrictAddressFamilies` muss `AF_UNIX` enthalten (PG-Socket in `DATA_DIR/run/`). Linux-/macOS-Tarball entpackt **flach** (`build-release.sh`: `tar -czf … -C "$DIR" .`, kein Top-Level-Ordner) → `INSTALL-NATIVE.md` extrahiert deshalb mit `-C <ordner>`. ⚠️ `validate-release.sh` + `validate-macos.yml` setzen das flache Layout voraus (`cd /opt/pz && tar xzf …`) — Tarball-Struktur NICHT auf Top-Level-Ordner umstellen, ohne beide Validatoren anzupassen.
+- **Docker-Bundle (ab 1.8.0):** `build-release.sh --docker-only` baut `praxiszeit-<version>-docker.tar.gz` (Top-Level-Ordner!) mit compose-Dateien + `.env.example` + `generate-secrets.sh` + Build-Kontext (`backend/ frontend/ ssl/ prometheus/ grafana/`). Native-Tarbälle enthalten KEIN compose (Braumann-Feedback). ⚠️ Der `-docker`-Name passt NICHT ins strikte pzweb-Upload-Regex (`linux-x64|macos-x64|macos-arm64|windows-x64`) → gehört an ein **GitHub-Release**, nicht in den pzweb-Shop. Doku: [docs/INSTALL-DOCKER.md](docs/INSTALL-DOCKER.md). `ssl/`-Copy im Build excludet `cert.pem`/`key.pem` (kein Build-Host-Key im Bundle).
 - **Alembic Revision-IDs:** Max 32 Zeichen (`version_num varchar(32)` Limit)
 - **clock_out `with_for_update`:** `_get_open_entry()` in `clock_out` MUSS mit Lock aufgerufen werden (Race Condition bei Doppelklick)
 - **F-026 Tenant-Filter (belt-and-suspenders):** ALLE `db.query(Model).filter(...)` auf tenant-scoped Tabellen brauchen expliziten `Model.tenant_id == current_user.tenant_id` zusätzlich zu RLS — gilt für list, lookup-by-id UND `.delete()`. Helper für User-Lookup: `_get_user_in_tenant()` in `admin_users.py`. Tests in `test_cross_tenant_api.py`.
@@ -210,6 +212,7 @@ JSON-Body über `sort_keys=True, separators=(",",":")` kanonisiert, mit Ed25519 
 | Admin-Handbuch | [docs/handbuch/HANDBUCH-ADMIN.md](docs/handbuch/HANDBUCH-ADMIN.md) |
 | Admin-Cheat-Sheet | [docs/handbuch/CHEATSHEET-ADMIN.md](docs/handbuch/CHEATSHEET-ADMIN.md) |
 | Native Installation | [docs/INSTALL-NATIVE.md](docs/INSTALL-NATIVE.md) |
+| Docker-Installation | [docs/INSTALL-DOCKER.md](docs/INSTALL-DOCKER.md) |
 | Native Installer Design | [docs/superpowers/specs/2026-04-07-native-single-instance-installer-design.md](docs/superpowers/specs/2026-04-07-native-single-instance-installer-design.md) |
 | Specs & Design-Docs | `docs/specs/` (arbzg, dsgvo, features, security) |
 

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.7.0"
+APP_VERSION = "1.8.0"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/routers/vacation_requests.py
+++ b/backend/app/routers/vacation_requests.py
@@ -280,16 +280,14 @@ def create_vacation_request(
                 dates_by_year.setdefault(d.year, []).append(d)
             d += timedelta(days=1)
 
+        # Tagesprinzip: tagebasiert prüfen (konsistent mit create_absence /
+        # review_vacation_request). half_day verbraucht 0,5 Tage pro Tag —
+        # sonst würde ein halber Tag bei genau 0,5 Resttagen fälschlich abgelehnt.
+        day_factor = 0.5 if data.half_day else 1.0
         for check_year, year_dates in dates_by_year.items():
             account = calculation_service.get_vacation_account(db, current_user, check_year)
-            year_hours_needed = sum(
-                float(calculation_service.get_daily_target_for_date(
-                    current_user, d,
-                    weekly_hours=calculation_service.get_weekly_hours_for_date(db, current_user, d),
-                ))
-                for d in year_dates
-            )
-            if float(account['remaining_hours']) - year_hours_needed < 0:
+            days_needed = len(year_dates) * day_factor
+            if days_needed > float(account['remaining_days']) + 1e-9:
                 raise HTTPException(
                     status_code=400,
                     detail=f"Nicht genügend Urlaubstage für {check_year} ({account['remaining_days']:.1f} Tage verfügbar)",

--- a/backend/app/schemas/absence.py
+++ b/backend/app/schemas/absence.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, Field, field_serializer
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 from typing import Optional
 from datetime import date, datetime, time
 from decimal import Decimal
@@ -21,6 +21,17 @@ class AbsenceCreate(AbsenceBase):
     refund_vacation: bool = False  # If sick: refund overlapping vacation days
     keep_time_entries: bool = False  # Don't delete existing time entries (mixed days)
     half_day: bool = False  # #167: half vacation day (0.5 × Tagessoll, diskriminierungsfrei)
+
+    @field_validator('half_day')
+    @classmethod
+    def half_day_single_day(cls, v, info):
+        # Halbe Tage nur für Einzeltage — ein Zeitraum würde jeden Tag halbieren.
+        if v:
+            start = info.data.get('date')
+            end = info.data.get('end_date')
+            if end is not None and start is not None and end != start:
+                raise ValueError('Halbe Tage sind nur für Einzeltage möglich')
+        return v
 
 
 class AbsenceResponse(AbsenceBase):

--- a/backend/app/schemas/vacation_request.py
+++ b/backend/app/schemas/vacation_request.py
@@ -28,6 +28,18 @@ class VacationRequestCreate(BaseModel):
             raise ValueError('end_date muss nach date liegen')
         return v
 
+    @field_validator('half_day')
+    @classmethod
+    def half_day_single_day(cls, v, info):
+        # Halbe Tage sind ein Einzeltag-Konzept — ein Zeitraum mit half_day=True
+        # würde jeden Tag des Bereichs halbieren (überraschend, inkonsistent zur UI).
+        if v:
+            start = info.data.get('date')
+            end = info.data.get('end_date')
+            if end is not None and start is not None and end != start:
+                raise ValueError('Halbe Tage sind nur für Einzeltage möglich')
+        return v
+
 
 class VacationRequestUpdate(BaseModel):
     """Partial update for a PENDING vacation request.

--- a/backend/tests/test_half_day_validation.py
+++ b/backend/tests/test_half_day_validation.py
@@ -1,0 +1,67 @@
+"""Review M1: half_day is a single-day concept.
+
+Both AbsenceCreate (admin direct booking) and VacationRequestCreate (MA self
+service) must reject half_day=True on a multi-day range, otherwise the booking
+loop would halve every day of the range (surprising + inconsistent with the UI).
+Pure-pydantic tests — no DB needed.
+"""
+import pytest
+from datetime import date
+from pydantic import ValidationError
+
+from app.schemas.absence import AbsenceCreate
+from app.schemas.vacation_request import VacationRequestCreate
+from app.models.absence import AbsenceType
+
+
+def test_absence_half_day_rejects_multiday():
+    with pytest.raises(ValidationError):
+        AbsenceCreate(
+            date=date(2026, 3, 2),
+            end_date=date(2026, 3, 6),
+            type=AbsenceType.VACATION,
+            hours=8,
+            half_day=True,
+        )
+
+
+def test_absence_half_day_accepts_single_day():
+    a = AbsenceCreate(date=date(2026, 3, 2), type=AbsenceType.VACATION, hours=8, half_day=True)
+    assert a.half_day is True
+
+
+def test_absence_half_day_accepts_explicit_same_start_end():
+    a = AbsenceCreate(
+        date=date(2026, 3, 2),
+        end_date=date(2026, 3, 2),
+        type=AbsenceType.VACATION,
+        hours=8,
+        half_day=True,
+    )
+    assert a.half_day is True
+
+
+def test_absence_multiday_without_half_day_is_fine():
+    a = AbsenceCreate(
+        date=date(2026, 3, 2),
+        end_date=date(2026, 3, 6),
+        type=AbsenceType.VACATION,
+        hours=8,
+        half_day=False,
+    )
+    assert a.end_date == date(2026, 3, 6)
+
+
+def test_vacation_request_half_day_rejects_multiday():
+    with pytest.raises(ValidationError):
+        VacationRequestCreate(
+            date=date(2026, 3, 2),
+            end_date=date(2026, 3, 6),
+            hours=8,
+            half_day=True,
+        )
+
+
+def test_vacation_request_half_day_accepts_single_day():
+    vr = VacationRequestCreate(date=date(2026, 3, 2), hours=8, half_day=True)
+    assert vr.half_day is True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     # runtime (in v13 the feature toggle to turn it off was removed; Scenes is
     # always-on). Startup performs a one-time dashboard/folder migration to
     # unified storage.
-    image: grafana/grafana:13.0.1
+    image: grafana/grafana:13.0.1-security-01
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD must be set in .env}
       GF_AUTH_ANONYMOUS_ENABLED: "false"

--- a/docs/INSTALL-DOCKER.md
+++ b/docs/INSTALL-DOCKER.md
@@ -1,0 +1,147 @@
+# PraxisZeit — Installation mit Docker
+
+Empfohlene Methode für Server mit Docker. Es gibt zwei Wege, an die nötigen
+Dateien (inkl. `docker-compose.yml`) zu kommen:
+
+| Weg | Für wen | Quelle |
+|-----|---------|--------|
+| **A) Docker-Bundle** | Kunden ohne Git | `praxiszeit-X.Y.Z-docker.tar.gz` (GitHub-Release-Asset) |
+| **B) Aus dem Quellcode** | Entwickler / Updates per `git pull` | `git clone https://github.com/phash/praxiszeit` |
+
+> Die Native-Pakete (`praxiszeit-X.Y.Z-linux-x64.tar.gz` etc.) enthalten **kein**
+> `docker-compose.yml` — sie sind für die Installation ohne Docker gedacht
+> (siehe [INSTALL-NATIVE.md](INSTALL-NATIVE.md)). Für Docker eines der beiden
+> oben genannten Bundles verwenden.
+
+---
+
+## Voraussetzungen
+
+- Docker Engine 24+ und Docker Compose v2 (`docker compose version`)
+- Ausgehender Internetzugang beim ersten `up` (Base-Images, pip/npm-Build)
+
+---
+
+## Weg A — Docker-Bundle
+
+```bash
+# 1. Bundle entpacken (enthält einen Top-Level-Ordner praxiszeit-X.Y.Z/)
+tar xzf praxiszeit-1.8.0-docker.tar.gz
+cd praxiszeit-1.8.0
+
+# 2. Secrets erzeugen (.env mit Zufallswerten + komplexem Admin-Passwort)
+bash generate-secrets.sh
+#    -> gibt das initiale Admin-Passwort aus. Notieren!
+
+# 3a. Schneller HTTP-Test (nur lokal/intern, KEINE externe Exposition):
+#     in .env ENVIRONMENT=development und COOKIE_SECURE=false setzen, dann:
+docker compose up -d --build
+#     -> http://<server-ip>
+
+# 3b. Produktiv mit HTTPS (empfohlen):
+bash ssl/generate-cert.sh          # selbstsigniertes Zertifikat (oder eigenes ablegen)
+docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d --build
+#     -> https://<server-ip>
+```
+
+---
+
+## Weg B — Aus dem Quellcode
+
+```bash
+git clone https://github.com/phash/praxiszeit.git
+cd praxiszeit
+
+bash tools/docker/generate-secrets.sh   # schreibt ./.env
+
+# HTTPS (empfohlen)
+bash ssl/generate-cert.sh
+docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d --build
+```
+
+Updates: `git pull && docker compose up -d --build` (bei aktivem SSL-Overlay
+beide `-f`-Dateien angeben).
+
+---
+
+## HTTP vs. HTTPS
+
+- **HTTP** (`docker compose up -d`): Frontend auf Port **80**. Nur für interne
+  Tests. Bei `ENVIRONMENT=production` muss `COOKIE_SECURE=false` gesetzt werden,
+  sonst sendet der Browser das Refresh-Cookie über HTTP nicht und der Login
+  schlägt nach 30 Minuten fehl.
+- **HTTPS** (`-f docker-compose.ssl.yml`): Frontend zusätzlich auf Port **443**,
+  `COOKIE_SECURE` bleibt auf `true` (Default). Empfohlen für jeden echten
+  Einsatz. Bei eigener Domain `SERVER_DOMAIN` in `.env` setzen und
+  `CORS_ORIGINS` anpassen.
+
+---
+
+## .env — wichtige Werte
+
+`generate-secrets.sh` setzt zufällig: `SECRET_KEY`, `POSTGRES_PASSWORD`,
+`APP_DB_PASSWORD`, `GRAFANA_ADMIN_PASSWORD`, ein komplexes `ADMIN_PASSWORD` und
+`ENVIRONMENT=production`. Manuell anpassen:
+
+| Variable | Bedeutung |
+|----------|-----------|
+| `CORS_ORIGINS` | Erlaubte Origins (eigene Domain statt `localhost`) |
+| `ADMIN_USERNAME` / `ADMIN_EMAIL` | Initialer Admin |
+| `PRACTICE_NAME` / `PRACTICE_ADDRESS` | Erscheint u.a. in Excel-Exporten (DSGVO) |
+| `HOLIDAY_STATE` | Bundesland für Feiertage (z.B. `Bayern`) |
+
+Das initiale Admin-Passwort **nach dem ersten Login** in der Benutzerverwaltung
+ändern.
+
+---
+
+## Dienste & Ports
+
+| Dienst | Port | Zweck |
+|--------|------|-------|
+| frontend (nginx) | 80 (+443 mit SSL) | Web-UI + Reverse-Proxy auf das Backend |
+| backend (FastAPI) | intern 8000 | API |
+| db (PostgreSQL 16) | intern 5432 | Datenbank (Volume `postgres_data`) |
+| prometheus | `127.0.0.1:9090` | Metriken (nur lokal) |
+| grafana | unter `/grafana/` | Dashboards (Passwort = `GRAFANA_ADMIN_PASSWORD`) |
+
+Monitoring (Prometheus/Grafana) läuft mit — wer es nicht braucht, kann
+`docker compose stop prometheus grafana` ausführen.
+
+---
+
+## Verwaltung
+
+```bash
+docker compose ps                 # Status
+docker compose logs -f backend    # Backend-Logs
+docker compose down               # Stoppen (Daten bleiben im Volume)
+docker compose pull && docker compose up -d --build   # Update (Weg A: neues Bundle entpacken)
+```
+
+---
+
+## Backup (gesetzliche Aufbewahrung, §16 ArbZG)
+
+Die Zeitdaten liegen im Docker-Volume `postgres_data`. **Vor jedem `docker
+compose down -v` und vor Updates** ein DB-Dump ziehen:
+
+```bash
+docker compose exec -T db pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" \
+    > backup-$(date +%F).sql
+```
+
+§16 ArbZG verlangt eine Aufbewahrung von mindestens 2 Jahren. Das Volume
+`postgres_data` daher **niemals ungesichert löschen**.
+
+---
+
+## Fehlerbehebung
+
+| Problem | Lösung |
+|---------|--------|
+| Login bricht nach 30 Min ab (HTTP) | `COOKIE_SECURE=false` setzen **oder** auf HTTPS umstellen |
+| `APP_DB_PASSWORD is missing` | `generate-secrets.sh` ausführen / `.env` prüfen |
+| Backend startet nicht (production) | Schwaches/Platzhalter-`ADMIN_PASSWORD` → von `generate-secrets.sh` setzen lassen |
+| 502 auf `/grafana/` | Grafana-Container läuft nicht (`docker compose up -d grafana`) |
+| Port 80/443 belegt | Anderen Host-Port mappen oder Konflikt auflösen |

--- a/docs/INSTALL-NATIVE.md
+++ b/docs/INSTALL-NATIVE.md
@@ -3,6 +3,10 @@
 Anleitung zur Installation von PraxisZeit als Einzelinstanz auf einem Server ohne Docker.
 Alle Pakete enthalten Python und PostgreSQL — keine Voraussetzungen noetig.
 
+> **Docker bevorzugt?** Wer lieber mit Docker Compose deployt, nutzt nicht diese
+> Native-Pakete, sondern das Docker-Bundle bzw. den Quellcode — siehe
+> [INSTALL-DOCKER.md](INSTALL-DOCKER.md).
+
 ## Unterstuetzte Plattformen
 
 | Plattform | Architektur | Paket | Groesse |
@@ -18,12 +22,20 @@ Alle Pakete enthalten Python und PostgreSQL — keine Voraussetzungen noetig.
 
 ```bash
 # 1. Herunterladen + entpacken
-tar xzf praxiszeit-1.2.0-linux-x64.tar.gz
-cd praxiszeit
+#    Das Tarball entpackt FLACH (kein Top-Level-Ordner) — daher zuerst einen
+#    Zielordner anlegen und mit -C dorthin entpacken:
+mkdir -p praxiszeit-1.8.0
+tar xzf praxiszeit-1.8.0-linux-x64.tar.gz -C praxiszeit-1.8.0
+cd praxiszeit-1.8.0
 
 # 2. Installer starten (als root)
 sudo ./install.sh
 ```
+
+> **Hinweis Port 443 / privilegierte Ports:** Der Dienst laeuft als
+> non-root-Benutzer. Der Installer vergibt fuer Ports < 1024 automatisch
+> `CAP_NET_BIND_SERVICE` in der systemd-Unit — ein Bind auf 443 funktioniert
+> damit ohne root. (Aeltere Versionen scheiterten hier mit `permission denied`.)
 
 Der Installer fragt interaktiv nach Praxis-Name, Admin-Zugangsdaten und Port.
 
@@ -42,7 +54,7 @@ journalctl -u praxiszeit -f          # Live-Logs
 ## Windows-Installation
 
 ```
-1. praxiszeit-1.2.0-windows-x64.zip entpacken nach C:\PraxisZeit\
+1. praxiszeit-1.8.0-windows-x64.zip entpacken nach C:\PraxisZeit\
 
 2. setup.bat als Administrator ausfuehren
    - Installiert PostgreSQL (silent, kein GUI)
@@ -75,11 +87,14 @@ Deinstallation: `uninstall-service.bat` ausfuehren (Datenbank wird beibehalten).
 ## macOS-Installation
 
 ```bash
+# Tarball entpackt flach — in einen eigenen Ordner entpacken:
+mkdir -p praxiszeit-1.8.0 && cd praxiszeit-1.8.0
+
 # Intel Mac:
-tar xzf praxiszeit-1.2.0-macos-x64.tar.gz
+tar xzf ../praxiszeit-1.8.0-macos-x64.tar.gz
 
 # Apple Silicon (M1/M2/M3/M4):
-tar xzf praxiszeit-1.2.0-macos-arm64.tar.gz
+tar xzf ../praxiszeit-1.8.0-macos-arm64.tar.gz
 
 # Installer starten (als root)
 sudo ./install.sh
@@ -214,11 +229,21 @@ openssl req -x509 -newkey ed25519 \
 
 ## Backup & Restore
 
-Automatische Backups laufen taeglich (konfigurierbar in `[backup] schedule`).
+Automatische Backups laufen taeglich um 02:00. Unter Linux geschieht das ueber
+einen **systemd-Timer** (`praxiszeit-backup.timer`) — kein `cron` noetig (das
+fehlt auf Minimal-/Cloud-Images wie dem Debian-13-Cloudimage).
 
 ```bash
-# Manuelles Backup (Linux/macOS)
-sudo -u praxiszeit /opt/praxiszeit/praxiszeit-server.py backup
+# Timer-Status / naechster Lauf (Linux)
+systemctl status praxiszeit-backup.timer
+systemctl list-timers praxiszeit-backup.timer
+
+# Backup sofort ausloesen (Linux)
+sudo systemctl start praxiszeit-backup.service
+
+# Manuelles Backup (Linux/macOS, direkt)
+sudo -u praxiszeit /opt/praxiszeit/bin/python/bin/python3 \
+    /opt/praxiszeit/praxiszeit-server.py backup
 
 # Backups anzeigen
 ls -la /opt/praxiszeit/data/backups/
@@ -274,7 +299,7 @@ Gebuendelte Komponenten:
 | Komponente | Linux | Windows | macOS |
 |------------|-------|---------|-------|
 | Python 3.13 | python-build-standalone | python-build-standalone | python-build-standalone |
-| PostgreSQL | System-Binaries | EDB Installer (.exe, silent) | EDB Installer (.dmg, silent) |
+| PostgreSQL | theseus-rs 16 (gebuendelt) | EDB Installer (.exe, silent) | theseus-rs 16 (gebuendelt) |
 | Service Manager | systemd | nssm | launchd |
 
 Ergebnis in `dist/`:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,7 @@
 # Build stage
-FROM node:20-alpine AS build
+# node:22-alpine — Node 20 ist seit 2026-04-30 EOL (keine Security-Patches mehr);
+# 22 ist Active LTS. Nur Build-Stage (Runtime-Image ist nginx:alpine).
+FROM node:22-alpine AS build
 
 WORKDIR /app
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "axios": "^1.15.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/AbsenceBadge.tsx
+++ b/frontend/src/components/AbsenceBadge.tsx
@@ -11,6 +11,12 @@ interface AbsenceBadgeProps {
   title?: string;
   /** Diameter in px. */
   size?: number;
+  /**
+   * When the surrounding row already renders the name + type as text (e.g. the
+   * mobile list), set this so the badge is hidden from screen readers and not
+   * announced twice. The `title` tooltip stays available for mouse users.
+   */
+  decorative?: boolean;
 }
 
 /**
@@ -19,7 +25,7 @@ interface AbsenceBadgeProps {
  * - centre = absence-type colour (admin-configurable; neutral grey for masked "absent")
  * - initials in white with a thin dark contour so they stay legible on any centre colour.
  */
-export default function AbsenceBadge({ type, userColor, initials, title, size = 26 }: AbsenceBadgeProps) {
+export default function AbsenceBadge({ type, userColor, initials, title, size = 26, decorative = false }: AbsenceBadgeProps) {
   const colors = useTypeColorsStore((s) => s.colors);
   const centre = (colors as Record<string, string>)[type] ?? '#6B7280';
   const ring = Math.max(2, Math.round(size * 0.1)); // 10 % of diameter = 20 % of radius
@@ -31,7 +37,8 @@ export default function AbsenceBadge({ type, userColor, initials, title, size = 
   return (
     <span
       title={title}
-      aria-label={title}
+      aria-label={decorative ? undefined : title}
+      aria-hidden={decorative || undefined}
       style={{
         display: 'inline-flex',
         alignItems: 'center',

--- a/frontend/src/pages/AbsenceCalendarPage.tsx
+++ b/frontend/src/pages/AbsenceCalendarPage.tsx
@@ -581,10 +581,13 @@ export default function AbsenceCalendarPage() {
                   value={formData.hours}
                   onChange={(e) => setFormData({ ...formData, hours: parseHours(e.target.value) })}
                   required
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
+                  disabled={!isDateRange && formData.half_day}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary disabled:bg-gray-100 disabled:text-gray-400"
                 />
                 <p className="text-xs text-gray-500 mt-1">
-                  {formData.type === 'vacation'
+                  {!isDateRange && formData.half_day
+                    ? 'Halber Tag: 0,5 × Tagessoll wird automatisch gebucht (Stundenwert wird ignoriert)'
+                    : formData.type === 'vacation'
                     ? 'Stunden = Regelarbeitszeit pro Tag (für Urlaubsberechnung)'
                     : formData.type === 'overtime'
                     ? 'Vorausgefüllt mit Ihren Sollstunden des Tages'
@@ -748,7 +751,7 @@ export default function AbsenceCalendarPage() {
                         <div className="flex flex-wrap gap-1">
                           {dayEntries.map((entry, idx) => (
                             <AbsenceBadge
-                              key={idx}
+                              key={`${entry.date}-${entry.user_first_name}-${entry.user_last_name}-${entry.type}-${idx}`}
                               type={entry.type}
                               userColor={entry.user_color}
                               initials={`${entry.user_first_name?.[0] ?? ''}${entry.user_last_name?.[0] ?? ''}`.toUpperCase()}
@@ -808,14 +811,15 @@ export default function AbsenceCalendarPage() {
                       {/* Absence Entries */}
                       {dayEntries.map((entry, idx) => (
                         <div
-                          key={idx}
+                          key={`${entry.date}-${entry.user_first_name}-${entry.user_last_name}-${entry.type}-${idx}`}
                           className="px-3 py-2 rounded-lg border border-gray-200 flex items-center gap-2"
                         >
                           <AbsenceBadge
                             type={entry.type}
                             userColor={entry.user_color}
                             initials={`${entry.user_first_name?.[0] ?? ''}${entry.user_last_name?.[0] ?? ''}`.toUpperCase()}
-                            title={`${entry.user_first_name} ${entry.user_last_name}`}
+                            title={`${entry.user_first_name} ${entry.user_last_name} – ${absenceTypeLabel(entry.type)}`}
+                            decorative
                           />
                           <div>
                             <p className="text-sm font-medium">
@@ -903,7 +907,7 @@ export default function AbsenceCalendarPage() {
                             <div className="flex items-center space-x-0.5 mt-0.5">
                               {dayAbsences.slice(0, 3).map((a, idx) => (
                                 <div
-                                  key={idx}
+                                  key={`${a.user_first_name ?? ''}${a.user_last_name ?? ''}-${a.type}-${idx}`}
                                   className="w-1.5 h-1.5 rounded-full"
                                   style={{ backgroundColor: (absColors as Record<string, string>)[a.type] ?? '#6B7280' }}
                                 ></div>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -835,7 +835,7 @@ export default function Dashboard() {
                                 <div className="space-y-0.5">
                                   {dayAbsences.map((absence, idx) => (
                                     <div
-                                      key={idx}
+                                      key={`${absence.user_first_name ?? ''}-${absence.user_last_name ?? ''}-${absence.type}-${idx}`}
                                       className="text-xs px-1 py-0.5 rounded-sm"
                                       style={{
                                         backgroundColor: absColors[absence.type] ?? '#6B7280',
@@ -879,7 +879,7 @@ export default function Dashboard() {
                                 <div className="space-y-1">
                                   {dayAbsences.map((absence, idx) => (
                                     <div
-                                      key={idx}
+                                      key={`${absence.user_first_name ?? ''}-${absence.user_last_name ?? ''}-${absence.type}-${idx}`}
                                       className="flex items-center text-sm"
                                     >
                                       <span

--- a/frontend/src/pages/admin/AdminAbsences.tsx
+++ b/frontend/src/pages/admin/AdminAbsences.tsx
@@ -76,13 +76,18 @@ export default function AdminAbsences() {
     loadClosures();
   }, []);
 
+  // Single source of truth for the month/employee load. Guarding the
+  // all-employees branch on employees.length avoids the empty first-mount
+  // no-op AND the duplicate fetch that a second employees-keyed effect caused
+  // on every month change (Review M5).
   useEffect(() => {
     if (selectedEmployee) {
       loadAbsences(selectedEmployee);
-    } else {
+    } else if (employees.length > 0) {
       loadAllAbsences();
     }
-  }, [selectedEmployee, currentMonth]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedEmployee, currentMonth, employees]);
 
   const loadEmployees = async () => {
     try {
@@ -186,12 +191,6 @@ export default function AdminAbsences() {
     );
     setAllAbsences(result);
   };
-
-  useEffect(() => {
-    if (!selectedEmployee && employees.length > 0) {
-      loadAllAbsences();
-    }
-  }, [employees, currentMonth]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -611,8 +610,14 @@ export default function AdminAbsences() {
                   value={formData.hours}
                   onChange={e => setFormData(p => ({ ...p, hours: parseHours(e.target.value) }))}
                   required
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
+                  disabled={!isDateRange && formData.half_day}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary disabled:bg-gray-100 disabled:text-gray-400"
                 />
+                {!isDateRange && formData.half_day && (
+                  <p className="text-xs text-gray-500 mt-1">
+                    Halber Tag: 0,5 × Tagessoll wird automatisch gebucht (Stundenwert wird ignoriert)
+                  </p>
+                )}
               </div>
             </div>
 

--- a/frontend/src/pages/admin/users/UserForm.tsx
+++ b/frontend/src/pages/admin/users/UserForm.tsx
@@ -328,7 +328,7 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
               id="f-vacation"
               type="number"
               value={formData.vacation_days}
-              onChange={(e) => setFormData({ ...formData, vacation_days: parseInt(e.target.value) })}
+              onChange={(e) => setFormData({ ...formData, vacation_days: parseInt(e.target.value) || 0 })}
               required
               min="0"
               max="50"

--- a/frontend/src/stores/typeColorsStore.test.ts
+++ b/frontend/src/stores/typeColorsStore.test.ts
@@ -29,6 +29,20 @@ describe('pickTextColor', () => {
   it('falls back to dark for malformed input', () => {
     expect(pickTextColor('nope')).toBe('#111827');
   });
+
+  it('picks dark text on mid-tone colours for WCAG-AA contrast', () => {
+    // Regression for the 0.5-threshold bug: these mid-tone defaults previously
+    // got white text below 4.5:1. The 0.179 WCAG flip-point gives dark text.
+    expect(pickTextColor('#0D9488')).toBe('#111827'); // paid_leave teal
+    expect(pickTextColor('#16A34A')).toBe('#111827'); // work green
+    expect(pickTextColor('#E5A50A')).toBe('#111827'); // amber
+  });
+
+  it('still picks white on genuinely dark colours', () => {
+    expect(pickTextColor('#15803D')).toBe('#FFFFFF'); // dark green (training)
+    expect(pickTextColor('#7C3AED')).toBe('#FFFFFF'); // purple (overtime)
+    expect(pickTextColor('#DC2626')).toBe('#FFFFFF'); // red (sick)
+  });
 });
 
 describe('colorFor', () => {

--- a/frontend/src/stores/typeColorsStore.ts
+++ b/frontend/src/stores/typeColorsStore.ts
@@ -64,5 +64,8 @@ export function pickTextColor(hex: string): string {
   const g = toLin(parseInt(h.slice(2, 4), 16));
   const b = toLin(parseInt(h.slice(4, 6), 16));
   const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
-  return luminance > 0.5 ? '#111827' : '#FFFFFF';
+  // WCAG-Flip-Punkt: dunkler Text gewinnt erst ab L ≈ 0.179 (= sqrt(1.05·0.05)−0.05),
+  // dem geometrischen Mittel der Kontrastformel. Mit 0.5 bekamen mittelhelle
+  // Farben (Amber, das Default-Grün/Teal) weiße Schrift unter AA 4.5:1.
+  return luminance > 0.179 ? '#111827' : '#FFFFFF';
 }

--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -160,6 +160,10 @@ read -rp "Lizenzschluessel-Datei (Pfad, oder leer fuer spaeter): " LICENSE_FILE
 echo ""
 read -rp "HTTPS-Port [443]: " PORT
 PORT=${PORT:-443}
+if ! [[ "$PORT" =~ ^[0-9]+$ ]] || [ "$PORT" -lt 1 ] || [ "$PORT" -gt 65535 ]; then
+    error "Ungueltiger Port '${PORT}'. Erlaubt: 1-65535."
+    exit 1
+fi
 
 read -rp "Selbstsigniertes SSL-Zertifikat generieren? [J/n]: " GEN_SSL
 GEN_SSL=${GEN_SSL:-J}
@@ -288,6 +292,20 @@ chmod 600 "${INSTALL_DIR}/config/ssl/"*.pem 2>/dev/null || true
 
 # --- Install systemd service ---
 
+# Der Dienst laeuft als non-root (User=${SERVICE_USER}). Ein Bind auf einen
+# privilegierten Port (<1024, z.B. 443) scheitert dann mit "permission denied"
+# (Feldreport Debian-13-Cloud). CAP_NET_BIND_SERVICE erlaubt genau diesen Bind,
+# ohne dem Dienst root-Rechte zu geben. Bei Ports >= 1024 wird keine Capability
+# vergeben (least privilege).
+if [ "${PORT}" -lt 1024 ]; then
+    CAP_AMBIENT="AmbientCapabilities=CAP_NET_BIND_SERVICE"
+    CAP_BOUNDING="CapabilityBoundingSet=CAP_NET_BIND_SERVICE"
+    info "Port ${PORT} < 1024 -> CAP_NET_BIND_SERVICE wird dem Dienst gewaehrt."
+else
+    CAP_AMBIENT="# Port ${PORT} >= 1024: keine Capabilities erforderlich"
+    CAP_BOUNDING="CapabilityBoundingSet="
+fi
+
 info "Installiere systemd Service..."
 cat > "/etc/systemd/system/${SERVICE_NAME}.service" << SVCEOF
 [Unit]
@@ -305,11 +323,29 @@ ExecStop=${INSTALL_DIR}/bin/python/bin/python3 ${INSTALL_DIR}/praxiszeit-server.
 Restart=on-failure
 RestartSec=10
 Environment=PYTHONUNBUFFERED=1
+
+# Privilegierte Ports (<1024) als non-root binden
+${CAP_AMBIENT}
+${CAP_BOUNDING}
+
+# Security-Hardening
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes
 ReadWritePaths=${INSTALL_DIR}/data ${INSTALL_DIR}/logs ${INSTALL_DIR}/config
 PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+SystemCallArchitectures=native
 
 [Install]
 WantedBy=multi-user.target
@@ -318,11 +354,49 @@ SVCEOF
 systemctl daemon-reload
 systemctl enable "${SERVICE_NAME}"
 
-# --- Setup backup cron ---
+# --- Setup daily backup (systemd-Timer, kein cron noetig) ---
+# Frueher via crontab — cron ist auf Minimal-/Cloud-Images (z.B. Debian-13-Cloud)
+# nicht installiert ("crontab: command not found", Feldreport). Ein systemd-Timer
+# braucht keine zusaetzlichen Pakete und holt verpasste Laeufe nach (Persistent).
+info "Richte taegliches Backup ein (systemd-Timer, 02:00)..."
+cat > "/etc/systemd/system/${SERVICE_NAME}-backup.service" << BKSVCEOF
+[Unit]
+Description=PraxisZeit taegliches Backup
 
-info "Richte taegliches Backup ein (02:00)..."
-CRON_CMD="${INSTALL_DIR}/bin/python/bin/python3 ${INSTALL_DIR}/praxiszeit-server.py backup"
-(crontab -u "${SERVICE_USER}" -l 2>/dev/null || true; echo "0 2 * * * ${CRON_CMD}") | crontab -u "${SERVICE_USER}" -
+[Service]
+Type=oneshot
+User=${SERVICE_USER}
+Group=${SERVICE_USER}
+WorkingDirectory=${INSTALL_DIR}
+ExecStart=${INSTALL_DIR}/bin/python/bin/python3 ${INSTALL_DIR}/praxiszeit-server.py backup
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=${INSTALL_DIR}/data ${INSTALL_DIR}/logs
+PrivateTmp=yes
+BKSVCEOF
+
+cat > "/etc/systemd/system/${SERVICE_NAME}-backup.timer" << BKTMREOF
+[Unit]
+Description=PraxisZeit taegliches Backup (02:00)
+
+[Timer]
+OnCalendar=*-*-* 02:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+BKTMREOF
+
+# Best-effort: einen alten cron-Eintrag frueherer Versionen entfernen (nur wenn
+# cron ueberhaupt vorhanden ist) — sonst liefen Backup-Timer und cron doppelt.
+if command -v crontab &>/dev/null; then
+    ( crontab -u "${SERVICE_USER}" -l 2>/dev/null | grep -v "praxiszeit-server.py backup" || true ) \
+        | crontab -u "${SERVICE_USER}" - 2>/dev/null || true
+fi
+
+systemctl daemon-reload
+systemctl enable --now "${SERVICE_NAME}-backup.timer"
 
 # --- Start service ---
 

--- a/installer/linux/praxiszeit.service
+++ b/installer/linux/praxiszeit.service
@@ -13,12 +13,29 @@ ExecStop=/opt/praxiszeit/bin/python/bin/python3 /opt/praxiszeit/praxiszeit-serve
 Restart=on-failure
 RestartSec=10
 
+# Privilegierte Ports (<1024, z.B. 443) als non-root binden.
+# Bei Port >= 1024 koennen die naechsten beiden Zeilen entfernt werden.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
 # Security hardening
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes
 ReadWritePaths=/opt/praxiszeit/data /opt/praxiszeit/logs /opt/praxiszeit/config
 PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+SystemCallArchitectures=native
 
 # Environment
 Environment=PYTHONUNBUFFERED=1

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.7.0"
+APP_VERSION="1.8.0"
 PYTHON_VERSION="3.13.3"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 PYTHON_STANDALONE_TAG="20250529"
@@ -34,14 +34,16 @@ NSSM_VERSION="2.24"
 BUILD_LINUX=true
 BUILD_WINDOWS=true
 BUILD_MACOS=true
+BUILD_DOCKER=true
 SKIP_DOWNLOAD=false
 SKIP_FRONTEND=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --linux-only)    BUILD_WINDOWS=false; BUILD_MACOS=false; shift ;;
-        --windows-only)  BUILD_LINUX=false; BUILD_MACOS=false; shift ;;
-        --macos-only)    BUILD_LINUX=false; BUILD_WINDOWS=false; shift ;;
+        --linux-only)    BUILD_WINDOWS=false; BUILD_MACOS=false; BUILD_DOCKER=false; shift ;;
+        --windows-only)  BUILD_LINUX=false; BUILD_MACOS=false; BUILD_DOCKER=false; shift ;;
+        --macos-only)    BUILD_LINUX=false; BUILD_WINDOWS=false; BUILD_DOCKER=false; shift ;;
+        --docker-only)   BUILD_LINUX=false; BUILD_WINDOWS=false; BUILD_MACOS=false; shift ;;
         --skip-download) SKIP_DOWNLOAD=true; shift ;;
         --skip-frontend) SKIP_FRONTEND=true; shift ;;
         --version)       APP_VERSION="$2"; shift 2 ;;
@@ -53,6 +55,7 @@ Options:
   --linux-only       Build nur die Linux-Plattform
   --windows-only     Build nur die Windows-Plattform
   --macos-only       Build nur die macOS-Plattform
+  --docker-only      Build nur das Docker-Bundle (compose + Build-Kontext)
   --skip-download    Cache nutzen (PG/Python-Downloads nicht wiederholen)
   --skip-frontend    Frontend-Build überspringen (Dist muss schon existieren)
   --version VERSION  Explizit Versionsnummer setzen
@@ -770,6 +773,67 @@ else
 fi
 
 # =============================================================================
+# Phase 6b: Docker-Bundle (self-contained: compose + Quellcode-Build-Kontext)
+# -----------------------------------------------------------------------------
+# Feedback Braumann (2026-05): Wer Docker bevorzugt, fand kein docker-compose.yml
+# im Download. Dieses Bundle enthaelt compose-Dateien, .env.example, einen
+# Secrets-Generator und den kompletten Build-Kontext (backend/ + frontend/ +
+# ssl/ + prometheus/ + grafana/), sodass `docker compose up -d --build` direkt
+# laeuft. Top-Level-Ordner praxiszeit-<version>/ -> `tar xzf … && cd …` klappt.
+# =============================================================================
+
+if [ "$BUILD_DOCKER" = true ]; then
+    step "6b — Docker-Bundle"
+
+    DOCKER_STAGE="${BUILD_DIR}/docker/praxiszeit-${APP_VERSION}"
+    rm -rf "${BUILD_DIR}/docker"
+    mkdir -p "${DOCKER_STAGE}"
+
+    cp "${REPO_DIR}/docker-compose.yml"               "${DOCKER_STAGE}/"
+    cp "${REPO_DIR}/docker-compose.ssl.yml"           "${DOCKER_STAGE}/"
+    cp "${REPO_DIR}/.env.example"                     "${DOCKER_STAGE}/"
+    cp "${REPO_DIR}/tools/docker/generate-secrets.sh" "${DOCKER_STAGE}/generate-secrets.sh"
+    chmod +x "${DOCKER_STAGE}/generate-secrets.sh"
+
+    # Build-Kontext kopieren (ohne Ballast / ohne evtl. lokale Secrets+Certs).
+    # cd ins REPO_DIR -> Pfade in den tar-Excludes sind relativ ("backend/...").
+    _copy_tree() {  # $1 = Unterverzeichnis, $2.. = zusaetzliche tar-Excludes
+        local sub="$1"; shift
+        (cd "${REPO_DIR}" && tar cf - "$@" "${sub}") | tar xf - -C "${DOCKER_STAGE}/"
+    }
+    _copy_tree backend \
+        --exclude='backend/__pycache__' --exclude='*.pyc' --exclude='backend/tests' \
+        --exclude='backend/.pytest_cache' --exclude='backend/htmlcov' \
+        --exclude='backend/test.db' --exclude='backend/.venv'
+    _copy_tree frontend \
+        --exclude='frontend/node_modules' --exclude='frontend/dist'
+    # ssl/: Skript + nginx-Config, aber NIE einen evtl. lokal erzeugten Key/Cert
+    _copy_tree ssl --exclude='ssl/cert.pem' --exclude='ssl/key.pem'
+    _copy_tree prometheus
+    _copy_tree grafana
+
+    cat > "${DOCKER_STAGE}/DOCKER-README.md" << DOCKEREOF
+# PraxisZeit ${APP_VERSION} — Docker
+
+1. Secrets erzeugen:        bash generate-secrets.sh
+2. (HTTPS) Zertifikat:      bash ssl/generate-cert.sh
+3. Starten (HTTPS):         docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d --build
+   ODER (nur intern, HTTP): in .env ENVIRONMENT=development + COOKIE_SECURE=false setzen, dann
+                            docker compose up -d --build
+
+Volle Anleitung: https://github.com/phash/praxiszeit/blob/master/docs/INSTALL-DOCKER.md
+DOCKEREOF
+
+    tar -czf "${DIST_DIR}/praxiszeit-${APP_VERSION}-docker.tar.gz" \
+        -C "${BUILD_DIR}/docker" "praxiszeit-${APP_VERSION}"
+    info "Docker-Bundle: $(du -h "${DIST_DIR}/praxiszeit-${APP_VERSION}-docker.tar.gz" | cut -f1)"
+    warn "Docker-Bundle gehoert an ein GitHub-Release — der '-docker'-Name passt"
+    warn "NICHT in das strikte pzweb-Upload-Regex (nur linux/macos/windows)."
+else
+    step "6b — Docker: uebersprungen"
+fi
+
+# =============================================================================
 # Phase 7: Checksums + Zusammenfassung
 # =============================================================================
 
@@ -824,5 +888,14 @@ $BUILD_MACOS && cat << EOF
   macOS-Installation (Intel ODER Apple Silicon):
     tar xzf praxiszeit-${APP_VERSION}-macos-{x64|arm64}.tar.gz
     sudo ./install.sh
+
+EOF
+
+$BUILD_DOCKER && cat << EOF
+  Docker-Installation (Bundle -> GitHub-Release, NICHT pzweb):
+    tar xzf praxiszeit-${APP_VERSION}-docker.tar.gz
+    cd praxiszeit-${APP_VERSION}
+    bash generate-secrets.sh && bash ssl/generate-cert.sh
+    docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d --build
 
 EOF

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -16,9 +16,11 @@ set -euo pipefail
 # =============================================================================
 
 APP_VERSION="1.8.0"
-PYTHON_VERSION="3.13.3"
+PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
-PYTHON_STANDALONE_TAG="20250529"
+# 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes
+# (CVE-2025-4517 u.a.) gegenueber dem alten 3.13.3 (Tag 20250529).
+PYTHON_STANDALONE_TAG="20260510"
 # theseus-rs/postgresql-binaries — manylinux-Build, portable bis glibc 2.34
 # (Ubuntu 22.04, Debian 12, RHEL 9 und neuer). Releases:
 #   https://github.com/theseus-rs/postgresql-binaries/releases
@@ -801,12 +803,16 @@ if [ "$BUILD_DOCKER" = true ]; then
         local sub="$1"; shift
         (cd "${REPO_DIR}" && tar cf - "$@" "${sub}") | tar xf - -C "${DOCKER_STAGE}/"
     }
+    # Belt-and-suspenders: nie lokale Secrets/Keys ins Bundle, auch wenn jemand
+    # mal welche unter backend/ oder frontend/ ablegt.
     _copy_tree backend \
         --exclude='backend/__pycache__' --exclude='*.pyc' --exclude='backend/tests' \
         --exclude='backend/.pytest_cache' --exclude='backend/htmlcov' \
-        --exclude='backend/test.db' --exclude='backend/.venv'
+        --exclude='backend/test.db' --exclude='backend/.venv' \
+        --exclude='*.pem' --exclude='*.key' --exclude='.env'
     _copy_tree frontend \
-        --exclude='frontend/node_modules' --exclude='frontend/dist'
+        --exclude='frontend/node_modules' --exclude='frontend/dist' \
+        --exclude='*.pem' --exclude='*.key' --exclude='.env'
     # ssl/: Skript + nginx-Config, aber NIE einen evtl. lokal erzeugten Key/Cert
     _copy_tree ssl --exclude='ssl/cert.pem' --exclude='ssl/key.pem'
     _copy_tree prometheus

--- a/tools/docker/generate-secrets.sh
+++ b/tools/docker/generate-secrets.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# PraxisZeit — erzeugt eine .env mit zufaelligen Secrets fuer das Docker-Deployment.
+#
+# Erwartet, dass es NEBEN der docker-compose.yml + .env.example liegt
+# (im Docker-Bundle der Fall; aus dem Quellcode: aus dem Repo-Root aufrufen).
+#
+# Setzt zufaellige Werte fuer SECRET_KEY, DB-Passwoerter und das Grafana-Passwort,
+# ein zufaelliges (komplexes) initiales Admin-Passwort und ENVIRONMENT=production.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [ ! -f .env.example ]; then
+    echo "FEHLER: .env.example nicht gefunden. Dieses Skript aus dem Verzeichnis mit" >&2
+    echo "        der docker-compose.yml / .env.example heraus aufrufen." >&2
+    exit 1
+fi
+
+if [ -f .env ]; then
+    echo "FEHLER: .env existiert bereits. Bitte manuell pruefen/ergaenzen — dieses" >&2
+    echo "        Skript ueberschreibt keine bestehende .env." >&2
+    exit 1
+fi
+
+# Zufallswert: openssl bevorzugt, sonst Python-Fallback.
+gen() {
+    local n="${1:-24}"
+    openssl rand -hex "$n" 2>/dev/null \
+        || python3 -c "import secrets,sys;print(secrets.token_hex(int(sys.argv[1])))" "$n"
+}
+
+cp .env.example .env
+
+SECRET_KEY="$(gen 64)"
+POSTGRES_PASSWORD="$(gen 24)"
+APP_DB_PASSWORD="$(gen 24)"
+GRAFANA_ADMIN_PASSWORD="$(gen 16)"
+# Admin-Passwort komplex genug fuer die Production-Passwortpruefung
+# (Gross-/Kleinbuchstaben, Ziffer, Sonderzeichen):
+ADMIN_PASSWORD="$(gen 16)-Pz9!Aa"
+
+# sed mit | als Delimiter — alle Werte sind hex/ASCII ohne | und ohne &.
+sed -i "s|^SECRET_KEY=.*|SECRET_KEY=${SECRET_KEY}|"                     .env
+sed -i "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=${POSTGRES_PASSWORD}|" .env
+sed -i "s|^APP_DB_PASSWORD=.*|APP_DB_PASSWORD=${APP_DB_PASSWORD}|"       .env
+sed -i "s|^GRAFANA_ADMIN_PASSWORD=.*|GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}|" .env
+sed -i "s|^ADMIN_PASSWORD=.*|ADMIN_PASSWORD=${ADMIN_PASSWORD}|"         .env
+sed -i "s|^ENVIRONMENT=.*|ENVIRONMENT=production|"                      .env
+# DATABASE_URL referenziert den App-User (Compose setzt sie ohnehin neu — hier
+# nur zur Kohaerenz der .env):
+sed -i "s|^DATABASE_URL=.*|DATABASE_URL=postgresql://praxiszeit_app:${APP_DB_PASSWORD}@db:5432/praxiszeit|" .env
+
+chmod 600 .env
+
+echo ""
+echo "============================================================"
+echo "  .env erzeugt — Secrets zufaellig gesetzt."
+echo "------------------------------------------------------------"
+echo "  Initiales Admin-Passwort: ${ADMIN_PASSWORD}"
+echo "  (Nach dem ersten Login in der Benutzerverwaltung aendern!)"
+echo "============================================================"
+echo ""
+echo "  Noch anpassen in .env, falls extern erreichbar:"
+echo "    - CORS_ORIGINS   (eigene Domain statt localhost)"
+echo "    - ADMIN_EMAIL / PRACTICE_NAME"
+echo ""
+echo "  HTTPS (empfohlen): zuerst ein Zertifikat erzeugen"
+echo "    bash ssl/generate-cert.sh"
+echo "  dann mit SSL-Overlay starten:"
+echo "    docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d --build"
+echo ""


### PR DESCRIPTION
## Version 1.8.0

### Native-Installer-Härtung (Feldreport Braumann, Debian-13-Cloud)
- **A** — systemd-Unit vergibt `CAP_NET_BIND_SERVICE` automatisch für Ports < 1024 (443-Bind als non-root, sonst „permission denied"); least-privilege via `CapabilityBoundingSet`. Plus Hardening (`ProtectKernel*`, `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX`, `RestrictNamespaces`, `LockPersonality` …). PORT numerisch validiert.
- **B** — Tägliches Backup als **systemd-Timer** statt `crontab` (cron fehlt auf Minimal-/Cloud-Images), `Persistent=true`.
- **C** — `INSTALL-NATIVE.md`: Tarball entpackt flach → Extraktion mit `-C <ordner>` (statt `cd praxiszeit`).
- **D** — Docker-Bundle: `build-release.sh --docker-only` → `praxiszeit-<v>-docker.tar.gz` (compose + `.env.example` + `generate-secrets.sh` + Build-Kontext). Neue Doku `docs/INSTALL-DOCKER.md`.
- **E** — veraltete Versionsangaben (1.2.0) korrigiert; PG-Quelle in Komponententabelle berichtigt.

### Review-Fixes (Code/Security/UX/Dependency — bis Medium)
- ArbZG: `create_vacation_request`-Budgetprüfung half_day-aware (tagebasiert); `half_day` für Mehrtages-Zeiträume verboten (Schema-Validatoren).
- UX: `pickTextColor`-Schwelle 0.5 → 0.179 (WCAG); AbsenceBadge a11y; stabile Keys; „Halber Tag" deaktiviert Stunden-Feld; AdminAbsences Doppel-Fetch behoben.
- Deps: Node 20 (EOL) → 22; Python-Bundle 3.13.3 → 3.13.13; Grafana 13.0.1 → 13.0.1-security-01.

### Deferred (dokumentiert, kein Blocker)
PG-native 16.14 (theseus noch nicht veröffentlicht), Prometheus 3.x (Config-Migration), workalendar→python-holidays.

### Tests/Validierung
- Backend 824 passed / 44 skipped · Frontend 70 passed + Build · tsc clean
- `validate-release.sh`: Ubuntu 22.04/24.04, Debian 12, Rocky 9 ✓
- Docker lokal: Frontend (node:22) + Grafana (security) recreated, healthy
- Native-Install .131: Unit/Timer/CAP korrekt generiert; End-to-End-Bind durch eine **vorhandene System-PostgreSQL** auf dem Test-Laptop blockiert (Umgebungs-, kein Code-Problem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
