### PR TITLE
1.8.2: ArbZG- & Security-Audit-Härtung (OWASP)

### DIFF
--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.8.1"
+APP_VERSION = "1.8.2"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -114,6 +114,32 @@ def _verify_download_host(download_url: str) -> None:
         )
 
 
+def _version_tuple(v: str) -> tuple:
+    """Parse 'X.Y.Z[-suffix]' into a comparable (major, minor, patch) int tuple.
+    Non-numeric/pre-release suffixes are truncated (best-effort, defensive)."""
+    parts = []
+    for p in str(v).split(".")[:3]:
+        digits = ""
+        for ch in p:
+            if ch.isdigit():
+                digits += ch
+            else:
+                break
+        parts.append(int(digits) if digits else 0)
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts)
+
+
+def _is_newer_version(candidate: str, current: str) -> bool:
+    """Audit R3 (A08 anti-rollback): True only if *candidate* is strictly newer
+    than *current*. A manifest signature is valid for ANY version the issuer ever
+    signed, so a replayed/compromised update server could otherwise serve an
+    older, validly-signed manifest to force a signed DOWNGRADE. Comparing by
+    semver (not string ``!=``) makes equal-or-older versions a no-op."""
+    return _version_tuple(candidate) > _version_tuple(current)
+
+
 @dataclass
 class UpdateInfo:
     """Available update information."""
@@ -133,7 +159,7 @@ class UpdateInfo:
             "size_mb": self.size_mb,
             "checksum_sha256": self.checksum_sha256,
             "critical": self.critical,
-            "update_available": self.latest_version != APP_VERSION,
+            "update_available": _is_newer_version(self.latest_version, APP_VERSION),
         }
 
 
@@ -185,7 +211,11 @@ def check_for_updates(server_url: str, license_id: str = "") -> Optional[UpdateI
         return None
 
     latest = data.get("latest", APP_VERSION)
-    if latest == APP_VERSION:
+    # Audit R3 (A08 anti-rollback): only treat a STRICTLY NEWER version as an
+    # update. Equal OR older (a replayed, validly-signed downgrade manifest) is a
+    # no-op — a valid signature alone must not be sufficient to move the client
+    # to an older, potentially weaker build.
+    if not _is_newer_version(latest, APP_VERSION):
         _cached_update = None
         return None
 

--- a/backend/app/routers/admin_change_requests.py
+++ b/backend/app/routers/admin_change_requests.py
@@ -16,6 +16,7 @@ from app.schemas.change_request import (
 )
 from app.schemas.time_entry import TimeEntryResponse
 from app.routers.admin_helpers import _create_audit_log, _enrich_cr_response, _enrich_cr_responses
+from app.routers.admin_users import _tenant_has_other_active_admin
 from app.routers.time_entries import (
     _calculate_daily_net_hours, _calculate_weekly_net_hours,
     MAX_DAILY_HOURS_HARD, MAX_NIGHT_WORKER_DAILY_WARN, MAX_WEEKLY_HOURS_WARN,
@@ -144,6 +145,21 @@ def review_change_request(
         raise HTTPException(
             status_code=403,
             detail="Eigene Pflicht-Pause-Ausnahmen dürfen nicht selbst genehmigt werden.",
+        )
+
+    # Audit A01: 4-eyes principle for ORDINARY change-requests. An admin who is
+    # also a tracked employee must not approve their OWN time-entry/absence CR —
+    # but ONLY when independent oversight is actually possible (another active
+    # admin exists). Sole-admin practices may still self-approve (the break-waiver
+    # block above stays unconditional/stricter for §4 waivers). reviewed_by ==
+    # user_id already records the allowed sole-admin self-approval.
+    if cr.user_id == current_user.id and _tenant_has_other_active_admin(db, current_user):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Eigene Änderungsanträge dürfen nicht selbst genehmigt werden, "
+                "wenn ein weiterer Admin vorhanden ist (4-Augen-Prinzip)."
+            ),
         )
 
     # Approve: validate preconditions BEFORE changing status

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -39,6 +39,29 @@ def _get_user_in_tenant(db: Session, user_id: str, current_user: User) -> User:
     return user
 
 
+def _tenant_has_other_active_admin(db: Session, current_user: User) -> bool:
+    """Audit A01 (4-Augen-Prinzip): does the caller's tenant have ANOTHER
+    active admin besides ``current_user``?
+
+    Used to gate self-approval of one's own change/vacation requests. A medical
+    practice frequently runs with a single admin who legitimately must approve
+    their own corrections — blocking that would lock them out. So the 4-eyes
+    rule only bites when independent oversight is actually possible: a second
+    active admin exists in the SAME tenant. F-026: explicit tenant scope.
+    """
+    return (
+        db.query(User)
+        .filter(
+            User.tenant_id == current_user.tenant_id,
+            User.role == UserRole.ADMIN,
+            User.is_active == True,
+            User.id != current_user.id,
+        )
+        .first()
+        is not None
+    )
+
+
 # ── User Management ──────────────────────────────────────────────────────
 
 @router.get("/users", response_model=List[UserListResponse])

--- a/backend/app/routers/admin_vacations.py
+++ b/backend/app/routers/admin_vacations.py
@@ -14,6 +14,7 @@ from app.services import calculation_service
 from app.services.calculation_service import count_workdays
 from app.services.timezone_service import today_local
 from app.routers.admin_helpers import _create_audit_log
+from app.routers.admin_users import _tenant_has_other_active_admin
 from app.routers.vacation_requests import (
     cancel_approved_vacation_request,
     apply_vacation_request_patch,
@@ -148,6 +149,21 @@ def review_vacation_request(
         db.commit()
         db.refresh(vr)
         return _enrich_vr_response(vr, db)
+
+    # Audit A01: 4-eyes principle. An admin must not approve their OWN vacation
+    # request — but ONLY when independent oversight is actually possible (another
+    # active admin exists in the tenant). A sole-admin practice may still
+    # self-approve (reviewed_by == user_id records it). Raised before any state
+    # change / absence materialisation; the get_db txn rolls back the reviewed_*
+    # assignments above so the VR stays cleanly PENDING.
+    if vr.user_id == current_user.id and _tenant_has_other_active_admin(db, current_user):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Eigene Urlaubsanträge dürfen nicht selbst genehmigt werden, "
+                "wenn ein weiterer Admin vorhanden ist (4-Augen-Prinzip)."
+            ),
+        )
 
     # Approve: create absence entries (same logic as create_absence in absences.py)
     # F-026: explicit tenant scoping

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -7,12 +7,24 @@ from pydantic import BaseModel, Field, field_validator
 from typing import Optional
 from datetime import datetime, timedelta, timezone
 import base64
+import logging
 import secrets
 from collections import OrderedDict
 from app.database import get_db, set_superadmin_context
 from app.middleware.csrf import CSRF_COOKIE_NAME
 from app.models import User, TimeEntry, Absence, TimeEntryAuditLog
 from app.models.tenant import Tenant
+
+# Audit A09 (OWASP Security Logging Failures): security-relevant auth events
+# are emitted as structured application-log records on a dedicated logger.
+# These go to stdout → Docker logs / journald → the standard forensic/SIEM
+# sink (persists across restarts). Marker prefix "AUTH " + a stable event
+# keyword keeps the records greppable for a SIEM.
+#
+# CRITICAL: never log the password, JWT, refresh token, or TOTP secret. We log
+# the submitted *username* (attacker-supplied identifier, useful for forensics)
+# but not the email.
+security_logger = logging.getLogger("praxiszeit.security")
 
 # F-039: In-memory failed login tracking as an OrderedDict LRU so eviction
 # is O(1) instead of O(n log n). Also fixes the attacker-evicts-real-user
@@ -152,6 +164,7 @@ def login(request: Request, response: Response, login_data: LoginRequest, db: Se
         del _failed_logins[username_lower]
 
     if len(attempts) >= _LOCKOUT_ATTEMPTS:
+        security_logger.warning("AUTH account_locked user=%s attempts=%d", username_lower, len(attempts))
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="Konto vorübergehend gesperrt. Bitte in 15 Minuten erneut versuchen."
@@ -167,6 +180,10 @@ def login(request: Request, response: Response, login_data: LoginRequest, db: Se
         # module load time from a random string (see _DUMMY_BCRYPT_HASH).
         auth_service.verify_password(login_data.password, _DUMMY_BCRYPT_HASH)
         _record_failed_login(username_lower, now)
+        security_logger.warning(
+            "AUTH login_failed user=%s reason=%s", username_lower,
+            "unknown_user" if not user else "inactive_user",
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Ungültiger Benutzername oder Passwort"
@@ -174,6 +191,7 @@ def login(request: Request, response: Response, login_data: LoginRequest, db: Se
 
     if not auth_service.verify_password(login_data.password, user.password_hash):
         _record_failed_login(username_lower, now)
+        security_logger.warning("AUTH login_failed user=%s reason=%s", username_lower, "bad_password")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Ungültiger Benutzername oder Passwort"
@@ -199,6 +217,9 @@ def login(request: Request, response: Response, login_data: LoginRequest, db: Se
     # F-019: TOTP check with replay protection (per-user counter)
     if user.totp_enabled:
         if not login_data.totp_code:
+            # Not a hard failure (the client is expected to re-submit with a
+            # code), but record it so a SIEM can correlate the 2FA challenge.
+            security_logger.info("AUTH totp_required user=%s", username_lower)
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="TOTP-Code erforderlich",
@@ -208,6 +229,8 @@ def login(request: Request, response: Response, login_data: LoginRequest, db: Se
             user.totp_secret, login_data.totp_code, user.last_totp_counter
         )
         if accepted_counter is None:
+            _record_failed_login(username_lower, now)
+            security_logger.warning("AUTH login_failed user=%s reason=%s", username_lower, "bad_totp")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Ungültiger TOTP-Code",
@@ -227,6 +250,8 @@ def login(request: Request, response: Response, login_data: LoginRequest, db: Se
     _set_refresh_cookie(response, refresh_token)
     # F-024: issue a fresh CSRF double-submit token
     _set_csrf_cookie(response)
+
+    security_logger.info("AUTH login_success user=%s", username_lower)
 
     return LoginResponse(
         access_token=access_token,
@@ -308,6 +333,7 @@ def logout(
     db.commit()
     _delete_refresh_cookie(response)
     _delete_csrf_cookie(response)
+    security_logger.info("AUTH logout user=%s", current_user.username)
     return {"message": "Erfolgreich abgemeldet"}
 
 
@@ -333,6 +359,10 @@ def change_password(
     Requires current password verification.
     """
     if not auth_service.verify_password(password_data.current_password, current_user.password_hash):
+        security_logger.warning(
+            "AUTH password_change_failed user=%s reason=%s",
+            current_user.username, "wrong_current_password",
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Aktuelles Passwort ist falsch"
@@ -343,6 +373,8 @@ def change_password(
     current_user.token_version += 1
     db.commit()
     db.refresh(current_user)
+
+    security_logger.warning("AUTH password_changed user=%s", current_user.username)
 
     # Issue a fresh token so the frontend session stays valid after the version bump
     tenant_id_str = str(current_user.tenant_id) if current_user.tenant_id else None

--- a/backend/app/routers/change_requests.py
+++ b/backend/app/routers/change_requests.py
@@ -9,8 +9,8 @@ from app.middleware.auth import get_current_user
 from app.schemas.change_request import ChangeRequestCreate, ChangeRequestResponse
 from app.services.break_validation_service import validate_daily_break
 from app.routers.time_entries import (
-    _calculate_daily_net_hours,
-    MAX_DAILY_HOURS_HARD, MAX_NIGHT_WORKER_DAILY_WARN,
+    _calculate_daily_net_hours, _calculate_weekly_net_hours,
+    MAX_DAILY_HOURS_HARD, MAX_NIGHT_WORKER_DAILY_WARN, MAX_WEEKLY_HOURS_WARN,
 )
 from app.services.arbzg_utils import is_night_work
 
@@ -297,6 +297,22 @@ def create_change_request(
                 f"§6 ArbZG: Nachtarbeitnehmer – Tageslimit 8h überschritten ({daily_hours_check:.1f}h). "
                 "Verlängerung auf 10h nur mit 1-Monats-Ausgleich zulässig."
             )
+
+        # Audit R3 (§3/§14 ArbZG): Wochen-48h-Warnung — fehlte bisher im
+        # Mitarbeiter-CR-Pfad (in time_entries.create + admin_change_requests
+        # bereits vorhanden), damit der Antrag schon bei Einreichung den
+        # Wochenüberschreitungs-Hinweis trägt.
+        weekly_hours_check = _calculate_weekly_net_hours(
+            db=db,
+            user_id=current_user.id,
+            entry_date=data.proposed_date,
+            start_time=data.proposed_start_time,
+            end_time=data.proposed_end_time,
+            break_minutes=data.proposed_break_minutes or 0,
+            exclude_entry_id=entry.id if entry else None,
+        )
+        if weekly_hours_check > MAX_WEEKLY_HOURS_WARN:
+            response.warnings.append("WEEKLY_HOURS_WARNING")
 
     return response
 

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -207,12 +207,14 @@ def get_totp_uri(username: str, secret: str) -> str:
     )
 
 
-def verify_totp(secret: str, code: str) -> bool:
-    """Verify a 6-digit TOTP code. Allows ±1 window (30s tolerance).
+def _verify_totp_unsafe(secret: str, code: str) -> bool:
+    """INTERNAL/UNSAFE — verify a 6-digit TOTP code (±1 window, 30s tolerance).
 
-    NOTE: this does not protect against replay within the valid window.
-    Callers that persist a per-user counter must use `verify_totp_with_counter`
-    instead.
+    Audit R3 (A02): renamed from the former public ``verify_totp`` so it cannot
+    be picked by accident. It does NOT protect against replay within the valid
+    window. ALL production callers (login, sensitive actions) MUST use
+    ``verify_totp_with_counter`` (persists a per-user counter). Kept only for the
+    low-level TOTP-verification unit test.
     """
     return pyotp.TOTP(secret).verify(code, valid_window=1)
 

--- a/backend/app/services/xls_import_service.py
+++ b/backend/app/services/xls_import_service.py
@@ -406,6 +406,11 @@ def _execute_import_inner(
             existing.end_time = entry.end_time
             existing.break_minutes = entry.break_minutes
             existing.note = entry.note
+            # Audit R3/§16: Roh-Stempel des Import-Eintrags übernehmen, sonst
+            # geht der Nachweis der tatsächlichen Anwesenheit beim Overwrite
+            # verloren (gekappter Wert bliebe, Rohwert verschwände).
+            existing.raw_start_time = entry.raw_start_time
+            existing.raw_end_time = entry.raw_end_time
             db.add(log)
             overwritten += 1
         else:

--- a/backend/tests/test_auth_logging.py
+++ b/backend/tests/test_auth_logging.py
@@ -1,0 +1,194 @@
+"""Audit A09 — structured application-log records for auth events.
+
+OWASP A09 (Security Logging Failures): authentication events must leave a
+forensic trail. These tests assert that the auth router emits greppable
+``AUTH <event>`` records via Python ``logging`` (stdout → Docker logs /
+journald → SIEM), covering:
+
+- login_failed (wrong password / unknown user)
+- login_success
+- account_locked (lockout threshold)
+- logout / token revocation
+- password_changed
+
+CRITICAL guarantee asserted here: NO password, JWT, refresh token, or TOTP
+secret ever appears in a log record. The submitted username is logged (it is
+the attacker-supplied identifier and useful for forensics); the email is not.
+
+The test app reuses the proven login harness from ``test_endpoints.py``
+(SQLite + ``set_superadmin_context`` patch). caplog captures the dedicated
+``praxiszeit.security`` logger.
+"""
+
+import logging
+
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.middleware.auth import get_current_user
+
+# Reuse the same lightweight test app + fixtures from test_endpoints.
+# Import the app under a non-``test_`` alias so pytest does not try to collect
+# it as a test object (it is a FastAPI instance).
+from tests.test_endpoints import test_app as app  # noqa: F401
+from tests.test_endpoints import (  # noqa: F401  (fixtures used by pytest)
+    _db_session,
+    tenant,
+    employee_user,
+)
+
+SECURITY_LOGGER = "praxiszeit.security"
+
+# A password used in the failure tests — must NEVER turn up in a log record.
+SECRET_PASSWORD = "SuperSecret-DoNotLog-9999!"
+
+
+def _login(client, username, password, totp_code=None):
+    body = {"username": username, "password": password}
+    if totp_code is not None:
+        body["totp_code"] = totp_code
+    return client.post("/api/auth/login", json=body)
+
+
+@pytest.fixture(scope="function")
+def login_client(_db_session):
+    """TestClient for the real (unauthenticated) login endpoint.
+
+    ``set_superadmin_context`` is patched out because SQLite has no SET LOCAL
+    (mirrors TestAuthLogin in test_endpoints.py).
+    """
+    def _override_db():
+        yield _db_session
+
+    app.dependency_overrides[get_db] = _override_db
+    with patch("app.routers.auth.set_superadmin_context"):
+        with TestClient(app) as client:
+            yield client
+    app.dependency_overrides.clear()
+
+
+def _no_credentials_leaked(caplog, *, password):
+    """Assert no record text contains the password or token-ish material."""
+    for rec in caplog.records:
+        msg = rec.getMessage()
+        assert password not in msg, f"password leaked into log: {msg!r}"
+        # Crude JWT detector: three base64 segments joined by dots.
+        assert "eyJ" not in msg, f"possible JWT leaked into log: {msg!r}"
+
+
+class TestLoginFailedLogging:
+    def test_wrong_password_emits_login_failed_warning(self, login_client, employee_user, caplog):
+        with caplog.at_level(logging.WARNING, logger=SECURITY_LOGGER):
+            resp = _login(login_client, "employee", SECRET_PASSWORD)
+
+        assert resp.status_code == 401
+        recs = [r for r in caplog.records if "AUTH login_failed" in r.getMessage()]
+        assert recs, "expected an 'AUTH login_failed' record on wrong password"
+        assert recs[0].levelno == logging.WARNING
+        assert "employee" in recs[0].getMessage()
+        _no_credentials_leaked(caplog, password=SECRET_PASSWORD)
+
+    def test_unknown_user_emits_login_failed_warning(self, login_client, tenant, caplog):
+        with caplog.at_level(logging.WARNING, logger=SECURITY_LOGGER):
+            resp = _login(login_client, "ghost", SECRET_PASSWORD)
+
+        assert resp.status_code == 401
+        recs = [r for r in caplog.records if "AUTH login_failed" in r.getMessage()]
+        assert recs, "expected an 'AUTH login_failed' record on unknown user"
+        assert "ghost" in recs[0].getMessage()
+        _no_credentials_leaked(caplog, password=SECRET_PASSWORD)
+
+
+class TestLoginSuccessLogging:
+    def test_valid_login_emits_login_success_info(self, login_client, employee_user, caplog):
+        with caplog.at_level(logging.INFO, logger=SECURITY_LOGGER):
+            resp = _login(login_client, "employee", "Employee2025!")
+
+        assert resp.status_code == 200
+        recs = [r for r in caplog.records if "AUTH login_success" in r.getMessage()]
+        assert recs, "expected an 'AUTH login_success' record on valid login"
+        assert recs[0].levelno == logging.INFO
+        assert "employee" in recs[0].getMessage()
+        # The issued access token must not be logged.
+        _no_credentials_leaked(caplog, password="Employee2025!")
+
+
+class TestAccountLockedLogging:
+    def test_lockout_threshold_emits_account_locked_warning(self, login_client, employee_user, caplog):
+        """After _LOCKOUT_ATTEMPTS failures within the window, the next attempt
+        is locked out (429) and emits an 'AUTH account_locked' record."""
+        from app.routers import auth as auth_router
+
+        # Clean slate for the in-memory tracker.
+        auth_router._failed_logins.clear()
+
+        with caplog.at_level(logging.WARNING, logger=SECURITY_LOGGER):
+            for _ in range(auth_router._LOCKOUT_ATTEMPTS):
+                _login(login_client, "employee", SECRET_PASSWORD)
+            # This attempt should trip the lockout (>= threshold).
+            locked = _login(login_client, "employee", SECRET_PASSWORD)
+
+        assert locked.status_code == 429
+        recs = [r for r in caplog.records if "AUTH account_locked" in r.getMessage()]
+        assert recs, "expected an 'AUTH account_locked' record once lockout trips"
+        assert recs[0].levelno == logging.WARNING
+        assert "employee" in recs[0].getMessage()
+        _no_credentials_leaked(caplog, password=SECRET_PASSWORD)
+        auth_router._failed_logins.clear()
+
+
+class TestLogoutLogging:
+    def test_logout_emits_logout_info(self, _db_session, employee_user, caplog):
+        """Logout revokes tokens (token_version++). Authenticated via the
+        get_current_user override (same pattern as employee_client)."""
+        def _override_db():
+            yield _db_session
+
+        def _override_current_user():
+            return employee_user
+
+        app.dependency_overrides[get_db] = _override_db
+        app.dependency_overrides[get_current_user] = _override_current_user
+        try:
+            with caplog.at_level(logging.INFO, logger=SECURITY_LOGGER):
+                with TestClient(app) as client:
+                    resp = client.post("/api/auth/logout")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        recs = [r for r in caplog.records if "AUTH logout" in r.getMessage()]
+        assert recs, "expected an 'AUTH logout' record on logout"
+        assert recs[0].levelno == logging.INFO
+        assert "employee" in recs[0].getMessage()
+
+
+class TestPasswordChangedLogging:
+    def test_change_password_emits_password_changed_warning(self, _db_session, employee_user, caplog):
+        def _override_db():
+            yield _db_session
+
+        def _override_current_user():
+            return employee_user
+
+        app.dependency_overrides[get_db] = _override_db
+        app.dependency_overrides[get_current_user] = _override_current_user
+        try:
+            with caplog.at_level(logging.WARNING, logger=SECURITY_LOGGER):
+                with TestClient(app) as client:
+                    resp = client.post("/api/auth/change-password", json={
+                        "current_password": "Employee2025!",
+                        "new_password": SECRET_PASSWORD,
+                    })
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        recs = [r for r in caplog.records if "AUTH password_changed" in r.getMessage()]
+        assert recs, "expected an 'AUTH password_changed' record"
+        assert recs[0].levelno == logging.WARNING
+        assert "employee" in recs[0].getMessage()
+        # The new password must not appear in any record.
+        _no_credentials_leaked(caplog, password=SECRET_PASSWORD)

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -4,7 +4,7 @@ import pyotp
 from app.services.auth_service import (
     generate_totp_secret,
     get_totp_uri,
-    verify_totp,
+    _verify_totp_unsafe,
     hash_password,
     verify_password,
     needs_rehash,
@@ -66,31 +66,31 @@ class TestGetTotpUri:
 
 
 class TestVerifyTotp:
-    """Test verify_totp() function."""
+    """Test _verify_totp_unsafe() function."""
 
     def test_valid_code_returns_true(self):
         """Prüft dass ein aktuell gültiger TOTP-Code korrekt verifiziert wird."""
         secret = generate_totp_secret()
         totp = pyotp.TOTP(secret)
         code = totp.now()
-        assert verify_totp(secret, code) is True
+        assert _verify_totp_unsafe(secret, code) is True
 
     def test_invalid_code_returns_false(self):
         """Prüft dass ein falscher TOTP-Code abgelehnt wird — Schutz vor Brute-Force."""
         secret = generate_totp_secret()
-        assert verify_totp(secret, "000000") is False
+        assert _verify_totp_unsafe(secret, "000000") is False
 
     def test_empty_code_returns_false(self):
         """Prüft dass ein leerer Code abgelehnt wird — Edge Case bei fehlender Eingabe."""
         secret = generate_totp_secret()
-        assert verify_totp(secret, "") is False
+        assert _verify_totp_unsafe(secret, "") is False
 
     def test_wrong_secret_returns_false(self):
         """Prüft dass ein Code von einem anderen Secret abgelehnt wird — verhindert Account-Übernahme."""
         secret1 = generate_totp_secret()
         secret2 = generate_totp_secret()
         code = pyotp.TOTP(secret1).now()
-        assert verify_totp(secret2, code) is False
+        assert _verify_totp_unsafe(secret2, code) is False
 
 
 class TestHashPassword:

--- a/backend/tests/test_break_waiver.py
+++ b/backend/tests/test_break_waiver.py
@@ -852,3 +852,32 @@ class TestClockOutSection3NonBlocking:
         assert resp.status_code == 200, resp.text
         warnings = resp.json().get("warnings", [])
         assert not any("DAILY_HOURS_HARD" in w for w in warnings), warnings
+
+
+class TestChangeRequestWeeklyWarning:
+    """Audit R3 (§3/§14 ArbZG): Der Mitarbeiter-Änderungsantrag-Erstellpfad muss
+    — wie create_time_entry und die CR-Genehmigung — bei >48h Wochenarbeitszeit
+    eine WEEKLY_HOURS_WARNING zurückgeben (fehlte bisher)."""
+
+    def test_create_cr_over_48h_week_emits_weekly_warning(self, db, employee, employee_client):
+        # 5 vergangene Werktage à 10h netto (06:00–16:30, 30min Pause) = 50h.
+        for d in [date(2026, 5, 25), date(2026, 5, 26), date(2026, 5, 27),
+                  date(2026, 5, 28), date(2026, 5, 29)]:
+            db.add(TimeEntry(
+                user_id=employee.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+                start_time=time(6, 0), end_time=time(16, 30), break_minutes=30,
+            ))
+        db.commit()
+
+        # CR (create) für den Samstag derselben ISO-Woche → Woche > 48h.
+        resp = employee_client.post("/api/change-requests", json={
+            "request_type": "create",
+            "proposed_date": "2026-05-30",
+            "proposed_start_time": "06:00",
+            "proposed_end_time": "09:00",
+            "proposed_break_minutes": 0,
+            "reason": "Wochenende nachtragen",
+        })
+        assert resp.status_code in (200, 201), resp.text
+        warnings = resp.json().get("warnings", [])
+        assert any("WEEKLY_HOURS_WARNING" in w for w in warnings), warnings

--- a/backend/tests/test_break_waiver.py
+++ b/backend/tests/test_break_waiver.py
@@ -619,6 +619,90 @@ class TestBreakWaiverSelfApprovalForbidden:
         assert cr.status == ChangeRequestStatus.APPROVED
 
 
+class TestOrdinaryCrSelfApproval:
+    """Audit A01 (4-Augen-Prinzip): ein Admin, der zugleich getrackter MA ist,
+    darf seinen EIGENEN normalen (Nicht-Waiver) Zeit-Änderungsantrag nur dann
+    selbst genehmigen, wenn es KEINEN weiteren aktiven Admin gibt (Einzel-
+    Admin-Praxis). Gibt es einen zweiten aktiven Admin, ist Selbstgenehmigung
+    verboten (403)."""
+
+    def _ordinary_cr(self, db, user):
+        cr = ChangeRequest(
+            user_id=user.id,
+            tenant_id=DEFAULT_TENANT_ID,
+            request_type=ChangeRequestType.CREATE,
+            entry_kind="time_entry",
+            status=ChangeRequestStatus.PENDING,
+            proposed_date=date.today() - timedelta(days=2),
+            proposed_start_time=time(8, 0),
+            proposed_end_time=time(12, 0),  # 4h, kein §4-/§3-Problem
+            proposed_break_minutes=0,
+            reason="Nachtrag eigener Eintrag",
+        )
+        db.add(cr)
+        db.commit()
+        db.refresh(cr)
+        return cr
+
+    def _second_admin(self, db):
+        u = User(
+            username="admin2_bw",
+            email="admin2_bw@example.com",
+            password_hash=auth_service.hash_password("admin123"),
+            first_name="Zweit",
+            last_name="Admin",
+            role=UserRole.ADMIN,
+            weekly_hours=40.0,
+            vacation_days=30,
+            work_days_per_week=5,
+            is_active=True,
+            tenant_id=DEFAULT_TENANT_ID,
+        )
+        db.add(u)
+        db.commit()
+        db.refresh(u)
+        return u
+
+    def test_self_approve_blocked_with_second_admin(self, db, admin, admin_client):
+        """Zweiter aktiver Admin vorhanden → Selbstgenehmigung verboten (403)."""
+        self._second_admin(db)
+        cr = self._ordinary_cr(db, admin)
+        resp = admin_client.post(
+            f"/api/admin/change-requests/{cr.id}/review",
+            json={"action": "approve"},
+        )
+        assert resp.status_code == 403, resp.text
+        assert "selbst genehmigt" in resp.json()["detail"].lower()
+        db.refresh(cr)
+        assert cr.status == ChangeRequestStatus.PENDING
+        assert db.query(TimeEntry).filter(TimeEntry.user_id == admin.id).count() == 0
+
+    def test_self_approve_allowed_sole_admin(self, db, admin, admin_client):
+        """Einziger Admin → Selbstgenehmigung erlaubt (200), Eintrag entsteht."""
+        cr = self._ordinary_cr(db, admin)
+        resp = admin_client.post(
+            f"/api/admin/change-requests/{cr.id}/review",
+            json={"action": "approve"},
+        )
+        assert resp.status_code == 200, resp.text
+        db.refresh(cr)
+        assert cr.status == ChangeRequestStatus.APPROVED
+        assert cr.reviewed_by == admin.id
+        assert db.query(TimeEntry).filter(TimeEntry.user_id == admin.id).count() == 1
+
+    def test_reject_own_cr_always_allowed(self, db, admin, admin_client):
+        """Ablehnung des eigenen Antrags bleibt erlaubt (kein 4-Augen-Block)."""
+        self._second_admin(db)
+        cr = self._ordinary_cr(db, admin)
+        resp = admin_client.post(
+            f"/api/admin/change-requests/{cr.id}/review",
+            json={"action": "reject", "rejection_reason": "doch nicht"},
+        )
+        assert resp.status_code == 200, resp.text
+        db.refresh(cr)
+        assert cr.status == ChangeRequestStatus.REJECTED
+
+
 class TestCrApprovalRevalidatesDailyHardCap:
     """C-1: a CREATE/UPDATE ChangeRequest is re-validated against the CURRENT DB
     state on approval. A CR that was valid (≤10h) at creation time but would,

--- a/backend/tests/test_updater_version.py
+++ b/backend/tests/test_updater_version.py
@@ -1,0 +1,41 @@
+"""Audit R3 (A08 anti-rollback): die Update-Versionsentscheidung darf NUR bei
+echt neuerer Version anschlagen — ein replaytes, gültig signiertes älteres
+Manifest darf kein (signiertes) Downgrade auslösen."""
+from app.core.updater import _is_newer_version, _version_tuple, UpdateInfo, APP_VERSION
+
+
+def test_newer_version_is_update():
+    assert _is_newer_version("1.8.2", "1.8.1") is True
+    assert _is_newer_version("1.9.0", "1.8.1") is True
+    assert _is_newer_version("2.0.0", "1.8.1") is True
+
+
+def test_equal_version_is_not_update():
+    assert _is_newer_version("1.8.1", "1.8.1") is False
+
+
+def test_older_version_is_rejected_no_rollback():
+    # Genau der Angriffsfall: alt-signiertes Manifest mit kleinerer Version.
+    assert _is_newer_version("1.4.4", "1.8.1") is False
+    assert _is_newer_version("1.8.0", "1.8.1") is False
+    assert _is_newer_version("0.9.9", "1.8.1") is False
+
+
+def test_semver_not_string_compare():
+    # String-Vergleich würde "1.10.0" < "1.8.1" liefern — semver muss 1.10 > 1.8.
+    assert _is_newer_version("1.10.0", "1.8.1") is True
+    assert _version_tuple("1.10.0") > _version_tuple("1.8.1")
+
+
+def test_prerelease_suffix_tolerated():
+    assert _version_tuple("1.8.1-beta") == (1, 8, 1)
+    assert _is_newer_version("1.8.2-rc1", "1.8.1") is True
+
+
+def test_update_info_update_available_rejects_older():
+    older = UpdateInfo(latest_version="1.4.4", download_url="", changelog="",
+                       size_mb=0, checksum_sha256="", critical=False)
+    assert older.to_dict()["update_available"] is False
+    newer = UpdateInfo(latest_version="9.9.9", download_url="", changelog="",
+                       size_mb=0, checksum_sha256="", critical=False)
+    assert newer.to_dict()["update_available"] is True

--- a/backend/tests/test_vacation_request_edit.py
+++ b/backend/tests/test_vacation_request_edit.py
@@ -569,6 +569,52 @@ class TestPostBudgetExcludesHolidays:
         assert resp.status_code == 201, resp.text
 
 
+class TestVacationSelfApproval:
+    """Audit A01 (4-Augen-Prinzip): ein Admin darf seinen EIGENEN Urlaubsantrag
+    nur dann selbst genehmigen, wenn KEIN weiterer aktiver Admin existiert
+    (Einzel-Admin-Praxis). Mit zweitem aktivem Admin → 403."""
+
+    def test_self_approve_blocked_with_second_admin(self, db, admin, admin_client):
+        from app.models import Absence
+        _user(db, "adm2", role=UserRole.ADMIN)  # zweiter aktiver Admin
+        # Zukünftiger Montag, damit es ein gültiger Arbeitstag ist.
+        vr = _vr(db, admin, start=date(2026, 6, 8), end=None, absence_type="vacation")
+        resp = admin_client.post(
+            f"/api/admin/vacation-requests/{vr.id}/review",
+            json={"action": "approve"},
+        )
+        assert resp.status_code == 403, resp.text
+        assert "selbst genehmigt" in resp.json()["detail"].lower()
+        db.refresh(vr)
+        assert vr.status == VacationRequestStatus.PENDING.value
+        # Keine Abwesenheit materialisiert.
+        assert db.query(Absence).filter(Absence.user_id == admin.id).count() == 0
+
+    def test_self_approve_allowed_sole_admin(self, db, admin, admin_client):
+        from app.models import Absence
+        vr = _vr(db, admin, start=date(2026, 6, 8), end=None, absence_type="vacation")
+        resp = admin_client.post(
+            f"/api/admin/vacation-requests/{vr.id}/review",
+            json={"action": "approve"},
+        )
+        assert resp.status_code == 200, resp.text
+        db.refresh(vr)
+        assert vr.status == VacationRequestStatus.APPROVED.value
+        assert vr.reviewed_by == admin.id
+        assert db.query(Absence).filter(Absence.user_id == admin.id).count() == 1
+
+    def test_reject_own_request_always_allowed(self, db, admin, admin_client):
+        _user(db, "adm3", role=UserRole.ADMIN)  # zweiter aktiver Admin
+        vr = _vr(db, admin, start=date(2026, 6, 8), end=None, absence_type="vacation")
+        resp = admin_client.post(
+            f"/api/admin/vacation-requests/{vr.id}/review",
+            json={"action": "reject", "rejection_reason": "storno"},
+        )
+        assert resp.status_code == 200, resp.text
+        db.refresh(vr)
+        assert vr.status == VacationRequestStatus.REJECTED.value
+
+
 class TestApproveNoCrossTypeDoubleBooking:
     """R2-c: review_vacation_request prüfte nur auf bestehende Abwesenheiten
     GLEICHEN Typs (+ ohne tenant_id-Filter). Existierte am Tag eine Abwesenheit

--- a/backend/tests/test_xls_import_service.py
+++ b/backend/tests/test_xls_import_service.py
@@ -338,6 +338,30 @@ def test_execute_import_overwrites_conflict(db, test_user, test_admin):
     assert existing.note == "updated"
 
 
+def test_execute_import_overwrite_preserves_raw_stamps(db, test_user, test_admin):
+    """Audit R3/§16: Beim Overwrite müssen die Roh-Stempel (raw_start/raw_end)
+    des Import-Eintrags auf den bestehenden Eintrag übernommen werden — sonst
+    geht der §16-Nachweis der tatsächlichen Anwesenheit beim Überschreiben
+    verloren (gekappter Wert bleibt, Rohwert verschwindet)."""
+    existing = TimeEntry(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID, date=date(2026, 1, 12),
+                         start_time=time(7, 15), end_time=time(12, 45), break_minutes=30,
+                         raw_start_time=None, raw_end_time=None)
+    db.add(existing)
+    db.commit()
+
+    # Import-Eintrag mit gekapptem end + bewahrtem Roh-Ende (z.B. Soll-Fenster-Kappung).
+    entries = [ImportedEntry(date=date(2026, 1, 12), start_time=time(7, 15),
+                             end_time=time(16, 0), break_minutes=30, note="ow",
+                             has_conflict=True, arbzg_warnings=[],
+                             raw_start_time=time(6, 30), raw_end_time=time(18, 0))]
+    execute_import(test_user.id, entries, overwrite=True, db=db,
+                   changed_by_id=test_admin.id, filename="test.xls",
+                   tenant_id=DEFAULT_TENANT_ID)
+    db.refresh(existing)
+    assert existing.raw_start_time == time(6, 30)
+    assert existing.raw_end_time == time(18, 0)
+
+
 def test_execute_import_writes_audit_log(db, test_user, test_admin):
     """Prüft dass Import Audit-Logs schreibt — Nachvollziehbarkeit gemaess DSGVO Art. 5."""
     from app.models import TimeEntryAuditLog

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "axios": "^1.15.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.8.1"
+APP_VERSION="1.8.2"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
Härtung aus dem ArbZG- & Security-Audit (OWASP + ähnliche Szenarien) gegen v1.8.1. **Kein HIGH/kritischer Befund.** Beide bisher offenen Findings bestätigt als geschlossen/widerlegt: **H3** (GUC-RLS-Bypass — fail-closed, `praxiszeit_app` ohne BYPASSRLS, nur `SET LOCAL`) und **M-SEC3** (CSP — in nginx UND Middleware gesetzt). Behoben wurde der „Fokus-Batch" der MEDIUM-Findings; SaaS-Gates/Design-Punkte sind in #208 getrackt.

## Behobene Findings

**ArbZG**
- `92dcb16` **§16** — XLS-Import-Overwrite übernahm `raw_start_time/raw_end_time` nicht → Nachweis der tatsächlichen Anwesenheit ging beim Überschreiben verloren. Jetzt mitgeschrieben.
- `92dcb16` **§3/§14** — `create_change_request` (MA-Pfad) gab keine `WEEKLY_HOURS_WARNING` bei >48h aus (überall sonst vorhanden). Symmetrisch ergänzt.

**Security (OWASP)**
- `1f1f7a8` **A08 Integrity** — Update-**Anti-Rollback**: `check_for_updates` verglich String-`!=`; ein replaytes, gültig signiertes älteres Manifest erlaubte ein signiertes Downgrade. Jetzt semver-Vergleich (`_is_newer_version`), gleich/älter = No-op.
- `3df13df` **A01 Access Control** — **4-Augen-Prinzip** jetzt auch auf normale Zeit-CRs UND Urlaubsanträge (vorher nur Pausen-Ausnahme): Selbst-Genehmigung 403, aber NUR wenn ein zweiter aktiver Admin existiert (Single-Admin-Praxis darf weiter selbst genehmigen). Break-Waiver-Block bleibt unverändert streng.
- `61c4219` **A09 Logging** — strukturiertes **Auth-Event-Logging** (`praxiszeit.security`): login_success/failed (+reason), account_locked, logout, password_changed, totp_required/bad_totp. Nur Username, NIE Passwort/JWT/Refresh/TOTP-Secret.
- `e773706` **A02 Footgun** — replay-unsichere `verify_totp` → `_verify_totp_unsafe` (intern), damit sie nicht versehentlich statt der Counter-Variante genutzt wird. Produktiv nutzt nur `verify_totp_with_counter`.

## Bestätigt SOLID (kein Handlungsbedarf)
Multi-Tenant-Isolation/RLS (fail-closed), Authz (`require_admin`/`require_superadmin`, IDOR + F-026), Mass-Assignment (kein tenant_id/role/is_active self-set), JWT (HS256-pinned, kein alg=none), bcrypt_sha256, Ed25519 (License/Manifest), SQL (kein Raw, nur gebundene Params + ORM), Native-Subprocess (list-args, validierte PG-Identifier), XLS-Formel-Injection-Guard, CORS (kein Wildcard-mit-Credentials), SSRF (Host-Allowlist + HTTPS), Security-Headers/CSP, Docs-off-in-prod, PII-Scrubbing im Error-Log, DSGVO-Art.9-Maskierung, Stripe-Webhook-Signatur.

## Zurückgestellt → #208
SaaS-Gate: Shared Lockout-Store (Redis), Lockout-DoS/Enumeration-Tradeoff. DSGVO/Design: absence-Audit-Purge, Admin-liest-Krank-Audit, clock-out-Verstoß-Marker, §6-TV-Fenster, §18-Doku, §4-Kurztag-Diskussion, Grafana-Allowlist-Doku.

## Verifikation
Version 1.8.1 → **1.8.2** (3 SoT + Lock). Backend: **921 passed, 44 skipped, 0 failed** (frische `test.db`, `-p no:randomly`). +20 neue Audit-Tests (xls-import, CR-Wochenwarnung, anti-rollback ×6, 4-Augen ×6, auth-logging ×6, totp-rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
