### PR TITLE
chore(seo): Google-Search-Console-Verifizierungsdatei

### DIFF
--- a/frontend/public/google7bfda710bc689b22.html
+++ b/frontend/public/google7bfda710bc689b22.html
@@ -1,0 +1,1 @@
+google-site-verification: google7bfda710bc689b22.html


### PR DESCRIPTION
Legt `google7bfda710bc689b22.html` in `frontend/public/` → wird unter `/google7bfda710bc689b22.html` ausgeliefert (nginx + nativ verifiziert). Für die Google-Verifizierung muss das relevante PUBLIC-Deployment neu gebaut/deployt werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)