### PR TITLE
chore(release): 1.8.13

### DIFF
--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.8.12"
+APP_VERSION = "1.8.13"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.8.12",
+  "version": "1.8.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.8.12",
+      "version": "1.8.13",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "axios": "^1.18.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.8.12",
+  "version": "1.8.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.8.12"
+APP_VERSION="1.8.13"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
## Release 1.8.13

Version-Bump **1.8.12 → 1.8.13** in allen vier Quellen (`backend/app/core/updater.py`, `tools/build-release.sh`, `frontend/package.json` + `package-lock.json`).

### Enthalten
- **#227** `fix(login)`: klarere Falsch-Passwort-Anzeige (Icon + `role="alert"` + Hinweis auf Groß-/Kleinschreibung & Caps Lock) und Live-Caps-Lock-Warnung im `PasswordInput`.

### Hinweis
- `BETA_MODE=True` bleibt unverändert (Lizenzprüfung aus).
- Installer-Artefakte (`build-release.sh`) und pzweb-Shop-Upload sind **nicht** Teil dieses PRs — separater, manueller Schritt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
