### PR TITLE
fix(review): Beta-Bugreports erlauben + Release-Warnung für BETA_MODE

### DIFF
--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -76,11 +76,18 @@ def report_feedback(
       502  -> Netzwerk-/Server-Fehler beim pzweb-Call
     """
     lic = license_module.get_current_license()
-    if lic is None or not getattr(lic, "customer_id", ""):
-        raise HTTPException(
-            status_code=400,
-            detail="Ohne hinterlegte Lizenz ist keine Bug-Meldung möglich.",
-        )
+    license_id = getattr(lic, "customer_id", "") if lic else ""
+    if not license_id:
+        if settings.BETA_MODE:
+            # In der Beta gibt es keine Lizenz — Bug-Reports sollen trotzdem
+            # möglich sein (gerade in der Beta will man Feedback). Synthetische
+            # license_id, damit pzweb die Meldung einer Beta-Quelle zuordnen kann.
+            license_id = "beta"
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail="Ohne hinterlegte Lizenz ist keine Bug-Meldung möglich.",
+            )
 
     target = f"{settings.FEEDBACK_SERVER_URL.rstrip('/')}/v1/bugs"
     try:
@@ -94,7 +101,7 @@ def report_feedback(
 
     # multipart/form-data: jedes Feld als eigener Part (None = kein Dateiname).
     files = {
-        "license_id": (None, lic.customer_id),
+        "license_id": (None, license_id),
         "title": (None, payload.title),
         "description": (None, payload.description),
         "app_version": (None, APP_VERSION),

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -132,11 +132,27 @@ def test_network_error_maps_to_502(client, mock_license, monkeypatch):
 
 
 def test_no_license_returns_400_and_does_not_call_pzweb(client, monkeypatch):
+    # Produktivpfad (BETA_MODE aus): ohne Lizenz -> 400, kein pzweb-Call.
+    from app.routers import feedback
+    monkeypatch.setattr(feedback.settings, "BETA_MODE", False)
     monkeypatch.setattr("app.core.license.get_current_license", lambda: None)
     rec = _patch_post(monkeypatch, response=httpx.Response(201, json={"id": "x"}))
     resp = client.post("/api/feedback/report", json=VALID)
     assert resp.status_code == 400
     assert rec.calls == []  # never reach out to pzweb without a license_id
+
+
+def test_beta_no_license_forwards_with_beta_id(client, monkeypatch):
+    # In der Beta (BETA_MODE=True) darf ein Bug-Report auch OHNE Lizenz raus —
+    # mit synthetischer license_id "beta".
+    from app.routers import feedback
+    monkeypatch.setattr(feedback.settings, "BETA_MODE", True)
+    monkeypatch.setattr("app.core.license.get_current_license", lambda: None)
+    rec = _patch_post(monkeypatch, response=httpx.Response(201, json={"id": "b-1"}))
+    resp = client.post("/api/feedback/report", json=VALID)
+    assert resp.status_code == 200
+    assert len(rec.calls) == 1
+    assert rec.calls[0]["kwargs"]["files"]["license_id"][1] == "beta"
 
 
 def test_title_too_long_returns_422(client, mock_license, monkeypatch):

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -142,6 +142,17 @@ if [ "$_fe_ver" != "$APP_VERSION" ]; then
     exit 1
 fi
 
+# BETA_MODE-Hinweis: solange Default True, ist die Lizenzpruefung in JEDEM
+# gebauten Paket deaktiviert (keine Lizenz noetig). Das ist in der Beta gewollt,
+# aber vor dem ersten KOSTENPFLICHTIGEN Release MUSS BETA_MODE auf False —
+# sonst laeuft jede Installation dauerhaft ohne Lizenzdurchsetzung. Laut warnen,
+# damit es beim GA-Build nicht uebersehen wird (nicht abbrechen — Beta-Builds
+# sind legitim).
+if grep -qE '^\s*BETA_MODE:\s*bool\s*=\s*True' "${REPO_DIR_PRE}/backend/app/config.py" 2>/dev/null; then
+    echo -e "${YELLOW}[WARN]${NC} BETA_MODE=True -> Lizenzpruefung in diesem Build DEAKTIVIERT (keine Lizenz noetig)." >&2
+    echo -e "${YELLOW}[WARN]${NC} Fuer ein kostenpflichtiges Release vorher backend/app/config.py BETA_MODE=False setzen." >&2
+fi
+
 # =============================================================================
 # Download-URLs
 # =============================================================================


### PR DESCRIPTION
Re-Review-Fixes der Lizenz-/Beta-Änderungen (#176/#178):
- **M (Footgun):** `build-release.sh` warnt laut bei `BETA_MODE=True` (Lizenzprüfung im Build deaktiviert) → nicht vergessen, vor dem kostenpflichtigen GA-Release `BETA_MODE=False` zu setzen. Kein Abbruch (Beta-Builds legitim).
- **L (Beta-UX):** `feedback.py` blockierte Bug-Reports ohne Lizenz (400) — in der Beta unerwünscht. Jetzt Forward mit `license_id="beta"`; Produktivpfad (`BETA_MODE=False`) bleibt 400. Tests angepasst + Beta-Forward-Test ergänzt.

Sonstige Review-Findings waren Low/kosmetisch/beabsichtigt (SaaS-Suspend nicht beta-gated = gewollt; utf-8-sig benign; redundante SCRIPT_DIR-Berechnung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
