### PR TITLE
fix(review-2026-06-18): Backup-Restore-CRITICAL + Onboarding-Block + Doku-Aktualität

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installierbar als **Progressive Web App (PWA)** auf Smartphone und Desktop.
 - ✅ **Stempeluhr** - Ein-/Ausstempeln direkt auf dem Dashboard
 - ✅ **Zeiterfassung** (von–bis mit Pausen)
 - ✅ **Dashboard** mit Soll/Ist-Vergleich und Überstundenkonto
-- ✅ **Urlaubsverwaltung** (stundenbasiert mit Restanzeige)
+- ✅ **Urlaubsverwaltung** (tagebasiert nach Tagesprinzip §3 BUrlG, mit Restanzeige)
 - ✅ **Abwesenheiten** (Urlaub, Krankheit, Fortbildung, Überstundenausgleich, Sonstiges)
 - ✅ **Abwesenheiten mit Zeiten** (Start-/Endzeit oder "ganzer Tag")
 - ✅ **Zeitraum-Erfassung** (mehrere Tage auf einmal)
@@ -34,7 +34,7 @@ Installierbar als **Progressive Web App (PWA)** auf Smartphone und Desktop.
 - ✅ **ArbZG-Compliance-Reports**: Ruhezeitverstöße (§5), Sonntagsarbeit (§11), Nachtarbeit (§6), Ersatzruhetag-Tracking (§11)
 
 ### ArbZG-Compliance (§3–§18)
-- ⚖️ **§3**: 8h-Warnung + 10h-Hard-Stop an allen Eingabepfaden (inkl. Admin-Direkteintrag, Änderungsanträge)
+- ⚖️ **§3**: 8h-Warnung überall; 10h-Hard-Stop bei manuellen Eingaben (Admin-Direkteintrag, Änderungsanträge) — Live-Ausstempeln erzeugt nur eine Warnung (die Zeit ist bereits geleistet und §16-aufzeichnungspflichtig)
 - ⚖️ **§4**: Pflichtpause-Prüfung (>6h→30min, >9h→45min) + Mindestdauer-Warnung (<15min, §4 Satz 2)
 - ⚖️ **§5**: 11h-Mindestruhezeit — Echtzeit-Warnung beim Einstempeln + Admin-Report
 - ⚖️ **§6**: Nachtarbeit-Erkennung (23–6 Uhr), Badge im Frontend, Admin-Report mit Nachtarbeitnehmer-Schwellwert (≥48 Tage/Jahr)

--- a/backend/app/core/totp_crypto.py
+++ b/backend/app/core/totp_crypto.py
@@ -18,6 +18,7 @@ blast radius as session invalidation. Affected users must re-enroll 2FA. This is
 documented and acceptable for the on-prem single-instance deployment model.
 """
 import base64
+import logging
 
 from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.primitives import hashes
@@ -25,8 +26,17 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 from app.config import settings
 
+logger = logging.getLogger(__name__)
+
 # Versioned context label — changing it (or SECRET_KEY) invalidates old tokens.
 _HKDF_INFO = b"praxiszeit-totp-secret-encryption-v1"
+
+
+def _looks_like_token(stored: str) -> bool:
+    """Heuristik: Fernet-Tokens sind urlsafe-base64 eines fuehrenden 0x80-
+    Versionsbytes und beginnen daher IMMER mit ``gAAAAA``. Legacy-base32-TOTP-
+    Secrets bestehen nur aus Grossbuchstaben A-Z und Ziffern 2-7 (nie lowercase)."""
+    return stored.startswith("gAAAAA")
 
 
 def _fernet() -> Fernet:
@@ -57,6 +67,15 @@ def decrypt_secret(stored: str) -> str:
     try:
         return _fernet().decrypt(stored.encode("ascii")).decode("utf-8")
     except (InvalidToken, ValueError):
+        if _looks_like_token(stored):
+            # Sieht aus wie ein Fernet-Token, laesst sich aber nicht entschluesseln
+            # -> SECRET_KEY wurde rotiert / passt nicht. Das Secret ist verloren;
+            # der Nutzer muss 2FA neu einrichten. Laut loggen, sonst aeussert es
+            # sich nur als "Ungueltiger TOTP-Code" (sieht aus wie Tippfehler/Drift).
+            logger.warning(
+                "TOTP-Secret nicht entschluesselbar (SECRET_KEY rotiert?). "
+                "Betroffener Nutzer muss 2FA neu einrichten."
+            )
         return stored
 
 

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -14,9 +14,10 @@ gelegentlich die Wiederherstellung.
 | **Docker** | ❌ **nein** | nur manuell bzw. per Host-Cron (s. u.) | wohin Sie den Dump schreiben |
 
 > **Native:** Das Backup ruft intern `praxiszeit-server.py backup`. Der Dienst
-> muss dafür **nicht** gestoppt werden (Online-Dump). Standard-Aufbewahrung:
-> **31 Tage** (`retention_days` in `praxiszeit.conf` → für §16 auf z. B. `760`
-> erhöhen, oder zusätzlich Jahresarchive extern ablegen).
+> muss dafür **nicht** gestoppt werden (Online-Dump, Plain-SQL `pg_dump` + gzip).
+> Standard-Aufbewahrung: **31 Tage** (`retention_days` in `praxiszeit.conf` → für
+> §16 auf z. B. `730` (= 2 Jahre) erhöhen, oder zusätzlich Jahresarchive extern
+> ablegen).
 >
 > **Docker hat KEIN eingebautes Auto-Backup** — richten Sie einen Host-Cron ein
 > (siehe unten) oder ziehen Sie regelmäßig ein manuelles Backup.
@@ -74,14 +75,27 @@ täglich 02:00 + 30-Tage-Rotation:
 
 ### Native
 
+Die Backups sind **gzip-komprimierte Plain-SQL-Dumps** (`praxiszeit_<ts>.sql.gz`,
+erzeugt mit `--clean --if-exists` → der Restore dropt + legt die Objekte neu an).
+Erst entpacken, dann durch `psql` leiten — **nicht** `psql -f` auf die `.gz`:
+
 ```bash
-# Linux/macOS — psql aus dem gebündelten PostgreSQL
-/opt/praxiszeit/bin/postgresql/bin/psql -U praxiszeit -h /opt/praxiszeit/data/run \
-    -d praxiszeit -f /opt/praxiszeit/data/backups/<datei>.sql
+# Linux/macOS — gebündeltes psql, Verbindung über den eigenen Unix-Socket.
+# Das Superuser-Passwort steht in config/.db-credentials (SUPERUSER_PASSWORD=...).
+PZ=/opt/praxiszeit          # macOS: /usr/local/praxiszeit
+export PGPASSWORD="$(grep '^SUPERUSER_PASSWORD=' "$PZ/config/.db-credentials" | cut -d= -f2-)"
+gunzip -c "$PZ/data/backups/<datei>.sql.gz" \
+  | "$PZ/bin/postgresql/bin/psql" -w -h "$PZ/data/run" -U praxiszeit -d praxiszeit
+unset PGPASSWORD
 ```
+> Möglichst zu einem ruhigen Zeitpunkt einspielen (kein paralleles Stempeln).
+> Der Dienst (und damit PostgreSQL) muss laufen, damit der Socket erreichbar ist.
+
 ```bat
-:: Windows
-C:\PraxisZeit\bin\postgresql\bin\psql.exe -U praxiszeit -h localhost -d praxiszeit -f <datei>.sql
+:: Windows — der gebündelte restore-backup.bat stoppt den Dienst, legt die DB
+:: frisch an, entpackt und spielt das Backup ein (erwartet die .sql.gz direkt):
+cd C:\PraxisZeit
+restore-backup.bat data\backups\<datei>.sql.gz
 ```
 
 ### Docker

--- a/docs/DOCKER-START.md
+++ b/docs/DOCKER-START.md
@@ -7,7 +7,7 @@ Daten in eine Cloud übertragen.
 > **Wichtig — welches Paket?** Die **Native-Pakete**
 > (`praxiszeit-…-linux-x64.tar.gz`, `…-windows-x64.zip` usw.) enthalten **kein**
 > `docker-compose.yml` — sie sind für die Installation **ohne** Docker gedacht.
-> Für Docker brauchen Sie das **Docker-Paket** `praxiszeit-<version>-docker.zip`
+> Für Docker brauchen Sie das **Docker-Paket** `praxiszeit-<version>-docker.tar.gz`
 > (enthält Compose + Build-Kontext) **oder** den Quellcode (`git clone`).
 
 ---
@@ -23,8 +23,8 @@ Daten in eine Cloud übertragen.
 ## 1. Docker-Paket entpacken
 
 ```bash
-unzip praxiszeit-<version>-docker.zip
-cd praxiszeit-<version>-docker
+tar xzf praxiszeit-<version>-docker.tar.gz
+cd praxiszeit-<version>
 ```
 
 Das Paket enthält alles Nötige: `docker-compose.yml`, `docker-compose.ssl.yml`,

--- a/docs/INSTALL-DOCKER.md
+++ b/docs/INSTALL-DOCKER.md
@@ -26,8 +26,8 @@ Dateien (inkl. `docker-compose.yml`) zu kommen:
 
 ```bash
 # 1. Bundle entpacken (enthält einen Top-Level-Ordner praxiszeit-X.Y.Z/)
-tar xzf praxiszeit-1.8.10-docker.tar.gz
-cd praxiszeit-1.8.10
+tar xzf praxiszeit-1.8.11-docker.tar.gz
+cd praxiszeit-1.8.11
 
 # 2. Secrets erzeugen (.env mit Zufallswerten + komplexem Admin-Passwort)
 bash generate-secrets.sh

--- a/docs/INSTALL-NATIVE.md
+++ b/docs/INSTALL-NATIVE.md
@@ -24,9 +24,9 @@ Alle Pakete enthalten Python und PostgreSQL — keine Voraussetzungen noetig.
 # 1. Herunterladen + entpacken
 #    Das Tarball entpackt FLACH (kein Top-Level-Ordner) — daher zuerst einen
 #    Zielordner anlegen und mit -C dorthin entpacken:
-mkdir -p praxiszeit-1.8.10
-tar xzf praxiszeit-1.8.10-linux-x64.tar.gz -C praxiszeit-1.8.10
-cd praxiszeit-1.8.10
+mkdir -p praxiszeit-1.8.11
+tar xzf praxiszeit-1.8.11-linux-x64.tar.gz -C praxiszeit-1.8.11
+cd praxiszeit-1.8.11
 
 # 2. Installer starten (als root)
 sudo ./install.sh
@@ -54,7 +54,7 @@ journalctl -u praxiszeit -f          # Live-Logs
 ## Windows-Installation
 
 ```
-1. praxiszeit-1.8.10-windows-x64.zip entpacken nach C:\PraxisZeit\
+1. praxiszeit-1.8.11-windows-x64.zip entpacken nach C:\PraxisZeit\
 
 2. setup.bat als Administrator ausfuehren
    - Installiert PostgreSQL (silent, kein GUI)
@@ -88,13 +88,13 @@ Deinstallation: `uninstall-service.bat` ausfuehren (Datenbank wird beibehalten).
 
 ```bash
 # Tarball entpackt flach — in einen eigenen Ordner entpacken:
-mkdir -p praxiszeit-1.8.10 && cd praxiszeit-1.8.10
+mkdir -p praxiszeit-1.8.11 && cd praxiszeit-1.8.11
 
 # Intel Mac:
-tar xzf ../praxiszeit-1.8.10-macos-x64.tar.gz
+tar xzf ../praxiszeit-1.8.11-macos-x64.tar.gz
 
 # Apple Silicon (M1/M2/M3/M4):
-tar xzf ../praxiszeit-1.8.10-macos-arm64.tar.gz
+tar xzf ../praxiszeit-1.8.11-macos-arm64.tar.gz
 
 # Installer starten (als root)
 sudo ./install.sh
@@ -120,10 +120,12 @@ tail -f /usr/local/praxiszeit/logs/praxiszeit.log
 
 **Standardpfad:** `/usr/local/praxiszeit/`
 
-Deinstallation:
+Deinstallation (beide launchd-Jobs entladen — Server **und** Backup-Timer):
 ```bash
 sudo launchctl unload /Library/LaunchDaemons/de.praxiszeit.server.plist
+sudo launchctl unload /Library/LaunchDaemons/de.praxiszeit.backup.plist
 sudo rm /Library/LaunchDaemons/de.praxiszeit.server.plist
+sudo rm /Library/LaunchDaemons/de.praxiszeit.backup.plist
 sudo rm -rf /usr/local/praxiszeit   # Optional: Daten loeschen
 ```
 

--- a/docs/handbuch/CHEATSHEET-MITARBEITER.md
+++ b/docs/handbuch/CHEATSHEET-MITARBEITER.md
@@ -53,7 +53,7 @@ Aktionsspalte in der Einträge-Tabelle:
 
 ### Tagesgrenze (§3 ArbZG)
 - Warnung ab **8 Stunden** Nettoarbeitszeit
-- Gesperrt ab **10 Stunden** Nettoarbeitszeit
+- Ab **10 Stunden** netto: manuelle Eingabe gesperrt; Live-Ausstempeln nur Warnung (Zeit ist bereits geleistet)
 
 ### Soll-Arbeitszeit-Fenster
 *Nur aktiv, wenn die Praxis für Sie Soll-Zeiten hinterlegt hat – sonst zählt alles wie gewohnt.*

--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -1,6 +1,6 @@
 # PraxisZeit – Handbuch für Administratoren
 
-**Version 2.4 | Stand: Juni 2026 (für PraxisZeit 1.8.2)**
+**Version 2.4 | Stand: Juni 2026 (für PraxisZeit 1.8.11)**
 
 ---
 
@@ -76,7 +76,7 @@ Das Admin-Dashboard zeigt alle aktiven Mitarbeiter mit ihren aktuellen Monatsdat
 | **Ist** | Tatsächlich geleistete Stunden |
 | **Saldo** | Differenz Ist – Soll (H:MM, + = Überstunden, – = Fehlstunden) |
 | **Übersto. Kum.** | Kumulierter Jahressaldo |
-| **Urlaub** | Verbleibende Urlaubsstunden (Ampelfarbe) |
+| **Urlaub** | Verbleibende Urlaubstage (Ampelfarbe) |
 | **Krank** | Kranktage im aktuellen Monat |
 
 ### Statistiken (oben)
@@ -699,7 +699,7 @@ Mitarbeiter können nicht nur Zeiteinträge korrigieren, sondern auch **Abwesenh
 
 ## 18. Berechnungsgrundlagen (Anhang)
 
-> Dieser Anhang erklärt **vollständig und exakt**, wie PraxisZeit Soll-, Ist-, Überstunden- und Urlaubswerte ermittelt – auf dem tatsächlichen Rechenstand der Software (Version 1.8.2). Die ausführliche, code-nahe Referenz mit allen durchgerechneten Beispielen (Teilzeit, individueller Tagesplan, Pro-rata, Historie) steht in [`docs/BERECHNUNGEN.md`](../BERECHNUNGEN.md).
+> Dieser Anhang erklärt **vollständig und exakt**, wie PraxisZeit Soll-, Ist-, Überstunden- und Urlaubswerte ermittelt – auf dem tatsächlichen Rechenstand der Software (Version 1.8.11). Die ausführliche, code-nahe Referenz mit allen durchgerechneten Beispielen (Teilzeit, individueller Tagesplan, Pro-rata, Historie) steht in [`docs/BERECHNUNGEN.md`](../BERECHNUNGEN.md).
 
 ### 18.1 Grundbegriffe
 
@@ -787,4 +787,4 @@ Urlaubskonto = 30 − 4                     = 26 Tage übrig
 ---
 
 *PraxisZeit – Zeiterfassungssystem für Arztpraxen und kleine Unternehmen*
-*Stand: Juni 2026 (Version 2.4, für PraxisZeit 1.8.2)*
+*Stand: Juni 2026 (Version 2.4, für PraxisZeit 1.8.11)*

--- a/docs/handbuch/HANDBUCH-MITARBEITER.md
+++ b/docs/handbuch/HANDBUCH-MITARBEITER.md
@@ -1,6 +1,6 @@
 # PraxisZeit – Mitarbeiter-Handbuch
 
-**Version:** 2.3 · **Stand:** Juni 2026 (PraxisZeit 1.8.2)
+**Version:** 2.3 · **Stand:** Juni 2026 (PraxisZeit 1.8.11)
 **System:** PraxisZeit Zeiterfassungssystem
 **Zugangsdaten:** Benutzername und Passwort vom Administrator
 
@@ -170,7 +170,7 @@ Klicken Sie auf **Speichern**. Mit **Abbrechen** (oben rechts) verwerfen Sie das
 > PraxisZeit prüft Eingaben automatisch auf ArbZG-Einhaltung:
 >
 > - **> 8 Stunden Netto:** Hinweis gem. [§ 3 ArbZG](https://www.gesetze-im-internet.de/arbzg/__3.html)
-> - **> 10 Stunden Netto:** Eintrag wird blockiert (Tageshöchstgrenze)
+> - **> 10 Stunden Netto:** Bei **manueller Eingabe** (wie hier) wird der Eintrag blockiert (Tageshöchstgrenze). Beim **Live-Ausstempeln** wird stattdessen nur gewarnt — die Zeit ist dann bereits geleistet und § 16-aufzeichnungspflichtig.
 > - **Zu kurze Pause:** Warnung gem. [§ 4 ArbZG](https://www.gesetze-im-internet.de/arbzg/__4.html):
 >   bei > 6h → mind. 30 Min.; bei > 9h → mind. 45 Min.
 
@@ -491,7 +491,7 @@ A: Überprüfen Sie, ob Sie den richtigen Monat anzeigen. Nutzen Sie die Pfeile 
 **F: Ich bekomme eine Warnung bei der Eingabe meiner Arbeitszeit.**
 A: PraxisZeit prüft die gesetzlichen Grenzen:
 - Netto > 8h: Hinweis (zulässig mit Ausgleich – § 3 ArbZG)
-- Netto > 10h: Blockiert (Tageshöchstgrenze – § 3 ArbZG)
+- Netto > 10h: bei **manueller Eingabe** blockiert; beim **Live-Ausstempeln** nur Warnung, weil die Zeit bereits geleistet ist (Tageshöchstgrenze – § 3 ArbZG)
 - Zu kurze Pause: Warnung (§ 4 ArbZG – bei >6h mind. 30 Min., bei >9h mind. 45 Min.)
 
 **F: Beim Ausstempeln werde ich nach meiner Pause gefragt – was muss ich eintragen?**
@@ -540,4 +540,4 @@ Vollständiger Gesetzestext: [https://www.gesetze-im-internet.de/arbzg/](https:/
 
 ---
 
-*PraxisZeit – Zeiterfassungssystem | Mitarbeiter-Handbuch v2.3 | Juni 2026 (PraxisZeit 1.8.2)*
+*PraxisZeit – Zeiterfassungssystem | Mitarbeiter-Handbuch v2.3 | Juni 2026 (PraxisZeit 1.8.11)*

--- a/docs/setup-anleitung.md
+++ b/docs/setup-anleitung.md
@@ -1,7 +1,15 @@
 # Setup-Anleitung PraxisZeit
 
-**Aktuelle Version:** 1.4.4 · **Stand:** 23. Mai 2026
+**Aktuelle Version:** 1.8.11 · **Stand:** Juni 2026
 Für Linux und Windows · Native Installation und Docker-Deployment
+
+> **Maßgebliche, gepflegte Anleitungen:** [INSTALL-NATIVE.md](INSTALL-NATIVE.md)
+> (nativ), [INSTALL-DOCKER.md](INSTALL-DOCKER.md) / [DOCKER-START.md](DOCKER-START.md)
+> (Docker), [UPDATE.md](UPDATE.md) (Update) und [BACKUP.md](BACKUP.md) (Sicherung).
+> Dieses Dokument ist die ausführliche Schritt-für-Schritt-Variante. Einzelne
+> versionsspezifische Beispiele (Release-Dateinamen, GitHub-Release-Hinweise)
+> stammen noch aus der 1.4.x-Ära — ausgeliefert wird inzwischen über den Shop
+> (praxiszeit.mr-development.de). In der Beta ist keine Lizenz nötig.
 
 ---
 
@@ -161,9 +169,8 @@ Der Installer ist **vollständig interaktiv** und fragt der Reihe nach ab:
 | `Admin-E-Mail:` | `admin@praxis.local` | Pflicht |
 | `Admin-Passwort (min. 12 Zeichen):` | `********` | Mindestens 12 Zeichen, **kein** Komplexitäts-Check (nur Längencheck) |
 | `Passwort wiederholen:` | `********` | Muss übereinstimmen |
-| `Lizenzschluessel-Datei:` | leer oder Pfad | Kann später nachgereicht werden |
 | `HTTPS-Port [443]:` | `443` | Default-Port ist HTTPS:443 |
-| `Selbstsigniertes SSL-Zertifikat generieren? [J/n]:` | `J` | Erzeugt sofort ed25519-Cert (10 Jahre) |
+| `Selbstsigniertes SSL-Zertifikat generieren? [J/n]:` | `J` | Erzeugt sofort ein selbstsigniertes **RSA-2048-Server-Zertifikat** (10 Jahre, Hostname/IP im SAN) |
 | `Installationsverzeichnis [/opt/praxiszeit]:` | leer = Default | Frei wählbar |
 
 Anschließend wird eine **Zusammenfassung** angezeigt und mit `J/n` bestätigt.
@@ -176,7 +183,7 @@ Anschließend wird eine **Zusammenfassung** angezeigt und mit `J/n` bestätigt.
 - Schreibt `config/praxiszeit.conf` mit `chmod 600` (Owner-only-Lesen)
 - Generiert optional selbstsigniertes SSL-Zertifikat
 - Registriert systemd-Service `praxiszeit.service`
-- Richtet täglichen **Backup-Cron um 02:00** ein (per `crontab -u praxiszeit`)
+- Richtet ein tägliches **Backup um 02:00** ein — über einen **systemd-Timer** `praxiszeit-backup.timer` (cron ist auf Minimal-/Cloud-Images oft nicht installiert)
 - Startet den Dienst und wartet auf den Health-Check
 
 ### 4.4 Service-Verwaltung
@@ -392,7 +399,7 @@ docker compose ps                                    # alle 5 Container sollten 
 curl http://localhost/api/health
 # {"status":"healthy","database":"connected"}
 curl http://localhost/api/system/info
-# {"deployment_mode":"onprem","version":"1.4.4"}
+# {"deployment_mode":"onprem","version":"1.8.11"}
 ```
 
 ### 6.5 Im LAN erreichbar machen
@@ -481,12 +488,17 @@ retention_days = 730                  # § 16 ArbZG: min. 2 Jahre!
 Bei der Linux-Installation wird das Zertifikat optional schon vom Installer generiert (`Selbstsigniertes SSL-Zertifikat generieren? [J/n]`). Manuell nachholen:
 
 ```bash
-sudo -u praxiszeit openssl req -x509 -newkey ed25519 \
+# WICHTIG: RSA-2048 + serverAuth. Browser lehnen ed25519-TLS-Server-Zertifikate
+# und CA-Certs (ohne extendedKeyUsage=serverAuth) ohne "Erweitert"-Option ab.
+sudo -u praxiszeit openssl req -x509 -nodes -newkey rsa:2048 \
   -keyout /opt/praxiszeit/config/ssl/key.pem \
   -out    /opt/praxiszeit/config/ssl/cert.pem \
-  -days 3650 -nodes \
-  -subj "/CN=PraxisZeit/O=Praxis Dr. Müller" \
-  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:$(hostname -I | awk '{print $1}')"
+  -days 3650 \
+  -subj "/O=PraxisZeit/CN=praxiszeit" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:$(hostname -I | awk '{print $1}')" \
+  -addext "basicConstraints=critical,CA:FALSE" \
+  -addext "keyUsage=critical,digitalSignature,keyEncipherment" \
+  -addext "extendedKeyUsage=serverAuth"
 ```
 
 In `praxiszeit.conf`:
@@ -534,10 +546,12 @@ Arbeitgeber müssen Arbeitszeiten **mindestens 2 Jahre** revisionssicher aufbewa
 
 ### 9.2 Automatische Backups (Native)
 
-Sind ab Werk aktiviert. Der Installer registriert einen Cron-Job:
+Sind ab Werk aktiviert. Der Installer richtet einen **systemd-Timer** ein (cron
+ist auf Minimal-/Cloud-Images oft nicht vorhanden):
 ```bash
-sudo crontab -u praxiszeit -l
-# 0 2 * * * /opt/praxiszeit/bin/python/bin/python3 /opt/praxiszeit/praxiszeit-server.py backup
+systemctl status praxiszeit-backup.timer
+systemctl list-timers | grep praxiszeit
+# Manuell sofort: sudo systemctl start praxiszeit-backup.service
 ```
 
 Retention erhöhen für ArbZG-Konformität:
@@ -771,4 +785,4 @@ C:\PraxisZeit\                    (Windows)
 
 ---
 
-*PraxisZeit · Version 1.4.4 · © 2026 · Erstellt am 23. Mai 2026 · Iteration 2*
+*PraxisZeit · Version 1.8.11 · © 2026*

--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -1,8 +1,14 @@
 # PraxisZeit – Windows-Installation und Erstinbetriebnahme
 
-**Aktuelle Version:** 1.4.4 · **Stand:** 23. Mai 2026
+**Aktuelle Version:** 1.8.11 · **Stand:** Juni 2026
 **Zielgruppe:** Praxis-Inhaber:in oder IT-Betreuer:in, der/die PraxisZeit erstmalig auf einem Windows-Rechner einrichtet
 **Ergebnis:** Ein einsatzbereiter Praxis-Server, eingerichtete Mitarbeiter:innen-Konten und der erste erfolgreiche Stempelvorgang am Morgen.
+
+> **Maßgebliche, gepflegte Anleitungen:** [INSTALL-NATIVE.md](INSTALL-NATIVE.md),
+> [UPDATE.md](UPDATE.md), [BACKUP.md](BACKUP.md) und
+> [NATIVE-WINDOWS-PITFALLS.md](NATIVE-WINDOWS-PITFALLS.md). Auslieferung erfolgt
+> über den Shop (praxiszeit.mr-development.de); in der Beta ist keine Lizenz nötig.
+> Einzelne versionsspezifische Beispiele unten stammen noch aus der 1.4.x-Ära.
 
 Diese Anleitung deckt **nur Windows** ab und führt Schritt für Schritt vom heruntergeladenen ZIP-Paket bis zum ersten Arbeitstag eines Mitarbeiters. Für Linux- oder Docker-Installationen siehe [`setup-anleitung.md`](setup-anleitung.md).
 
@@ -75,7 +81,10 @@ Folgende Dateien herunterladen:
 - `praxiszeit-<VERSION>-windows-x64.zip` (z. B. `praxiszeit-1.3.6-windows-x64.zip`)
 - `praxiszeit-<VERSION>-SHA256SUMS.txt` (Prüfsummen-Datei)
 
-> **Hinweis zur Versionslage (Stand 23.05.2026):** Aktuell signierte Releases sind **v1.3.5 / v1.3.6** (Windows). Neuere Features im `master`-Branch (1.4.x) erfordern einen Eigen-Build (siehe `setup-anleitung.md`, Kapitel 3.4).
+> **Hinweis zur Versionslage:** Releases (inkl. Windows-ZIP) werden inzwischen
+> zentral über den Shop **praxiszeit.mr-development.de** ausgeliefert (nicht mehr
+> nur als GitHub-Release). Aktuelle Version: **1.8.11**. Ein Eigen-Build aus dem
+> `master`-Branch ist weiterhin via `tools/build-release.sh` möglich.
 
 ### 2.2 Integrität prüfen (PowerShell)
 
@@ -232,12 +241,18 @@ install-service.bat
 Selbstsigniertes Zertifikat für lokalen HTTPS-Zugriff:
 
 ```cmd
+:: WICHTIG: RSA-2048 + serverAuth. Browser lehnen ed25519-TLS-Server-Zertifikate
+:: und CA-Certs (ohne extendedKeyUsage=serverAuth) ohne "Erweitert"-Option ab.
 cd C:\PraxisZeit
-bin\postgresql\bin\openssl.exe req -x509 -newkey ed25519 ^
+bin\postgresql\bin\openssl.exe req -x509 -nodes -newkey rsa:2048 ^
   -keyout config\ssl\key.pem ^
   -out    config\ssl\cert.pem ^
-  -days 3650 -nodes ^
-  -subj "/CN=PraxisZeit/O=Praxis Dr. Müller"
+  -days 3650 ^
+  -subj "/O=PraxisZeit/CN=praxiszeit" ^
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" ^
+  -addext "basicConstraints=critical,CA:FALSE" ^
+  -addext "keyUsage=critical,digitalSignature,keyEncipherment" ^
+  -addext "extendedKeyUsage=serverAuth"
 ```
 
 Dann in `config\praxiszeit.conf` aktivieren:
@@ -577,4 +592,4 @@ schtasks /query /tn "PraxisZeit-Backup" /v /fo LIST > C:\PraxisZeit\logs\task-st
 
 ---
 
-*PraxisZeit · Windows-Setup · Version 1.4.4 · Erstellt am 23. Mai 2026*
+*PraxisZeit · Windows-Setup · Version 1.8.11 · © 2026*

--- a/frontend/src/components/DocDrawer.tsx
+++ b/frontend/src/components/DocDrawer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Download, X } from 'lucide-react';
 import { DocViewerContent, type DocTab } from './DocViewer';
+import { lockBodyScroll, unlockBodyScroll } from '../utils/bodyScrollLock';
 
 interface DocDrawerProps {
   open: boolean;
@@ -76,14 +77,11 @@ export function DocDrawer({ open, onClose, isAdmin, initialTab = 'cheatsheet' }:
     return () => document.removeEventListener('keydown', handleTab);
   }, [open]);
 
-  // Body scroll lock on mobile
+  // Body scroll lock on mobile (ref-gezählt -> kollidiert nicht mit anderen Overlays)
   useEffect(() => {
-    if (open) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
-    return () => { document.body.style.overflow = ''; };
+    if (!open) return;
+    lockBodyScroll();
+    return () => { unlockBodyScroll(); };
   }, [open]);
 
   const downloadUrl = getDownloadUrl(isAdmin, activeTab);

--- a/frontend/src/components/DocModal.tsx
+++ b/frontend/src/components/DocModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Download, X } from 'lucide-react';
 import { DocViewerContent, type DocTab } from './DocViewer';
+import { lockBodyScroll, unlockBodyScroll } from '../utils/bodyScrollLock';
 
 interface DocModalProps {
   open: boolean;
@@ -42,14 +43,11 @@ export function DocModal({ open, onClose, initialTab = 'cheatsheet' }: DocModalP
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [open, onClose]);
 
-  // Body scroll lock
+  // Body scroll lock (ref-gezählt -> kollidiert nicht mit anderen Overlays)
   useEffect(() => {
-    if (open) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
-    return () => { document.body.style.overflow = ''; };
+    if (!open) return;
+    lockBodyScroll();
+    return () => { unlockBodyScroll(); };
   }, [open]);
 
   // Focus trap (live query per keydown) + initial focus on close button

--- a/frontend/src/components/OnboardingModal.tsx
+++ b/frontend/src/components/OnboardingModal.tsx
@@ -5,6 +5,7 @@ import {
 } from 'lucide-react';
 import { useAuthStore } from '../stores/authStore';
 import { useSystemStore } from '../stores/systemStore';
+import { lockBodyScroll, unlockBodyScroll } from '../utils/bodyScrollLock';
 import apiClient from '../api/client';
 
 interface Feature {
@@ -40,9 +41,12 @@ export default function OnboardingModal() {
   const { user, setUser } = useAuthStore();
   // Admin-Toggle (Default an): ein explizites false in /system/info unterdrückt die Tour.
   const onboardingEnabled = useSystemStore((s) => s.info?.onboarding_enabled !== false);
+  // Erst nach geladenem /system/info entscheiden — sonst flackert die Tour kurz auf,
+  // bevor ein evtl. gesetztes onboarding_enabled=false greift.
+  const systemLoaded = useSystemStore((s) => s.isLoaded);
   const [closed, setClosed] = useState(false);
 
-  const show = !!user && !closed && !user.onboarding_completed_at && onboardingEnabled;
+  const show = !!user && !closed && !user.onboarding_completed_at && onboardingEnabled && systemLoaded;
 
   const complete = useCallback(async () => {
     setClosed(true); // optimistisch sofort ausblenden
@@ -60,10 +64,10 @@ export default function OnboardingModal() {
     if (!show) return;
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') void complete(); };
     document.addEventListener('keydown', onKey);
-    document.body.style.overflow = 'hidden';
+    lockBodyScroll();
     return () => {
       document.removeEventListener('keydown', onKey);
-      document.body.style.overflow = '';
+      unlockBodyScroll();
     };
   }, [show, complete]);
 
@@ -73,7 +77,7 @@ export default function OnboardingModal() {
   const features = isAdmin ? ADMIN_FEATURES : EMPLOYEE_FEATURES;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/40" onClick={() => void complete()} aria-hidden="true" />
 
       <div

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -183,7 +183,13 @@ export default function Dashboard() {
           ? user.weekly_hours / (user.work_days_per_week || 5)
           : 8;
 
-        const vacation_days = sumAbsenceDays(absences, 'vacation', dailyTarget);
+        // Urlaub: autoritativ vom Backend (Tagesprinzip §3 BUrlG — zählt pro Tag
+        // mit dem Tagessoll DES TAGES). Die Client-Approximation Σ(Stunden) ÷
+        // Ø-Tagessoll ist für MA mit ungleichmäßigem Tagesplan (use_daily_schedule)
+        // systematisch falsch und darf für den legal relevanten Urlaub nicht
+        // genutzt werden. sick/training/overtime/other bleiben reine Anzeige-
+        // Näherungen (kein Budget, keine §-Pflicht).
+        const vacation_days = vacationRes.data?.used_days ?? sumAbsenceDays(absences, 'vacation', dailyTarget);
         const sick_days = sumAbsenceDays(absences, 'sick', dailyTarget);
         const training_days = sumAbsenceDays(absences, 'training', dailyTarget);
         const overtime_days = sumAbsenceDays(absences, 'overtime', dailyTarget);

--- a/frontend/src/pages/admin/AdminAbsences.tsx
+++ b/frontend/src/pages/admin/AdminAbsences.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { format } from 'date-fns';
 import { de } from 'date-fns/locale';
 import { Plus, X, Trash2, Pencil, ChevronDown, ChevronUp, Building2 } from 'lucide-react';
@@ -173,7 +173,11 @@ export default function AdminAbsences() {
     }
   };
 
+  // Out-of-order-Schutz: bei schnellem Monatswechsel kann eine ältere (langsamere)
+  // Antwort die neueren Daten überschreiben. Last-Write-Wins über allAbsencesSeq.
+  const allAbsencesSeq = useRef(0);
   const loadAllAbsences = async () => {
+    const seq = ++allAbsencesSeq.current;
     const year = currentMonth.split('-')[0];
     const result: Record<string, Absence[]> = {};
     await Promise.all(
@@ -189,6 +193,7 @@ export default function AdminAbsences() {
         }
       })
     );
+    if (seq !== allAbsencesSeq.current) return;
     setAllAbsences(result);
   };
 

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -193,7 +193,13 @@ export default function AdminDashboard() {
     });
   };
 
+  // C-2: Out-of-order-Schutz. Wechselt der Admin bei offenem Detail-Modal schnell
+  // den Monat, läuft fetchEmployeeDetails erneut, während der alte Lauf noch
+  // pendet — die langsamere Antwort würde sonst die Detaildaten des falschen
+  // Monats setzen. Last-Write-Wins über detailSeq.
+  const detailSeq = useRef(0);
   const fetchEmployeeDetails = async (employee: EmployeeReport) => {
+    const seq = ++detailSeq.current;
     setSelectedEmployee(employee);
     setDetailLoading(true);
     try {
@@ -201,6 +207,7 @@ export default function AdminDashboard() {
 
       // Fetch user details
       const userResponse = await apiClient.get(`/admin/users/${employee.user_id}`);
+      if (seq !== detailSeq.current) return;
       setSelectedUserDetails(userResponse.data);
 
       // Fetch time entries
@@ -210,6 +217,7 @@ export default function AdminDashboard() {
           month: currentMonth
         }
       });
+      if (seq !== detailSeq.current) return;
       setEmployeeTimeEntries(entriesResponse.data);
 
       // Fetch absences
@@ -219,14 +227,15 @@ export default function AdminDashboard() {
           year: parseInt(year)
         }
       });
+      if (seq !== detailSeq.current) return;
       setEmployeeAbsences(absencesResponse.data);
 
       // Fetch audit log
       fetchAuditForUser(employee.user_id);
     } catch (error) {
-      toast.error('Fehler beim Laden der Mitarbeiterdaten');
+      if (seq === detailSeq.current) toast.error('Fehler beim Laden der Mitarbeiterdaten');
     } finally {
-      setDetailLoading(false);
+      if (seq === detailSeq.current) setDetailLoading(false);
     }
   };
 

--- a/frontend/src/pages/admin/VacationApprovals.tsx
+++ b/frontend/src/pages/admin/VacationApprovals.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { format } from 'date-fns';
 import apiClient from '../../api/client';
 import { Clock, CheckCircle, XCircle, AlertCircle, Check, X, Trash2, Pencil } from 'lucide-react';
@@ -66,16 +66,21 @@ export default function VacationApprovals() {
     }
   };
 
+  // Out-of-order-Schutz: schneller Filter-Wechsel (Offen->Genehmigt->Offen) kann
+  // sonst die langsamere alte Antwort zuletzt anzeigen. Last-Write-Wins über requestsSeq.
+  const requestsSeq = useRef(0);
   const fetchRequests = async () => {
+    const seq = ++requestsSeq.current;
     setLoading(true);
     try {
       const params = filter ? `?status=${filter}` : '';
       const res = await apiClient.get(`/admin/vacation-requests${params}`);
+      if (seq !== requestsSeq.current) return;
       setRequests(res.data);
     } catch {
-      toast.error('Fehler beim Laden der Anträge');
+      if (seq === requestsSeq.current) toast.error('Fehler beim Laden der Anträge');
     } finally {
-      setLoading(false);
+      if (seq === requestsSeq.current) setLoading(false);
     }
   };
 

--- a/frontend/src/stores/systemStore.ts
+++ b/frontend/src/stores/systemStore.ts
@@ -32,8 +32,11 @@ export const useSystemStore = create<SystemState>((set, get) => ({
       const { data } = await apiClient.get<SystemInfo>('/system/info');
       set({ info: data, isLoaded: true });
     } catch {
+      // onboarding_enabled: false im Fehler-Fallback — laesst sich die Einstellung
+      // nicht laden, NICHT die Tour zeigen (sonst erschiene sie trotz Admin-
+      // Deaktivierung, weil ein fehlendes Feld als "an" gilt).
       set({
-        info: { deployment_mode: 'onprem', version: '' },
+        info: { deployment_mode: 'onprem', version: '', onboarding_enabled: false },
         isLoaded: true,
       });
     }

--- a/frontend/src/utils/bodyScrollLock.ts
+++ b/frontend/src/utils/bodyScrollLock.ts
@@ -1,0 +1,25 @@
+// Ref-gezählter body-scroll-lock.
+//
+// Mehrere gleichzeitig offene Overlays (OnboardingModal, DocDrawer, DocModal)
+// dürfen sich nicht gegenseitig den Scroll-Lock aufheben: Setzt jedes Overlay
+// beim Schließen `document.body.style.overflow = ''`, scrollt der Body wieder,
+// obwohl ein anderes Overlay noch offen ist. Stattdessen zählen wir die aktiven
+// Locks — `overflow` wird erst beim ersten Lock gesetzt und erst beim letzten
+// Unlock wieder freigegeben (auf den vorherigen Wert).
+let lockCount = 0;
+let previousOverflow = '';
+
+export function lockBodyScroll(): void {
+  if (lockCount === 0) {
+    previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+  }
+  lockCount += 1;
+}
+
+export function unlockBodyScroll(): void {
+  lockCount = Math.max(0, lockCount - 1);
+  if (lockCount === 0) {
+    document.body.style.overflow = previousOverflow;
+  }
+}

--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -287,6 +287,14 @@ ADMIN_USERNAME_ESC=$(toml_escape "$ADMIN_USERNAME")
 ADMIN_EMAIL_ESC=$(toml_escape "$ADMIN_EMAIL")
 ADMIN_PASSWORD_ESC=$(toml_escape "$ADMIN_PASSWORD")
 
+if [ -f "${INSTALL_DIR}/config/praxiszeit.conf" ]; then
+    # Reinstall/Update: bestehende Konfiguration NICHT ueberschreiben. Ein neu
+    # generierter secret_key wuerde sonst alle Sessions ungueltig machen UND alle
+    # verschluesselten TOTP-Secrets (Migration 050) unentschluesselbar -> jeder
+    # 2FA-Nutzer ausgesperrt. Auch port/SSL/retention/Admin-Passwort des Betreibers
+    # bleiben so erhalten. Neue Eingaben aus diesem Lauf werden bewusst ignoriert.
+    info "Bestehende config/praxiszeit.conf erkannt -> wird beibehalten (Reinstall/Update)."
+else
 info "Schreibe Konfiguration..."
 cat > "${INSTALL_DIR}/config/praxiszeit.conf" << TOMLEOF
 [server]
@@ -326,6 +334,7 @@ enabled = true
 schedule = "02:00"
 retention_days = 31
 TOMLEOF
+fi
 
 # Passwort nicht laenger als noetig im Shell-Environment des Installers halten
 # (war via /proc/self/environ fuer Co-Prozesse lesbar). Es steht jetzt escaped

--- a/installer/macos/install.sh
+++ b/installer/macos/install.sh
@@ -153,6 +153,13 @@ cp "${SCRIPT_DIR}/praxiszeit-server.py" "${INSTALL_DIR}/"
 
 SECRET_KEY=$("${INSTALL_DIR}/bin/python/bin/python3" -c "import secrets; print(secrets.token_hex(64))")
 
+if [ -f "${INSTALL_DIR}/config/praxiszeit.conf" ]; then
+    # Reinstall/Update: bestehende Konfiguration NICHT ueberschreiben. Ein neu
+    # generierter secret_key wuerde sonst alle Sessions ungueltig machen UND alle
+    # verschluesselten TOTP-Secrets (Migration 050) unentschluesselbar -> jeder
+    # 2FA-Nutzer ausgesperrt. port/retention/Admin-Passwort bleiben so erhalten.
+    info "Bestehende config/praxiszeit.conf erkannt -> wird beibehalten (Reinstall/Update)."
+else
 info "Schreibe Konfiguration..."
 cat > "${INSTALL_DIR}/config/praxiszeit.conf" << CONFEOF
 [server]
@@ -190,6 +197,7 @@ enabled = true
 schedule = "02:00"
 retention_days = 31
 CONFEOF
+fi
 chmod 600 "${INSTALL_DIR}/config/praxiszeit.conf"
 
 # --- Service-User ---

--- a/praxiszeit-server.py
+++ b/praxiszeit-server.py
@@ -838,7 +838,7 @@ def pg_load_credentials():
 # --- Alembic Migrations ---
 
 def _redact_db_url(text: str) -> str:
-    """Maskiert Passwörter in postgresql://user:pass@host-URLs.
+    """Maskiert Passwörter in postgresql://<user>:<pass>@<host>-URLs.
 
     Alembic schreibt bei Verbindungsfehlern die komplette Connection-URL
     (inkl. Passwort aus DATABASE_URL_MIGRATIONS) auf stderr; ungefiltert
@@ -1200,25 +1200,45 @@ def create_backup(config: dict):
 
     logger.info(f"Creating backup: {backup_file}")
 
-    # "-w": never prompt for a password (fail fast instead of hanging).
+    # Plain-SQL-Format (NICHT -Fc!): pg_dumps Custom-Format ist bereits komprimiert;
+    # ein zweites gzip darueber erzeugt ein DOPPELT komprimiertes Artefakt, das die
+    # dokumentierten "gunzip | psql"-Restores NICHT einlesen koennen (psql parst
+    # Custom-Format-Binaerdaten als SQL -> Syntaxfehler). Plain-SQL + gzip ist mit
+    # "gunzip -c <datei>.sql.gz | psql" restorebar. "--clean --if-exists" macht den
+    # Restore idempotent (DROP ... IF EXISTS vor jedem CREATE), auch in eine bereits
+    # befuellte DB. "-w": nie nach Passwort fragen (fail fast statt Haenger).
     pg_dump = subprocess.Popen(
-        [str(pg_cmd("pg_dump")), "-w", "-U", superuser, "-d", "praxiszeit", "-Fc"],
+        [str(pg_cmd("pg_dump")), "-w", "--clean", "--if-exists",
+         "-U", superuser, "-d", "praxiszeit"],
         stdout=subprocess.PIPE,
         env={**pg_env(), "PGPASSWORD": su_password},
     )
 
-    with open(backup_file, "wb") as f:
-        import gzip
-        with gzip.open(f, "wb") as gz:
-            while True:
-                chunk = pg_dump.stdout.read(8192)
-                if not chunk:
-                    break
-                gz.write(chunk)
+    import gzip
+    write_error = None
+    try:
+        with open(backup_file, "wb") as f:
+            with gzip.open(f, "wb") as gz:
+                while True:
+                    chunk = pg_dump.stdout.read(8192)
+                    if not chunk:
+                        break
+                    gz.write(chunk)
+    except OSError as e:  # z. B. Platte voll waehrend des Schreibens
+        write_error = e
+    finally:
+        if pg_dump.stdout:
+            pg_dump.stdout.close()
 
     pg_dump.wait()
-    if pg_dump.returncode != 0:
-        logger.error("Backup failed!")
+    # Erfolg nur, wenn pg_dump sauber durchlief UND eine nicht-leere Datei entstand.
+    # Sonst wuerde ein truncated/leeres Backup als "complete" geloggt und ueberlebte
+    # die Retention -> stiller Datenverlust im Ernstfall.
+    if (write_error is not None or pg_dump.returncode != 0
+            or not backup_file.exists() or backup_file.stat().st_size == 0):
+        logger.error(
+            f"Backup failed (rc={pg_dump.returncode}, write_error={write_error})!"
+        )
         backup_file.unlink(missing_ok=True)
         return None
 

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -859,8 +859,8 @@ DOCKEREOF
     tar -czf "${DIST_DIR}/praxiszeit-${APP_VERSION}-docker.tar.gz" \
         -C "${BUILD_DIR}/docker" "praxiszeit-${APP_VERSION}"
     info "Docker-Bundle: $(du -h "${DIST_DIR}/praxiszeit-${APP_VERSION}-docker.tar.gz" | cut -f1)"
-    warn "Docker-Bundle gehoert an ein GitHub-Release — der '-docker'-Name passt"
-    warn "NICHT in das strikte pzweb-Upload-Regex (nur linux/macos/windows)."
+    info "Docker-Bundle: das pzweb-Upload-Regex akzeptiert seit 2026-06 auch '-docker'"
+    info "(neben linux/macos/windows) — kann also in den Shop ODER an ein GitHub-Release."
 else
     step "6b — Docker: uebersprungen"
 fi


### PR DESCRIPTION
Intensives Code-/Funktions-Review (4 parallele Reviewer: Backend, Frontend, Doku, pzweb) + Fix aller Findings bis Low.

## CRITICAL
- **Backups waren nicht wiederherstellbar.** `pg_dump -Fc | gzip` erzeugte einen doppelt komprimierten Custom-Format-Dump, den die dokumentierten `gunzip | psql`-Restores nicht lesen können (psql parst Binärdaten als SQL → Syntaxfehler). Jetzt **Plain-SQL** (`--clean --if-exists`) + gzip → restorebar. Zusätzlich Schreibfehler-/Leerdatei-Guard (truncated Backup wurde sonst als „complete" geloggt + überlebte die Retention → stiller Datenverlust).
- **Onboarding-Modal blockierte den mobilen Stempel-FAB** und flackerte vor `/system/info` auf; bei `/system/info`-Fehler erschien die Tour trotz Admin-Deaktivierung.

## HIGH
- **Reinstall überschrieb `praxiszeit.conf`** (Linux+macOS) → neuer `secret_key` → alle Sessions ungültig + verschlüsselte TOTP-Secrets (Migration 050) unentschlüsselbar (jeder 2FA-Nutzer ausgesperrt). Conf wird jetzt bei Reinstall beibehalten. Macht zugleich die UPDATE.md-Aussage „Config bleibt erhalten" wahr.
- **AdminDashboard-Detailmodal** zeigte bei schnellem Monatswechsel die Daten des falschen Monats (Out-of-order-Fetch ohne Guard).
- **Dashboard-Urlaubstage** wurden client-seitig per Σ(Stunden)÷Ø-Tagessoll genähert → für MA mit ungleichmäßigem Tagesplan systematisch falsch (verletzt Tagesprinzip §3 BUrlG). Jetzt autoritativ vom Backend (`/dashboard/vacation`).
- **Body-Scroll-Lock** (OnboardingModal/DocDrawer/DocModal) hob sich gegenseitig auf → neuer ref-gezählter `bodyScrollLock`.

## MID/LOW
- TOTP-Wrong-Key-Token wird jetzt erkannt + geloggt statt still durchzulaufen.
- seq-Guards in AdminAbsences + VacationApprovals.
- **Doku-Aktualität:** macOS-Uninstall entlädt jetzt auch `de.praxiszeit.backup.plist`; DOCKER-START `.zip`→`.tar.gz`; Versionsbeispiele 1.8.10→1.8.11; Handbuch-Pins 1.8.2→1.8.11; README+Handbuch §3 (10h manuell-vs-live) + Urlaub tagebasiert; setup-anleitung/-windows: cron→systemd-Timer, Lizenz-Prompt entfernt (Beta), SSL ed25519→RSA-2048+serverAuth, Banner auf kanonische Guides.

## Verifiziert
- `tsc --noEmit` clean, **110 vitest** + **6 totp_crypto** pytest grün, `vite build` OK, Installer `bash -n` OK.
- ⚠️ Offen: Backup-Restore-Roundtrip auf einem **Realhost** mit nativem theseus-PG (Unit-Tests decken den Pfad nicht ab) — vor dem nächsten Release auf .131 durchspielen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
