### PR TITLE
fix(arbzg): §4-Pausen-Ausnahme bei Korrekturen (#200, Blocker) + Pausen-Prompt beim Ausstempeln (#199)

### DIFF
--- a/backend/app/routers/change_requests.py
+++ b/backend/app/routers/change_requests.py
@@ -198,7 +198,11 @@ def create_change_request(
             break_minutes=data.proposed_break_minutes or 0,
             exclude_entry_id=entry.id if entry else None,
         )
-        if break_error:
+        # #200: §4-Pausen-Ausnahme — bei dokumentierter Begründung den §4-Block
+        # NICHT hart werfen, sondern den Antrag mit break_waiver_reason anlegen
+        # (admin_change_requests honoriert ihn beim Genehmigen). Der §3-10h-Cap
+        # unten bleibt unabhängig davon hart.
+        if break_error and not (data.break_waiver_reason and data.break_waiver_reason.strip()):
             raise HTTPException(status_code=400, detail=break_error)
 
         # §3 ArbZG: daily hours hard limit
@@ -247,6 +251,11 @@ def create_change_request(
         proposed_break_minutes=data.proposed_break_minutes,
         proposed_note=data.proposed_note,
         reason=data.reason,
+        break_waiver_reason=(
+            data.break_waiver_reason.strip()
+            if data.break_waiver_reason and data.break_waiver_reason.strip()
+            else None
+        ),
     )
 
     # Snapshot original values

--- a/backend/tests/test_break_waiver.py
+++ b/backend/tests/test_break_waiver.py
@@ -186,6 +186,46 @@ _OVER_6H = {
     "end_time": "15:30",  # 7.5h gross, 0 break → §4 violation, under 10h
 }
 
+# CR-Variante (proposed_*-Keys) eines §4-verletzenden Eintrags.
+_CR_OVER_6H = {
+    "request_type": "create",
+    "proposed_date": (date.today() - timedelta(days=7)).isoformat(),  # vergangener Werktag
+    "proposed_start_time": "08:00",
+    "proposed_end_time": "15:46",  # 7h46m brutto, 0 Pause → §4-Verstoß, unter 10h
+    "proposed_break_minutes": 0,
+    "reason": "Korrektur Zeiteintrag",
+}
+
+
+class TestChangeRequestBreakWaiver:
+    """#200: Die §4-Pausen-Ausnahme muss auch im Änderungsantrag-Pfad greifen
+    (vorher: break_waiver_reason wurde ignoriert → 400 trotz korrekter Eingabe)."""
+
+    def test_cr_without_waiver_blocked(self, db, employee_client):
+        """Ohne Begründung bleibt der §4-Block (400) — Kontrolle."""
+        resp = employee_client.post("/api/change-requests/", json=_CR_OVER_6H)
+        assert resp.status_code == 400
+        assert "Pause" in resp.json()["detail"]
+
+    def test_cr_with_waiver_created(self, db, employee, employee_client):
+        """Mit Begründung wird der Antrag angelegt (201) statt abgewiesen."""
+        resp = employee_client.post(
+            "/api/change-requests/",
+            json={**_CR_OVER_6H, "break_waiver_reason": "Notfall, keine Vertretung"},
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["break_waiver_reason"] == "Notfall, keine Vertretung"
+        cr = db.query(ChangeRequest).filter(ChangeRequest.user_id == employee.id).one()
+        assert cr.break_waiver_reason == "Notfall, keine Vertretung"
+
+    def test_cr_waiver_still_blocks_over_10h(self, db, employee_client):
+        """§3-10h-Cap bleibt hart, auch MIT §4-Ausnahme (422, nicht 201)."""
+        resp = employee_client.post(
+            "/api/change-requests/",
+            json={**_CR_OVER_6H, "proposed_end_time": "19:00", "break_waiver_reason": "egal"},
+        )
+        assert resp.status_code == 422, resp.text
+
 
 class TestBreakWaiverNoApproval:
     """requires_approval = false (Default)."""

--- a/frontend/src/components/ChangeRequestForm.tsx
+++ b/frontend/src/components/ChangeRequestForm.tsx
@@ -31,11 +31,20 @@ export default function ChangeRequestForm({ entry, requestType, onClose, onSucce
   });
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
+  // #200: §4-Pausen-Ausnahme. Wird eingeblendet, sobald das Backend einen
+  // §4-Pausenfehler meldet (deckt auch Aggregat-Fälle „fast zeitgleicher
+  // Eintrag" ab, die das Formular allein nicht vorab erkennen kann).
+  const [showWaiver, setShowWaiver] = useState(false);
+  const [breakWaiverReason, setBreakWaiverReason] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!formData.reason.trim()) {
       setError('Bitte geben Sie eine Begründung an');
+      return;
+    }
+    if (showWaiver && !breakWaiverReason.trim()) {
+      setError('Bitte begründen Sie, warum die Pflicht-Pause nicht möglich war.');
       return;
     }
 
@@ -52,10 +61,18 @@ export default function ChangeRequestForm({ entry, requestType, onClose, onSucce
         proposed_break_minutes: requestType !== 'delete' ? formData.proposed_break_minutes : null,
         proposed_note: requestType !== 'delete' ? formData.proposed_note : null,
         reason: formData.reason,
+        break_waiver_reason: showWaiver && breakWaiverReason.trim() ? breakWaiverReason.trim() : null,
       });
       onSuccess();
     } catch (err: any) {
-      setError(getErrorMessage(err, 'Fehler beim Erstellen des Antrags'));
+      const msg = getErrorMessage(err, 'Fehler beim Erstellen des Antrags');
+      // §4-Pausenfehler enthält stets „Pause" (§3-10h-Cap nicht) → Ausnahme anbieten.
+      if (!showWaiver && msg.includes('Pause')) {
+        setShowWaiver(true);
+        setError(`${msg} Wenn die Pflicht-Pause nachweislich nicht möglich war, begründen Sie dies unten und senden Sie erneut.`);
+      } else {
+        setError(msg);
+      }
     } finally {
       setSubmitting(false);
     }
@@ -195,6 +212,23 @@ export default function ChangeRequestForm({ entry, requestType, onClose, onSucce
             />
           </div>
 
+          {/* #200: Pflicht-Pause-Ausnahme (§4 ArbZG) — erscheint bei §4-Verstoß */}
+          {showWaiver && (
+            <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg space-y-2">
+              <label className="block text-sm font-medium text-amber-800">
+                Pflicht-Pause war nicht möglich – Begründung <span className="text-red-500">*</span>
+              </label>
+              <textarea
+                value={breakWaiverReason}
+                onChange={(e) => setBreakWaiverReason(e.target.value)}
+                rows={2}
+                placeholder="z. B. Notfall, keine Vertretung verfügbar"
+                className="w-full px-3 py-2 border border-amber-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+              />
+              <p className="text-xs text-amber-700">Die Abweichung von §4 ArbZG wird dokumentiert.</p>
+            </div>
+          )}
+
           {/* Actions */}
           <div className="flex justify-end space-x-3 pt-4 border-t border-gray-200">
             <button
@@ -209,7 +243,7 @@ export default function ChangeRequestForm({ entry, requestType, onClose, onSucce
               disabled={submitting}
               className="px-4 py-2 bg-amber-500 hover:bg-amber-600 text-white rounded-lg transition disabled:opacity-50"
             >
-              {submitting ? 'Wird gesendet...' : 'Antrag stellen'}
+              {submitting ? 'Wird gesendet...' : showWaiver ? 'Mit dokumentierter Ausnahme senden' : 'Antrag stellen'}
             </button>
           </div>
         </form>

--- a/frontend/src/components/MonthlyJournal.tsx
+++ b/frontend/src/components/MonthlyJournal.tsx
@@ -4,6 +4,7 @@ import { de } from 'date-fns/locale';
 import { Pencil, Plus, Trash2, Check, X } from 'lucide-react';
 import apiClient from '../api/client';
 import { getErrorMessage } from '../utils/errorMessage';
+import { submitWithBreakWaiver } from '../utils/breakWaiverRetry';
 import { useToast } from '../contexts/ToastContext';
 import { useConfirm } from '../hooks/useConfirm';
 import ConfirmDialog from './ConfirmDialog';
@@ -258,14 +259,14 @@ export default function MonthlyJournal({ userId, isAdminView }: MonthlyJournalPr
           break_minutes: Math.min(parseInt(editState.breakMinutes, 10) || 0, 480),
         };
         const existing = !switchingToWork ? editedEntry : null;
-        if (existing) {
-          await apiClient.put(`/admin/time-entries/${existing.id}`, payload);
-        } else {
-          await apiClient.post(`/admin/users/${userId}/time-entries`, {
-            date: day.date,
-            ...payload,
-          });
-        }
+        // #200: §4-Pausen-Ausnahme per Retry mit dokumentierter Begründung.
+        await submitWithBreakWaiver(async (extra) => {
+          if (existing) {
+            await apiClient.put(`/admin/time-entries/${existing.id}`, { ...payload, ...extra });
+          } else {
+            await apiClient.post(`/admin/users/${userId}/time-entries`, { date: day.date, ...payload, ...extra });
+          }
+        });
       } else {
         // Delete existing absence of different type if present, then create new
         if (hadAbsence && day.absences[0] && !switchingToWork) {

--- a/frontend/src/components/StampWidget.tsx
+++ b/frontend/src/components/StampWidget.tsx
@@ -5,6 +5,7 @@ import { useToast } from '../contexts/ToastContext';
 import { useAuthStore } from '../stores/authStore';
 import { getErrorMessage } from '../utils/errorMessage';
 import { showArbzgWarnings } from '../utils/arbzgWarnings';
+import { computeBreakError } from '../utils/breakValidation';
 
 interface ClockStatus {
   is_clocked_in: boolean;
@@ -39,6 +40,9 @@ export default function StampWidget({ variant = 'inline', onSuccess }: StampWidg
   const [showBreakInput, setShowBreakInput] = useState(false);
   const [breakMinutes, setBreakMinutes] = useState(0);
   const [showSuccess, setShowSuccess] = useState(false);
+  // #199: §4-Pausenpflicht beim Ausstempeln — Warnung + Pflicht-Begründung.
+  const [breakWarn, setBreakWarn] = useState<string | null>(null);
+  const [breakWaiverReason, setBreakWaiverReason] = useState('');
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -91,13 +95,32 @@ export default function StampWidget({ variant = 'inline', onSuccess }: StampWidg
       setShowBreakInput(true);
       return;
     }
+    // #199: §4-Pausenpflicht — bei >6h Netto und unzureichender Pause die Pause
+    // nacherfassen ODER eine dokumentierte Ausnahme verlangen, statt still mit
+    // Warn-Toast durchzuwinken. (Aggregat mehrerer Tagesblöcke prüft das Backend.)
+    const st = status?.current_entry?.start_time;
+    if (st && !user?.exempt_from_arbzg) {
+      const startHHMM = st.includes('T') ? st.split('T')[1].substring(0, 5) : st.substring(0, 5);
+      const now = new Date();
+      const endHHMM = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+      const breakErr = computeBreakError([], startHHMM, endHHMM, breakMinutes, false);
+      if (breakErr && !breakWaiverReason.trim()) {
+        setBreakWarn(breakErr);
+        return; // Eingabe (Pause erhöhen oder Begründung) erforderlich
+      }
+    }
     setActing(true);
     try {
-      const res = await apiClient.post('/time-entries/clock-out', { break_minutes: breakMinutes });
+      const res = await apiClient.post('/time-entries/clock-out', {
+        break_minutes: breakMinutes,
+        break_waiver_reason: breakWaiverReason.trim() || undefined,
+      });
       toast.success('Erfolgreich ausgestempelt');
       showArbzgWarnings(toast, res.data?.warnings);
       setShowBreakInput(false);
       setBreakMinutes(0);
+      setBreakWarn(null);
+      setBreakWaiverReason('');
       await fetchStatus();
       if (variant === 'sheet') {
         setShowSuccess(true);
@@ -116,6 +139,8 @@ export default function StampWidget({ variant = 'inline', onSuccess }: StampWidg
   const cancelClockOut = () => {
     setShowBreakInput(false);
     setBreakMinutes(0);
+    setBreakWarn(null);
+    setBreakWaiverReason('');
   };
 
   const formatElapsed = (minutes: number) => {
@@ -187,10 +212,23 @@ export default function StampWidget({ variant = 'inline', onSuccess }: StampWidg
               min={0}
               max={480}
               value={breakMinutes}
-              onChange={(e) => setBreakMinutes(parseInt(e.target.value) || 0)}
+              onChange={(e) => { setBreakMinutes(parseInt(e.target.value) || 0); setBreakWarn(null); }}
               className="w-full border border-gray-200 rounded-xl px-4 py-3 text-center text-lg focus:ring-2 focus:ring-primary focus:border-transparent"
               autoFocus
             />
+            {breakWarn && (
+              <div className="mt-3 text-left bg-amber-50 border border-amber-200 rounded-xl p-3">
+                <p className="text-sm text-amber-800">{breakWarn}</p>
+                <p className="text-xs text-amber-700 mt-1">Pause oben nachtragen <strong>oder</strong> begründen, warum sie nicht möglich war:</p>
+                <textarea
+                  value={breakWaiverReason}
+                  onChange={(e) => setBreakWaiverReason(e.target.value)}
+                  rows={2}
+                  placeholder="z. B. Notfall, keine Vertretung"
+                  className="w-full mt-2 border border-amber-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-amber-500"
+                />
+              </div>
+            )}
             <button onClick={cancelClockOut} className="text-sm text-text-secondary hover:text-text-primary mt-2 transition">
               Abbrechen
             </button>
@@ -243,25 +281,40 @@ export default function StampWidget({ variant = 'inline', onSuccess }: StampWidg
 
         {/* Break input (shown before clock-out) */}
         {showBreakInput && (
-          <div className="flex items-center gap-2">
-            <label htmlFor="break-minutes-inline" className="text-sm text-text-secondary whitespace-nowrap">Pause (Min.):</label>
-            <input
-              id="break-minutes-inline"
-              type="number"
-              inputMode="numeric"
-              min="0"
-              max="480"
-              value={breakMinutes}
-              onChange={(e) => setBreakMinutes(parseInt(e.target.value) || 0)}
-              className="w-20 px-2 py-2 border border-gray-200 rounded-xl text-center focus:ring-2 focus:ring-primary"
-              autoFocus
-            />
-            <button
-              onClick={cancelClockOut}
-              className="text-sm text-text-secondary hover:text-text-primary px-2 py-2 transition"
-            >
-              Abbrechen
-            </button>
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <label htmlFor="break-minutes-inline" className="text-sm text-text-secondary whitespace-nowrap">Pause (Min.):</label>
+              <input
+                id="break-minutes-inline"
+                type="number"
+                inputMode="numeric"
+                min="0"
+                max="480"
+                value={breakMinutes}
+                onChange={(e) => { setBreakMinutes(parseInt(e.target.value) || 0); setBreakWarn(null); }}
+                className="w-20 px-2 py-2 border border-gray-200 rounded-xl text-center focus:ring-2 focus:ring-primary"
+                autoFocus
+              />
+              <button
+                onClick={cancelClockOut}
+                className="text-sm text-text-secondary hover:text-text-primary px-2 py-2 transition"
+              >
+                Abbrechen
+              </button>
+            </div>
+            {breakWarn && (
+              <div className="bg-amber-50 border border-amber-200 rounded-xl p-3 max-w-md">
+                <p className="text-sm text-amber-800">{breakWarn}</p>
+                <p className="text-xs text-amber-700 mt-1">Pause nachtragen <strong>oder</strong> Ausnahme begründen:</p>
+                <textarea
+                  value={breakWaiverReason}
+                  onChange={(e) => setBreakWaiverReason(e.target.value)}
+                  rows={2}
+                  placeholder="z. B. Notfall, keine Vertretung"
+                  className="w-full mt-2 border border-amber-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-amber-500"
+                />
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -9,6 +9,7 @@ import { useConfirm } from '../../hooks/useConfirm';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import MonthSelector from '../../components/MonthSelector';
 import { getErrorMessage } from '../../utils/errorMessage';
+import { submitWithBreakWaiver } from '../../utils/breakWaiverRetry';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import UpdateBanner from '../../components/UpdateBanner';
 
@@ -255,26 +256,22 @@ export default function AdminDashboard() {
     if (!selectedEmployee) return;
     try {
       if (entryForm.entry_type === 'work') {
-        // Normal time entry
-        if (editingEntryId) {
-          await apiClient.put(`/admin/time-entries/${editingEntryId}`, {
-            date: entryForm.date,
-            start_time: entryForm.start_time,
-            end_time: entryForm.end_time,
-            break_minutes: entryForm.break_minutes,
-            note: entryForm.note,
-          });
-          toast.success('Eintrag aktualisiert');
-        } else {
-          await apiClient.post(`/admin/users/${selectedEmployee.user_id}/time-entries`, {
-            date: entryForm.date,
-            start_time: entryForm.start_time,
-            end_time: entryForm.end_time,
-            break_minutes: entryForm.break_minutes,
-            note: entryForm.note,
-          });
-          toast.success('Eintrag erstellt');
-        }
+        // Normal time entry — #200: §4-Pausen-Ausnahme per Retry mit Begründung.
+        const base = {
+          date: entryForm.date,
+          start_time: entryForm.start_time,
+          end_time: entryForm.end_time,
+          break_minutes: entryForm.break_minutes,
+          note: entryForm.note,
+        };
+        await submitWithBreakWaiver(async (extra) => {
+          if (editingEntryId) {
+            await apiClient.put(`/admin/time-entries/${editingEntryId}`, { ...base, ...extra });
+          } else {
+            await apiClient.post(`/admin/users/${selectedEmployee.user_id}/time-entries`, { ...base, ...extra });
+          }
+        });
+        toast.success(editingEntryId ? 'Eintrag aktualisiert' : 'Eintrag erstellt');
       } else {
         // Absence entry (sick, training, overtime comp, other)
         await apiClient.post('/absences', {

--- a/frontend/src/utils/breakWaiverRetry.ts
+++ b/frontend/src/utils/breakWaiverRetry.ts
@@ -1,0 +1,30 @@
+import { getErrorMessage } from './errorMessage';
+
+/**
+ * #200: §4-Pausen-Ausnahme für Admin-Korrekturen.
+ *
+ * Führt `submit(extra)` aus. Schlägt es mit einem §4-Pausenfehler fehl, wird
+ * der/die Admin um eine dokumentierte Begründung gebeten und der Aufruf EINMAL
+ * mit `break_waiver_reason` wiederholt. Bei Abbruch (oder leerer Begründung)
+ * bleibt der ursprüngliche Fehler erhalten und wird vom Aufrufer angezeigt.
+ *
+ * Erkennung: die §4-Meldung des Backends enthält stets „Pause"; der §3-10h-Cap
+ * („Höchstgrenze … §3 ArbZG") NICHT — der harte §3-Block bleibt also bestehen.
+ */
+export async function submitWithBreakWaiver(
+  submit: (extra: { break_waiver_reason?: string }) => Promise<void>,
+): Promise<void> {
+  try {
+    await submit({});
+  } catch (err) {
+    const msg = getErrorMessage(err, '');
+    if (!msg.includes('Pause')) throw err;
+    const reason = window.prompt(
+      `${msg}\n\nWenn die Pflicht-Pause (§4 ArbZG) nachweislich nicht möglich war, ` +
+        'begründen Sie dies hier – die Abweichung wird dokumentiert. ' +
+        'Abbrechen lässt den Eintrag unverändert.',
+    );
+    if (!reason || !reason.trim()) throw err;
+    await submit({ break_waiver_reason: reason.trim() });
+  }
+}


### PR DESCRIPTION
Behebt zwei Befunde aus dem Test 01.06.

## #200 (Blocker) — §4-Pausen-Ausnahme blockierte Korrekturen
Die Ausnahme (`break_waiver_reason`) funktionierte nur im Eigen-Eintrag; auf den Korrektur-Pfaden fehlte sie → §4-verletzende Einträge waren weder per Antrag noch als Admin korrigierbar („Eingabe invalid").
- **Backend** `change_requests.py`: `break_waiver_reason` wird ausgewertet → bei dokumentierter Begründung wird der Antrag angelegt statt 400; §3-10h-Cap bleibt hart; Begründung am CR gespeichert (Genehmigung honoriert sie bereits).
- **Frontend** `ChangeRequestForm`: Ausnahme-Feld erscheint bei §4-Fehler (Error-Reaction → deckt auch Aggregat-Fälle „fast zeitgleicher Eintrag" ab).
- **Frontend** Admin-Edit (`AdminDashboard` + `MonthlyJournal`): Helper `submitWithBreakWaiver` fragt bei §4-Fehler eine Begründung ab und wiederholt PUT/POST mit `break_waiver_reason` (Backend `admin_time_entries` war bereits bereit).

## #199 — §4-Pause beim Live-Ausstempeln
`StampWidget` prüft vor dem Ausstempeln die §4-Pause und verlangt **Pause nacherfassen ODER dokumentierte Ausnahme** (statt flüchtigem Warn-Toast), in beiden Varianten (sheet/inline). Backend (`ClockOutRequest.break_waiver_reason`) war bereit.

## Tests/Verifikation
Backend `test_break_waiver.py::TestChangeRequestBreakWaiver` (3, TDD: Block ohne Begründung / Anlage mit Begründung / §3-Cap bleibt hart); 50 CR-/Waiver-Tests grün. Frontend `tsc` + `breakValidation` (10) + Build sauber.

Hinweis: Admin-Edit nutzt für die Begründung bewusst einen schlanken Prompt-Retry (Power-User-Flow); kann später durch ein Inline-Feld ersetzt werden.

Closes #200
Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)
