### PR TITLE
fix(auth): logout↔refresh-Storm beenden — Dashboard-Hang behoben

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -151,6 +151,26 @@ describe('401 response interceptor', () => {
     await expect(apiClient.post('/auth/login', {})).rejects.toBeTruthy();
     expect(refresh).not.toHaveBeenCalled();
   });
+
+  it('does NOT attempt refresh for /auth/logout 401 (prevents logout↔refresh storm)', async () => {
+    // A 401 on logout must NOT trigger the refresh path. Otherwise:
+    // logout 401 → refresh fails → 'auth:session-expired' → logout() → ∞ loop
+    // (real incident: logout 401 ×382, refresh 429 ×50, dashboard hangs).
+    setAccessToken('stale');
+    const refresh = vi
+      .spyOn(axios, 'post')
+      .mockRejectedValue(new Error('refresh must not be called from logout'));
+    const onExpired = vi.fn();
+    window.addEventListener('auth:session-expired', onExpired);
+
+    apiClient.defaults.adapter = (config) => reply(config, 401);
+
+    await expect(apiClient.post('/auth/logout')).rejects.toBeTruthy();
+    expect(refresh).not.toHaveBeenCalled();
+    // No refresh attempt ⇒ no session-expired re-dispatch ⇒ loop can't form.
+    expect(onExpired).not.toHaveBeenCalled();
+    window.removeEventListener('auth:session-expired', onExpired);
+  });
 });
 
 describe('tryRefreshSession', () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -76,10 +76,19 @@ apiClient.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
-    // Don't intercept auth endpoint errors (login / refresh themselves)
-    // to avoid masking TOTP-required responses or refresh failures.
+    // Don't intercept auth endpoint errors (login / refresh / logout).
+    // - login/refresh: avoid masking TOTP-required responses or refresh failures.
+    // - logout: a 401 here must NOT trigger a refresh. logout() is reached via
+    //   the 'auth:session-expired' handler, so refreshing on a logout 401 (which
+    //   then fails again) re-dispatches 'auth:session-expired' → logout() → an
+    //   infinite logout↔refresh storm that saturates the connection pool and
+    //   hangs every other request (incident: logout 401 ×382, refresh 429 ×50).
     const url: string = originalRequest?.url || '';
-    if (url.includes('/auth/login') || url.includes('/auth/refresh')) {
+    if (
+      url.includes('/auth/login') ||
+      url.includes('/auth/refresh') ||
+      url.includes('/auth/logout')
+    ) {
       return Promise.reject(error);
     }
 

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -150,4 +150,22 @@ describe('auth:session-expired listener', () => {
     });
     expect(post).toHaveBeenCalledWith('/auth/logout');
   });
+
+  it('collapses a burst of session-expired events into a single logout', async () => {
+    useAuthStore.setState({ user: USER as any, isAuthenticated: true, isHydrating: false });
+    post.mockResolvedValue({ data: {} });
+
+    // A broken session fires many events at once (e.g. dashboard's 7 parallel
+    // requests all fail the shared refresh). The re-entrancy guard must turn
+    // this into exactly one server logout.
+    window.dispatchEvent(new CustomEvent('auth:session-expired'));
+    window.dispatchEvent(new CustomEvent('auth:session-expired'));
+    window.dispatchEvent(new CustomEvent('auth:session-expired'));
+
+    await vi.waitFor(() => {
+      expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    });
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith('/auth/logout');
+  });
 });

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -177,8 +177,23 @@ export const useAuthStore = create<AuthState>()(
 
 // Global listener: when the refresh interceptor gives up, clear auth state.
 // This ensures every tab in the same window coordinates via one code path.
+//
+// Defense-in-depth (paired with the /auth/logout interceptor guard): a single
+// broken session can fire MANY 'auth:session-expired' events nearly at once —
+// e.g. the dashboard's 7 parallel requests all fail the shared refresh together.
+// The re-entrancy flag collapses such a burst into ONE logout; otherwise each
+// event would POST /auth/logout again, amplifying the storm. The `!user` check
+// drops events that arrive after we're already logged out (stale in-flight reqs).
 if (typeof window !== 'undefined') {
+  let loggingOut = false;
   window.addEventListener('auth:session-expired', () => {
-    void useAuthStore.getState().logout();
+    if (loggingOut || !useAuthStore.getState().user) return;
+    loggingOut = true;
+    void useAuthStore
+      .getState()
+      .logout()
+      .finally(() => {
+        loggingOut = false;
+      });
   });
 }


### PR DESCRIPTION
## Problem (Feldreport: MGB / Gertraud Boehlkau — "Dashboard lädt nicht")
Die Anwenderin ist eingeloggt, aber das Dashboard hängt dauerhaft auf „Lade Dashboard…". Konsole zeigt `GET /api/me/type-colors → 401`.

## Root Cause — `logout ↔ refresh`-Endlosschleife
Der 401-Refresh-Interceptor (`api/client.ts`) schließt `/auth/login` und `/auth/refresh` aus, **nicht** aber `/auth/logout`. Da `logout()` vom `auth:session-expired`-Handler aufgerufen wird:

```
request 401 → refresh scheitert (429/expired) → 'session-expired' → logout()
  → POST /auth/logout (toter Token) 401 → Interceptor refresh → scheitert
  → 'session-expired' → logout() → ∞
```

Jeder Durchlauf feuert `/auth/logout` + `/auth/refresh` → sättigt das Browser-Connection-Limit (~6/Host) + trippt das Refresh-Rate-Limit. Ein offenes Dashboard hängt, weil seine Requests nie eine Verbindung bekommen → `Promise.all` settled nie → `loading` bleibt `true`.

**Log-Beleg:** `logout` 401 ×382, `refresh` 429 ×50 / 401 ×123. Ein *frischer* Login funktioniert (Login 200 → type-colors 200 → dashboard 200), daher hilft Neu-Login temporär.

## Fix
1. **`/auth/logout` aus dem Refresh-Retry ausschließen** — bricht die Schleife an der Wurzel (logout ist best-effort; ein 401 wird einfach geschluckt).
2. **Re-Entrancy-Guard** am `session-expired → logout`-Listener — ein Event-Schwall (z. B. 7 parallele Dashboard-Requests) wird zu **einem** Logout (defense-in-depth).

## Tests
- `client.test.ts`: logout-401 löst **keinen** Refresh aus (kein Re-Dispatch ⇒ keine Schleife).
- `authStore.test.ts`: 3 rasche `session-expired`-Events ⇒ **1** Logout.
- Vollsuite **116/116** grün, `tsc` sauber, ESLint 0 Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
