### PR TITLE
fix(login): klarere Falsch-Passwort-Anzeige + Caps-Lock-Hinweis

### DIFF
--- a/frontend/src/components/PasswordInput.test.tsx
+++ b/frontend/src/components/PasswordInput.test.tsx
@@ -82,4 +82,66 @@ describe('PasswordInput', () => {
     expect(input.className).toContain('custom-input');
     expect(input.className).toContain('pr-10');
   });
+
+  it('warns when Caps Lock is active while typing, and clears it again', async () => {
+    const user = userEvent.setup();
+    render(<PasswordInput aria-label="Passwort" />);
+    const input = screen.getByLabelText('Passwort');
+    await user.click(input);
+
+    // No warning before Caps Lock is engaged.
+    expect(screen.queryByText(/Feststelltaste/i)).not.toBeInTheDocument();
+
+    // {CapsLock} toggles the lock on; the trailing key reports the new state.
+    await user.keyboard('{CapsLock}a');
+    expect(screen.getByText(/Feststelltaste/i)).toBeInTheDocument();
+
+    // Toggling Caps Lock off must remove the warning.
+    await user.keyboard('{CapsLock}a');
+    expect(screen.queryByText(/Feststelltaste/i)).not.toBeInTheDocument();
+  });
+
+  it('hides the Caps Lock warning when the field loses focus', async () => {
+    const user = userEvent.setup();
+    render(<PasswordInput aria-label="Passwort" />);
+    const input = screen.getByLabelText('Passwort');
+    await user.click(input);
+    await user.keyboard('{CapsLock}a');
+    expect(screen.getByText(/Feststelltaste/i)).toBeInTheDocument();
+
+    // Blur clears the warning — we can no longer observe the modifier state.
+    await user.tab();
+    expect(screen.queryByText(/Feststelltaste/i)).not.toBeInTheDocument();
+    // Reset the lock so it doesn't leak into the next test.
+    await user.keyboard('{CapsLock}');
+  });
+
+  it('never shows the warning when showCapsLockWarning={false}', async () => {
+    const user = userEvent.setup();
+    render(<PasswordInput aria-label="Passwort" showCapsLockWarning={false} />);
+    const input = screen.getByLabelText('Passwort');
+    await user.click(input);
+    await user.keyboard('{CapsLock}a');
+    expect(screen.queryByText(/Feststelltaste/i)).not.toBeInTheDocument();
+    await user.keyboard('{CapsLock}'); // reset lock state
+  });
+
+  it('still forwards consumer onKeyDown/onBlur handlers', async () => {
+    const user = userEvent.setup();
+    let keyDowns = 0;
+    let blurs = 0;
+    render(
+      <PasswordInput
+        aria-label="Passwort"
+        onKeyDown={() => { keyDowns += 1; }}
+        onBlur={() => { blurs += 1; }}
+      />,
+    );
+    const input = screen.getByLabelText('Passwort');
+    await user.click(input);
+    await user.keyboard('x');
+    await user.tab();
+    expect(keyDowns).toBeGreaterThan(0);
+    expect(blurs).toBe(1);
+  });
 });

--- a/frontend/src/components/PasswordInput.tsx
+++ b/frontend/src/components/PasswordInput.tsx
@@ -1,29 +1,64 @@
 import { useState } from 'react'
-import { Eye, EyeOff } from 'lucide-react'
+import { Eye, EyeOff, AlertTriangle } from 'lucide-react'
 
 interface PasswordInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
   className?: string
+  /**
+   * Show a "Caps Lock is on" warning below the field while it has focus and
+   * Caps Lock is active. Defaults to true — a wrong-case password is the most
+   * common silent login failure. Set false where it would be noise.
+   */
+  showCapsLockWarning?: boolean
 }
 
-export default function PasswordInput({ className = '', ...props }: PasswordInputProps) {
+export default function PasswordInput({
+  className = '',
+  showCapsLockWarning = true,
+  onKeyDown,
+  onKeyUp,
+  onBlur,
+  ...props
+}: PasswordInputProps) {
   const [visible, setVisible] = useState(false)
+  const [capsLockOn, setCapsLockOn] = useState(false)
+
+  // getModifierState is only meaningful on keyboard events, so we sync on both
+  // keydown and keyup (keyup catches the CapsLock key press itself).
+  const syncCapsLock = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (typeof e.getModifierState === 'function') {
+      setCapsLockOn(e.getModifierState('CapsLock'))
+    }
+  }
 
   return (
-    <div className="relative">
-      <input
-        {...props}
-        type={visible ? 'text' : 'password'}
-        className={`${className} pr-10`}
-      />
-      <button
-        type="button"
-        onClick={() => setVisible(v => !v)}
-        className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-400 hover:text-gray-600 focus:outline-hidden"
-        tabIndex={-1}
-        aria-label={visible ? 'Passwort verbergen' : 'Passwort anzeigen'}
-      >
-        {visible ? <EyeOff size={18} /> : <Eye size={18} />}
-      </button>
+    <div>
+      <div className="relative">
+        <input
+          {...props}
+          type={visible ? 'text' : 'password'}
+          className={`${className} pr-10`}
+          onKeyDown={(e) => { syncCapsLock(e); onKeyDown?.(e) }}
+          onKeyUp={(e) => { syncCapsLock(e); onKeyUp?.(e) }}
+          // We can no longer observe the modifier once focus leaves the field,
+          // so clear the warning rather than show a stale one.
+          onBlur={(e) => { setCapsLockOn(false); onBlur?.(e) }}
+        />
+        <button
+          type="button"
+          onClick={() => setVisible(v => !v)}
+          className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-400 hover:text-gray-600 focus:outline-hidden"
+          tabIndex={-1}
+          aria-label={visible ? 'Passwort verbergen' : 'Passwort anzeigen'}
+        >
+          {visible ? <EyeOff size={18} /> : <Eye size={18} />}
+        </button>
+      </div>
+      {showCapsLockWarning && capsLockOn && (
+        <p role="status" className="mt-1.5 flex items-center gap-1 text-xs text-amber-600">
+          <AlertTriangle size={13} aria-hidden="true" />
+          Feststelltaste (Caps&nbsp;Lock) ist aktiviert
+        </p>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -2,7 +2,7 @@ import { useState, FormEvent } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useAuthStore } from '../stores/authStore';
 import { useSystemStore } from '../stores/systemStore';
-import { LogIn, FileText, Shield, Smartphone } from 'lucide-react';
+import { LogIn, FileText, Shield, Smartphone, AlertCircle } from 'lucide-react';
 import PasswordInput from '../components/PasswordInput';
 import { getErrorMessage } from '../utils/errorMessage';
 import { DocModal } from '../components/DocModal';
@@ -14,6 +14,7 @@ export default function Login() {
   const [totpCode, setTotpCode] = useState('');
   const [totpRequired, setTotpRequired] = useState(false);
   const [error, setError] = useState('');
+  const [showCredentialHint, setShowCredentialHint] = useState(false);
   const [loading, setLoading] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalTab, setModalTab] = useState<'cheatsheet' | 'handbuch'>('cheatsheet');
@@ -26,6 +27,7 @@ export default function Login() {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError('');
+    setShowCredentialHint(false);
     setLoading(true);
 
     try {
@@ -40,6 +42,10 @@ export default function Login() {
         setError(
           getErrorMessage(err, 'Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut.')
         );
+        // Show the spelling/Caps-Lock hint only for a plain wrong-credentials
+        // 401. A wrong 2FA code (totpRequired) or a 429 lockout already carry a
+        // specific, self-explanatory message from the backend.
+        setShowCredentialHint(err.response?.status === 401 && !totpRequired);
         if (totpRequired) setTotpCode(''); // Clear wrong TOTP code
       }
     } finally {
@@ -57,8 +63,22 @@ export default function Login() {
 
         <form onSubmit={handleSubmit} className="space-y-6">
           {error && (
-            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
-              {error}
+            <div
+              role="alert"
+              className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm"
+            >
+              <div className="flex items-start gap-2">
+                <AlertCircle size={18} className="mt-0.5 shrink-0" aria-hidden="true" />
+                <div>
+                  <p className="font-medium">{error}</p>
+                  {showCredentialHint && (
+                    <p className="mt-1 text-xs text-red-600">
+                      Bitte prüfen Sie Benutzername und Passwort. Achten Sie auf
+                      Groß-/Kleinschreibung und die Feststelltaste (Caps&nbsp;Lock).
+                    </p>
+                  )}
+                </div>
+              </div>
             </div>
           )}
 


### PR DESCRIPTION
## Problem
Ein User (MGB) meldete „Dashboard lädt nicht". Im Security-Log: **2× `AUTH login_failed user=mgb reason=bad_password`** — tatsächlich ein fehlgeschlagener Login, der in der UI zu unauffällig war.

## Änderung
- **`PasswordInput`**: Live-Caps-Lock-Warnung („Feststelltaste (Caps Lock) ist aktiviert"), solange das Feld Fokus hat. Reusable über alle 6 Passwortfelder (Login, Profil, Signup, Set-Password, UserForm), abschaltbar via `showCapsLockWarning={false}`. Consumer-Handler werden weitergereicht.
- **`Login`**: Fehlerbox mit Icon + `role="alert"`; bei 401 zusätzlicher Hinweis auf Groß-/Kleinschreibung und Caps Lock. Nicht bei falschem 2FA-Code (totpRequired) oder 429-Sperre (haben eigene Backend-Texte).
- Neutrale Backend-Meldung (Anti-Enumeration) **unverändert**.

## Tests
- 4 neue `PasswordInput`-Tests (Caps-Lock an/aus, Blur, opt-out, Handler-Forwarding)
- Frontend-Suite **114/114 grün**, `tsc --noEmit` sauber, ESLint 0 Fehler
- E2E-kompatibel: `login.spec.ts` prüft `.bg-red-50` → Klasse bleibt erhalten

🤖 Generated with [Claude Code](https://claude.com/claude-code)
