### PR TITLE
feat(beta): Lizenzpruefung in der Beta deaktivieren + BETA-Badge; install.sh Arch/pacman

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -130,6 +130,12 @@ class Settings(BaseSettings):
     # frontend ourselves (i.e. behind a proxy). Override explicitly if needed.
     TRUST_PROXY_HEADERS: Optional[bool] = None
 
+    # Beta-Phase: solange True ist die Lizenzpruefung KOMPLETT deaktiviert —
+    # keine Lizenz noetig, kein Read-Only, kein Mitarbeiter-Limit. Das Frontend
+    # zeigt ein "BETA"-Badge (Flag kommt aus /api/health). Vor dem ersten
+    # kostenpflichtigen Release auf False setzen (dann greift die Lizenzlogik).
+    BETA_MODE: bool = True
+
     # License key file path (native installations only)
     LICENSE_KEY_PATH: Optional[str] = None
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -262,11 +262,18 @@ async def lifespan(app: FastAPI):
         finally:
             db.close()
 
-    # 7. License validation (native installations only). Drei Modi:
+    # 7. License validation (native installations only). Vier Modi:
+    #    0) BETA_MODE → Lizenzpruefung komplett aus (keine Lizenz noetig, kein
+    #       Read-Only, kein Limit) — die gesamte App ist waehrend der Beta frei.
     #    a) LICENSE_KEY_PATH gesetzt + Datei existiert → echte Lizenz validieren
     #    b) LICENSE_DEMO_EXPIRES_AT gesetzt (vom Setup-Wizard) → Demo-Mode bis dahin
     #    c) keins von beiden → klassisch ohne Lizenz (Docker-Dev / SaaS)
-    if settings.LICENSE_KEY_PATH and Path(settings.LICENSE_KEY_PATH).is_file():
+    if settings.BETA_MODE:
+        from app.core.license import set_license_state
+        set_license_state(None, read_only=False)
+        print("License: BETA-Modus aktiv — Lizenzpruefung deaktiviert, "
+              "volle Funktion ohne Lizenz.")
+    elif settings.LICENSE_KEY_PATH and Path(settings.LICENSE_KEY_PATH).is_file():
         from app.core.license import (
             validate_license, validate_license_quiet,
             set_license_state, LicenseError, LicenseExpiredError,
@@ -645,6 +652,8 @@ def system_info():
     return {
         "deployment_mode": settings.DEPLOYMENT_MODE,
         "version": APP_VERSION,
+        # beta: Lizenzpruefung deaktiviert; Frontend zeigt das "BETA"-Badge.
+        "beta": settings.BETA_MODE,
     }
 
 

--- a/backend/tests/test_deployment_mode.py
+++ b/backend/tests/test_deployment_mode.py
@@ -68,8 +68,21 @@ class TestSystemInfoEndpoint:
         response = client.get("/api/system/info")
         assert response.status_code == 200
 
+    def test_beta_flag_present(self, client):
+        # Während der Beta liefert /api/system/info beta=true → Frontend-Badge.
+        response = client.get("/api/system/info")
+        assert response.json().get("beta") is True
+
     def test_response_does_not_leak_internal_state(self, client, onprem_mode):
         # Intentionally tight schema: no env, no ADMIN_EMAIL, no DB status.
         response = client.get("/api/system/info")
         data = response.json()
-        assert set(data.keys()) == {"deployment_mode", "version"}
+        assert set(data.keys()) == {"deployment_mode", "version", "beta"}
+
+
+class TestBetaMode:
+    """Beta-Phase: Lizenzpruefung komplett deaktiviert."""
+
+    def test_beta_mode_defaults_true(self):
+        from app.config import Settings
+        assert Settings.model_fields["BETA_MODE"].default is True

--- a/frontend/src/components/BetaBadge.tsx
+++ b/frontend/src/components/BetaBadge.tsx
@@ -1,0 +1,15 @@
+/**
+ * Small "BETA" pill, shown next to the PraxisZeit title while the backend
+ * reports beta mode (/api/system/info → beta=true). During the beta phase no
+ * license is required; the badge signals that state to users.
+ */
+export default function BetaBadge() {
+  return (
+    <span
+      title="Beta-Version – während der Beta ist keine Lizenz erforderlich"
+      className="ml-2 px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wide bg-amber-400 text-amber-950 align-middle leading-none"
+    >
+      Beta
+    </span>
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import { useAuthStore } from '../stores/authStore';
 import { useUIStore } from '../stores/uiStore';
 import { useSystemStore } from '../stores/systemStore';
 import TrialBanner from './TrialBanner';
+import BetaBadge from './BetaBadge';
 import apiClient from '../api/client';
 import {
   LayoutDashboard,
@@ -37,6 +38,7 @@ export default function Layout() {
   const { user, logout } = useAuthStore();
   const { isStampSheetOpen, openStampSheet, closeStampSheet, notifyStampChange } = useUIStore();
   const deploymentMode = useSystemStore((s) => s.info?.deployment_mode);
+  const isBeta = useSystemStore((s) => s.info?.beta === true);
   const location = useLocation();
   const navigate = useNavigate();
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -203,7 +205,10 @@ export default function Layout() {
 
       {/* Mobile Header */}
       <div className="lg:hidden fixed top-0 left-0 right-0 h-16 bg-surface border-b border-border flex items-center justify-between px-4 z-30">
-        <h1 className="text-xl font-bold text-primary">PraxisZeit</h1>
+        <div className="flex items-center">
+          <h1 className="text-xl font-bold text-primary">PraxisZeit</h1>
+          {isBeta && <BetaBadge />}
+        </div>
         <button
           onClick={() => setSidebarOpen(true)}
           className="p-2 rounded-xl hover:bg-muted transition"
@@ -233,7 +238,10 @@ export default function Layout() {
         {/* Logo/Title */}
         <div className="p-6 border-b border-border flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-primary">PraxisZeit</h1>
+            <div className="flex items-center">
+              <h1 className="text-2xl font-bold text-primary">PraxisZeit</h1>
+              {isBeta && <BetaBadge />}
+            </div>
             <p className="text-sm text-text-secondary mt-1">Zeiterfassung</p>
           </div>
           <button

--- a/frontend/src/stores/systemStore.ts
+++ b/frontend/src/stores/systemStore.ts
@@ -6,6 +6,7 @@ export type DeploymentMode = 'saas' | 'onprem';
 interface SystemInfo {
   deployment_mode: DeploymentMode;
   version: string;
+  beta?: boolean;
 }
 
 interface SystemState {
@@ -14,6 +15,7 @@ interface SystemState {
   fetch: () => Promise<void>;
   isSaas: () => boolean;
   isOnprem: () => boolean;
+  isBeta: () => boolean;
 }
 
 // Conservative default: treat as on-prem until the /api/system/info response
@@ -37,4 +39,5 @@ export const useSystemStore = create<SystemState>((set, get) => ({
 
   isSaas: () => get().info?.deployment_mode === 'saas',
   isOnprem: () => get().info?.deployment_mode !== 'saas',
+  isBeta: () => get().info?.beta === true,
 }));

--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -78,9 +78,29 @@ install_runtime_deps() {
         zypper -n install \
             libxml2-2 libopenssl3 krb5 libzstd1 liblz4-1 libreadline8 libbrotli1 \
             || { error "zypper install fehlgeschlagen"; exit 1; }
+    elif command -v pacman &>/dev/null; then
+        # Arch/CachyOS. KEIN -Sy (Partial-Upgrade-Falle) — --needed nutzt die
+        # vorhandene Sync-DB. ACHTUNG: Rolling-Distros koennen libxml2 bereits
+        # auf einen neueren Soname (libxml2.so.16) gehoben haben; theseus' PG
+        # braucht libxml2.so.2 — dann unten der Hinweis.
+        pacman -S --needed --noconfirm \
+            libxml2 openssl krb5 zstd lz4 readline brotli \
+            || { error "pacman install fehlgeschlagen (ggf. zuerst 'pacman -Sy')"; exit 1; }
     else
-        error "Kein bekannter Paketmanager (apt-get, dnf, zypper) gefunden."
+        error "Kein bekannter Paketmanager (apt-get, dnf, zypper, pacman) gefunden."
         error "Bitte installiere manuell: ${missing[*]}"
+        exit 1
+    fi
+
+    # Rolling-Distro-Soname-Check: theseus' postgres linkt gegen libxml2.so.2.
+    # Arch/CachyOS liefern ab libxml2 2.14 nur noch libxml2.so.16 -> der
+    # PG-Start wuerde mit "libxml2.so.2: cannot open shared object file"
+    # scheitern. Frueh + klar abbrechen statt im Dienst-Crash-Loop zu landen.
+    if ! ldconfig -p 2>/dev/null | grep -qE "^[[:space:]]*libxml2\.so\.2\b"; then
+        error "libxml2.so.2 ist auf diesem System nicht verfuegbar."
+        error "Vermutlich eine Rolling-Distro (z.B. Arch/CachyOS) mit libxml2 >= 2.14"
+        error "(nur libxml2.so.16). Die mitgelieferte PostgreSQL benoetigt aber"
+        error "libxml2.so.2. Unterstuetzt: Debian 12+, Ubuntu 22.04+, RHEL/Rocky/Alma 9+."
         exit 1
     fi
 }


### PR DESCRIPTION
## Beta-Modus (keine Lizenz nötig)
- `BETA_MODE` (Default **True**) in `config.py`; `main.py` gated den kompletten Lizenz-Block → keine Validierung, kein Read-Only, kein Mitarbeiter-Limit während der Beta.
- `/api/system/info` liefert `beta`; Frontend zeigt ein **BETA-Badge** (`BetaBadge.tsx`) neben dem Titel (Mobile + Sidebar) via `systemStore.isBeta()`.
- Vor dem ersten kostenpflichtigen Release: `BETA_MODE=False`.

## install.sh (Arch/CachyOS-Feldtest)
- **pacman**-Branch (Arch/CachyOS) für die Runtime-Libs, ohne `-Sy` (Partial-Upgrade-Falle), mit `--needed`.
- **Fail-Fast bei fehlendem `libxml2.so.2`** (Rolling-Distros ab libxml2 2.14 liefern nur `libxml2.so.16`) → klare Meldung statt opakem PG-Crash-Loop. Echter Bundle-Fix: #177.

## Tests
backend **830 passed** / 44 skipped (inkl. Beta-Flag-Tests); tsc + vite build grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
