### PR TITLE
revert: Google-Verify-Datei nicht im App-Frontend (läuft über pzweb)

### DIFF
--- a/frontend/public/google7bfda710bc689b22.html
+++ b/frontend/public/google7bfda710bc689b22.html
@@ -1,1 +1,0 @@
-google-site-verification: google7bfda710bc689b22.html


### PR DESCRIPTION
Nimmt `frontend/public/google7bfda710bc689b22.html` (PR #185) wieder raus — die Google-Verifizierung läuft über den pzweb-Shop, nicht über die selbstgehostete App (sonst lieferte jede Kundeninstanz den Token aus). Quelle bleibt unter `feedback/seo/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)