### PR TITLE
feat(backup): BACKUP.md + macOS-Auto-Backup (launchd)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,7 @@ JSON-Body über `sort_keys=True, separators=(",",":")` kanonisiert, mit Ed25519 
 | Docker-Installation | [docs/INSTALL-DOCKER.md](docs/INSTALL-DOCKER.md) |
 | Docker-Schnellstart (aus Tarball/ZIP, ohne git) | [docs/DOCKER-START.md](docs/DOCKER-START.md) |
 | Update (Docker & Native) | [docs/UPDATE.md](docs/UPDATE.md) |
+| Datensicherung (Backup & Restore) | [docs/BACKUP.md](docs/BACKUP.md) |
 | Native Installer Design | [docs/superpowers/specs/2026-04-07-native-single-instance-installer-design.md](docs/superpowers/specs/2026-04-07-native-single-instance-installer-design.md) |
 | Specs & Design-Docs | `docs/specs/` (arbzg, dsgvo, features, security) |
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Jeder Ordner enthält eine `HOWTO.md` mit dem Audit-Prozess, dem Claude-Prompt z
 - **docs/INSTALLATION.md** - Detaillierte Installationsanleitung
 - **docs/DOCKER-START.md** - PraxisZeit mit Docker starten (aus dem Docker-Paket, ohne git)
 - **docs/UPDATE.md** - Bestehende Docker-/Native-Installation aktualisieren
+- **docs/BACKUP.md** - Datensicherung: Auto-Backup je Variante, manuelles Backup, Restore
 - **docs/specs/** - Audit-Berichte (Security, DSGVO, ArbZG)
 - **API Docs** - http://localhost:8000/docs
 - **GitHub Issues** - https://github.com/phash/praxiszeit/issues

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,0 +1,106 @@
+# Datensicherung (Backup & Restore)
+
+PraxisZeit speichert alle Zeitdaten in PostgreSQL. **§16 ArbZG verlangt eine
+Aufbewahrung von mindestens 2 Jahren** — sorgen Sie für Backups und prüfen Sie
+gelegentlich die Wiederherstellung.
+
+## Automatisches Backup — pro Variante
+
+| Variante | Automatisch? | Wie / wann | Ablage |
+|----------|--------------|------------|--------|
+| **Native Linux** | ✅ ja | systemd-Timer `praxiszeit-backup.timer`, täglich **02:00** | `<install>/data/backups/` |
+| **Native Windows** | ✅ ja | Scheduled Task `PraxisZeit-Backup`, täglich **03:00** (ruft `backup.bat`) | `C:\PraxisZeit\data\backups\` |
+| **Native macOS** | ✅ ja | launchd `de.praxiszeit.backup.plist`, täglich **03:00** | `/usr/local/praxiszeit/data/backups/` |
+| **Docker** | ❌ **nein** | nur manuell bzw. per Host-Cron (s. u.) | wohin Sie den Dump schreiben |
+
+> **Native:** Das Backup ruft intern `praxiszeit-server.py backup`. Der Dienst
+> muss dafür **nicht** gestoppt werden (Online-Dump). Standard-Aufbewahrung:
+> **31 Tage** (`retention_days` in `praxiszeit.conf` → für §16 auf z. B. `760`
+> erhöhen, oder zusätzlich Jahresarchive extern ablegen).
+>
+> **Docker hat KEIN eingebautes Auto-Backup** — richten Sie einen Host-Cron ein
+> (siehe unten) oder ziehen Sie regelmäßig ein manuelles Backup.
+
+---
+
+## Manuelles Backup
+
+### Native (Linux / macOS / Windows)
+
+Erzeugt sofort ein Backup im konfigurierten `data/backups/`-Verzeichnis (gleiche
+Routine wie das automatische, inkl. Aufräumen alter Backups):
+
+```bash
+# Linux / macOS
+sudo -u praxiszeit /opt/praxiszeit/bin/python/bin/python3 \
+    /opt/praxiszeit/praxiszeit-server.py backup          # macOS: /usr/local/praxiszeit/...
+```
+
+```bat
+:: Windows (als Administrator)
+cd C:\PraxisZeit
+backup.bat
+```
+
+Backups anzeigen:
+```bash
+ls -la /opt/praxiszeit/data/backups/          # Windows: dir C:\PraxisZeit\data\backups
+```
+
+### Docker
+
+Direkter DB-Dump aus dem `db`-Container (Dienst läuft weiter):
+
+```bash
+docker compose exec -T db pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" \
+    > backup-$(date +%F).sql
+```
+
+**Automatisieren per Host-Cron** (empfohlen, da Docker kein Auto-Backup hat) —
+täglich 02:00 + 30-Tage-Rotation:
+
+```cron
+0 2 * * * cd /pfad/zu/praxiszeit && docker compose exec -T db pg_dump -U praxiszeit praxiszeit | gzip > ~/praxiszeit-backups/pz_$(date +\%F).sql.gz && find ~/praxiszeit-backups -name 'pz_*.sql.gz' -mtime +30 -delete
+```
+
+(Backup-Verzeichnis vorher anlegen: `mkdir -p ~/praxiszeit-backups`.)
+
+---
+
+## Restore (Wiederherstellung)
+
+> Vorher prüfen, welche Version das Backup erzeugt hat — ein Restore in eine
+> **ältere** Schemaversion wird nicht unterstützt (Migrationen sind vorwärts).
+
+### Native
+
+```bash
+# Linux/macOS — psql aus dem gebündelten PostgreSQL
+/opt/praxiszeit/bin/postgresql/bin/psql -U praxiszeit -h /opt/praxiszeit/data/run \
+    -d praxiszeit -f /opt/praxiszeit/data/backups/<datei>.sql
+```
+```bat
+:: Windows
+C:\PraxisZeit\bin\postgresql\bin\psql.exe -U praxiszeit -h localhost -d praxiszeit -f <datei>.sql
+```
+
+### Docker
+
+```bash
+# .sql.gz vorher entpacken: gunzip pz_<datum>.sql.gz
+docker compose exec -T db psql -U "$POSTGRES_USER" "$POSTGRES_DB" < backup.sql
+```
+
+---
+
+## Compliance-Checkliste (§16 ArbZG)
+
+- [ ] Automatisches Backup aktiv (Native: ja ab Installation; **Docker: Host-Cron einrichten**)
+- [ ] Aufbewahrung deckt **mind. 2 Jahre** ab (`retention_days` erhöhen oder Jahresarchive extern)
+- [ ] Backup-Ziel liegt **nicht nur** auf demselben Server (externe Kopie)
+- [ ] Restore regelmäßig testen
+- [ ] Vor jedem **Update** zusätzlich ein Backup ziehen → [UPDATE.md](UPDATE.md)
+
+---
+
+*Details zur Installation: [INSTALL-NATIVE.md](INSTALL-NATIVE.md) · [INSTALL-DOCKER.md](INSTALL-DOCKER.md) · [DOCKER-START.md](DOCKER-START.md)*

--- a/installer/macos/install.sh
+++ b/installer/macos/install.sh
@@ -245,6 +245,39 @@ PLISTEOF
 
 launchctl load /Library/LaunchDaemons/de.praxiszeit.server.plist
 
+info "Richte taegliches Backup ein (launchd, 03:00)..."
+cat > /Library/LaunchDaemons/de.praxiszeit.backup.plist << BKPLISTEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>de.praxiszeit.backup</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${INSTALL_DIR}/bin/python/bin/python3</string>
+        <string>${INSTALL_DIR}/praxiszeit-server.py</string>
+        <string>backup</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>${INSTALL_DIR}</string>
+    <key>UserName</key>
+    <string>_praxiszeit</string>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key><integer>3</integer>
+        <key>Minute</key><integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>${INSTALL_DIR}/logs/backup.log</string>
+    <key>StandardErrorPath</key>
+    <string>${INSTALL_DIR}/logs/backup.log</string>
+</dict>
+</plist>
+BKPLISTEOF
+
+launchctl load /Library/LaunchDaemons/de.praxiszeit.backup.plist
+
 # --- Fertig ---
 
 echo ""


### PR DESCRIPTION
feat(backup): docs/BACKUP.md + macOS-Auto-Backup (launchd)

- docs/BACKUP.md: Auto-Backup-Status je Variante (Native Linux/Windows/macOS:
  ja; Docker: nein -> Host-Cron-Snippet), manuelles Backup + Restore je Variante,
  Aufbewahrung/§16-Checkliste. Verlinkt in README + CLAUDE.md.
- installer/macos/install.sh: launchd de.praxiszeit.backup.plist (taeglich 03:00,
  ruft praxiszeit-server.py backup) -- schliesst die Luecke, dass der macOS-Shell-
  Installer bisher KEIN automatisches Backup einrichtete. Linux (systemd-Timer)
  und Windows (Scheduled Task) hatten es bereits.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
