### PR TITLE
feat: QR-Code (Smartphone), Admin-Update-Banner, Installer ohne Lizenz-Abfrage

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -156,6 +156,10 @@ class Settings(BaseSettings):
     # Update server URL (native installations only)
     UPDATE_SERVER_URL: Optional[str] = None
     UPDATE_CHECK_INTERVAL_HOURS: int = 12
+    # Menschlich aufrufbare Downloadseite (Shop), auf die das Admin-Update-Banner
+    # verlinkt, wenn eine neue Version verfügbar ist. (Die Direkt-Artefakt-URL
+    # kommt separat aus dem signierten Update-Manifest.)
+    DOWNLOAD_PAGE_URL: str = "https://praxiszeit.mr-development.de"
 
     # Feedback / Bug-Reporting: base URL of the pzweb bug-tracker the in-app
     # report endpoint proxies to (POST {url}/v1/bugs). Host must be in

--- a/backend/app/routers/admin_updates.py
+++ b/backend/app/routers/admin_updates.py
@@ -17,7 +17,7 @@ router = APIRouter(
 @router.get("/status")
 def update_status(current_user: User = Depends(require_admin)):
     """Get current update status and version info."""
-    return get_update_status()
+    return {**get_update_status(), "download_page": settings.DOWNLOAD_PAGE_URL}
 
 
 @router.post("/check")
@@ -38,9 +38,11 @@ def trigger_update_check(current_user: User = Depends(require_admin)):
         return {
             "update_available": True,
             "update": update.to_dict(),
+            "download_page": settings.DOWNLOAD_PAGE_URL,
         }
     return {
         "update_available": False,
         "current_version": get_app_version(),
+        "download_page": settings.DOWNLOAD_PAGE_URL,
         "message": "Keine Updates verfuegbar.",
     }

--- a/frontend/src/components/QrLinkModal.tsx
+++ b/frontend/src/components/QrLinkModal.tsx
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { X } from 'lucide-react';
+
+interface QrLinkModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** URL to encode. Defaults to the current origin (the app's own address). */
+  url?: string;
+}
+
+/**
+ * Zeigt einen QR-Code der App-Adresse, damit Mitarbeiter die Seite auf dem
+ * Smartphone öffnen können, ohne die URL eintippen zu müssen (einfach mit der
+ * Handy-Kamera scannen).
+ */
+export default function QrLinkModal({ open, onClose, url }: QrLinkModalProps) {
+  const target = url ?? window.location.origin;
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Auf dem Smartphone öffnen"
+    >
+      <div
+        className="bg-white rounded-2xl shadow-2xl w-full max-w-xs p-6 text-center"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-end -mt-2 -mr-2">
+          <button
+            onClick={onClose}
+            aria-label="Schließen"
+            className="p-1 text-gray-400 hover:text-gray-700 rounded-lg"
+          >
+            <X size={20} />
+          </button>
+        </div>
+        <h2 className="text-lg font-bold text-gray-900 mb-1">Auf dem Smartphone öffnen</h2>
+        <p className="text-sm text-gray-600 mb-4">
+          Mit der Kamera des Smartphones scannen — die Adresse muss nicht eingetippt werden.
+        </p>
+        <div className="flex justify-center mb-4">
+          <div className="p-3 bg-white border border-gray-200 rounded-xl">
+            <QRCodeSVG value={target} size={200} />
+          </div>
+        </div>
+        <a
+          href={target}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block text-xs text-primary break-all hover:underline"
+        >
+          {target}
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/UpdateBanner.tsx
+++ b/frontend/src/components/UpdateBanner.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import { Download, X } from 'lucide-react';
+import apiClient from '../api/client';
+
+interface UpdateData {
+  latest_version: string;
+  current_version: string;
+  changelog?: string;
+  critical?: boolean;
+}
+
+/**
+ * Admin-Hinweis, dass eine neue PraxisZeit-Version verfügbar ist, mit Link zur
+ * Downloadseite. Prüft einmal pro Browser-Session gegen den Update-Server
+ * (POST /api/admin/updates/check). Ist kein Update-Server konfiguriert
+ * (z.B. Docker/Dev → 404) oder kein Update vorhanden, wird nichts angezeigt.
+ * Pro Version einmal ausblendbar.
+ */
+export default function UpdateBanner() {
+  const [info, setInfo] = useState<UpdateData | null>(null);
+  const [downloadPage, setDownloadPage] = useState('https://praxiszeit.mr-development.de');
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const apply = (data: any) => {
+      if (!data?.update_available || !data?.update) return;
+      if (sessionStorage.getItem('pz-update-dismissed') === data.update.latest_version) return;
+      setInfo(data.update);
+      if (data.download_page) setDownloadPage(data.download_page);
+    };
+    const cached = sessionStorage.getItem('pz-update-check');
+    if (cached) {
+      try { apply(JSON.parse(cached)); } catch { /* ignore */ }
+      return;
+    }
+    (async () => {
+      try {
+        const { data } = await apiClient.post('/admin/updates/check');
+        if (cancelled) return;
+        sessionStorage.setItem('pz-update-check', JSON.stringify(data));
+        apply(data);
+      } catch {
+        // 404 (kein Update-Server) oder Netzwerkfehler → kein Banner
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!info || dismissed) return null;
+
+  const critical = info.critical === true;
+  return (
+    <div
+      className={`mb-4 rounded-xl border px-4 py-3 flex items-start gap-3 ${
+        critical ? 'bg-red-50 border-red-200' : 'bg-blue-50 border-blue-200'
+      }`}
+      role="status"
+    >
+      <Download size={20} className={`${critical ? 'text-red-600' : 'text-blue-600'} mt-0.5 shrink-0`} />
+      <div className="flex-1 text-sm">
+        <p className={`font-semibold ${critical ? 'text-red-800' : 'text-blue-800'}`}>
+          Neue Version {info.latest_version} verfügbar{critical && ' — wichtiges Update'}
+        </p>
+        <p className="text-gray-600">
+          Installiert: {info.current_version}.{' '}
+          <a
+            href={downloadPage}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary font-medium hover:underline"
+          >
+            Zur Downloadseite
+          </a>
+        </p>
+        {info.changelog && <p className="text-xs text-gray-500 mt-1 line-clamp-2">{info.changelog}</p>}
+      </div>
+      <button
+        onClick={() => {
+          sessionStorage.setItem('pz-update-dismissed', info.latest_version);
+          setDismissed(true);
+        }}
+        aria-label="Hinweis ausblenden"
+        className="p-1 text-gray-400 hover:text-gray-700 rounded-lg shrink-0"
+      >
+        <X size={18} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -6,6 +6,7 @@ import { LogIn, FileText, Shield, Smartphone } from 'lucide-react';
 import PasswordInput from '../components/PasswordInput';
 import { getErrorMessage } from '../utils/errorMessage';
 import { DocModal } from '../components/DocModal';
+import QrLinkModal from '../components/QrLinkModal';
 
 export default function Login() {
   const [username, setUsername] = useState('');
@@ -16,6 +17,7 @@ export default function Login() {
   const [loading, setLoading] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalTab, setModalTab] = useState<'cheatsheet' | 'handbuch'>('cheatsheet');
+  const [qrOpen, setQrOpen] = useState(false);
 
   const { login } = useAuthStore();
   const deploymentMode = useSystemStore((s) => s.info?.deployment_mode);
@@ -136,6 +138,15 @@ export default function Login() {
           </button>
         </form>
 
+        <button
+          type="button"
+          onClick={() => setQrOpen(true)}
+          className="mt-4 w-full flex items-center justify-center gap-2 text-sm text-gray-600 hover:text-primary transition-colors"
+        >
+          <Smartphone size={16} />
+          Auf dem Smartphone öffnen (QR-Code)
+        </button>
+
         {deploymentMode === 'saas' && (
           <div className="mt-6 text-center text-sm">
             <span className="text-gray-600">Noch keinen Account? </span>
@@ -183,6 +194,8 @@ export default function Login() {
           onClose={() => setModalOpen(false)}
           initialTab={modalTab}
         />
+
+        <QrLinkModal open={qrOpen} onClose={() => setQrOpen(false)} />
       </div>
     </div>
   );

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -10,6 +10,7 @@ import ConfirmDialog from '../../components/ConfirmDialog';
 import MonthSelector from '../../components/MonthSelector';
 import { getErrorMessage } from '../../utils/errorMessage';
 import LoadingSpinner from '../../components/LoadingSpinner';
+import UpdateBanner from '../../components/UpdateBanner';
 
 interface EmployeeReport {
   user_id: string;
@@ -386,6 +387,8 @@ export default function AdminDashboard() {
         onCancel={handleCancel}
       />
       <h1 className="text-3xl font-bold text-gray-900 mb-8">Admin-Dashboard</h1>
+
+      <UpdateBanner />
 
       {/* Stats */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">

--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -174,17 +174,15 @@ while true; do
     break
 done
 
-echo ""
-# Lizenz automatisch übernehmen, wenn eine license.key direkt neben dem
-# Installer liegt (z.B. aus dem entpackten Paket / einer früheren Installation).
-# Dann NICHT nachfragen — die vorhandene Datei wird sofort genutzt.
+# Beta (1.8.0): KEINE Lizenz-Abfrage — die Lizenzprüfung ist über BETA_MODE
+# deaktiviert (keine Lizenz nötig). Eine vorhandene license.key (neben dem
+# Installer oder aus einer früheren Installation) wird STILL übernommen, damit
+# sie für eine spätere Reaktivierung erhalten bleibt; es wird aber nicht danach
+# gefragt und nichts dazu angezeigt.
 _PKG_DIR="$(cd "$(dirname "$0")" && pwd)"
 LICENSE_FILE=""
 if [ -f "${_PKG_DIR}/license.key" ]; then
     LICENSE_FILE="${_PKG_DIR}/license.key"
-    info "Lizenzdatei neben dem Installer gefunden (${LICENSE_FILE}) — wird automatisch übernommen."
-else
-    read -rp "Lizenzschlüssel-Datei (Pfad, oder leer für später): " LICENSE_FILE
 fi
 
 echo ""


### PR DESCRIPTION
Drei Punkte aus dem User-Feedback:

1. **Installer ohne Lizenz-Abfrage (Linux):** Während der Beta (BETA_MODE) fragt der Linux-Installer nicht mehr nach einer Lizenz. Eine vorhandene `license.key` wird still übernommen (für spätere Reaktivierung). macOS hatte keine Abfrage; der Windows-Wizard wurde bereits in `225dc81` entkernt.
2. **QR-Code für MA:** „Auf dem Smartphone öffnen" auf der Login-Seite → Modal mit QR der App-Adresse (`window.location.origin`). Scannen mit der Handy-Kamera, kein URL-Eintippen. Reuse `qrcode.react`.
3. **Admin-Update-Banner:** `UpdateBanner` im Admin-Dashboard prüft 1×/Session `/api/admin/updates/check`; bei neuer Version Hinweis + **Link zur Downloadseite** (`DOWNLOAD_PAGE_URL`, default `praxiszeit.mr-development.de`). Ohne Update-Server (Docker/Dev → 404) kein Banner; pro Version ausblendbar.

Tests: deployment/beta/feedback grün; tsc + vite build grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
