### PR TITLE
feat(release): Docker-Backup/Restore-Skripte + windows-zip Dedup-Guard

### DIFF
--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -694,7 +694,11 @@ PTHEOF
                 # in Phase 7 die EXE mit aufnimmt.
                 _setup_exe_dist="${DIST_DIR}/praxiszeit-${APP_VERSION}-setup-windows-x64.exe"
                 cp "${_setup_publish}/PraxisZeit.Setup.exe" "${_setup_exe_dist}"
-                cp "${_setup_publish}/PraxisZeit.Setup.exe" "${WIN_DIR}/setup.exe"
+                # setup.exe wird NICHT in WIN_DIR kopiert: sonst landet die ~500 MB
+                # single-file-EXE (die denselben Payload bereits eingebettet hat) auch
+                # noch in der windows-x64.zip -> Payload doppelt, ZIP ~1 GB statt ~490 MB.
+                # Die setup.exe wird ausschliesslich als eigenes Artefakt
+                # praxiszeit-*-setup-windows-x64.exe ausgeliefert (oben nach DIST kopiert).
                 info "setup.exe: $(du -h "${_setup_exe_dist}" | cut -f1)"
                 rm -rf "${_setup_publish}" "${BUILD_DIR}/tmp-setup-publish.log" "${_payload_zip}"
             else
@@ -726,6 +730,15 @@ PTHEOF
         _win_zip="${DIST_DIR}/praxiszeit-${APP_VERSION}-windows-x64.tar.gz"
     fi
     info "Windows-Paket: $(du -h "$_win_zip" | cut -f1)"
+    # Regression-Guard: die portable/Updater-ZIP darf KEINE setup.exe enthalten
+    # (sonst ist der Payload doppelt drin — siehe Phase 5b). setup.exe wird separat
+    # als praxiszeit-*-setup-windows-x64.exe ausgeliefert.
+    if command -v unzip &>/dev/null && [[ "$_win_zip" == *.zip ]]; then
+        if unzip -Z1 "$_win_zip" 2>/dev/null | grep -qiE '(^|[/\\])setup\.exe$'; then
+            error "windows-x64.zip enthaelt setup.exe — Payload doppelt (~1 GB statt ~490 MB). Build abgebrochen."
+            exit 1
+        fi
+    fi
     if [ -n "${_setup_exe_dist}" ] && [ -f "${_setup_exe_dist}" ]; then
         info "setup.exe (Standalone): $(du -h "${_setup_exe_dist}" | cut -f1)"
     fi
@@ -821,7 +834,9 @@ if [ "$BUILD_DOCKER" = true ]; then
     cp "${REPO_DIR}/docker-compose.ssl.yml"           "${DOCKER_STAGE}/"
     cp "${REPO_DIR}/.env.example"                     "${DOCKER_STAGE}/"
     cp "${REPO_DIR}/tools/docker/generate-secrets.sh" "${DOCKER_STAGE}/generate-secrets.sh"
-    chmod +x "${DOCKER_STAGE}/generate-secrets.sh"
+    cp "${REPO_DIR}/tools/docker/backup.sh"           "${DOCKER_STAGE}/backup.sh"
+    cp "${REPO_DIR}/tools/docker/restore.sh"          "${DOCKER_STAGE}/restore.sh"
+    chmod +x "${DOCKER_STAGE}/generate-secrets.sh" "${DOCKER_STAGE}/backup.sh" "${DOCKER_STAGE}/restore.sh"
 
     # Build-Kontext kopieren (ohne Ballast / ohne evtl. lokale Secrets+Certs).
     # cd ins REPO_DIR -> Pfade in den tar-Excludes sind relativ ("backend/...").
@@ -852,6 +867,19 @@ if [ "$BUILD_DOCKER" = true ]; then
 3. Starten (HTTPS):         docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d --build
    ODER (nur intern, HTTP): in .env ENVIRONMENT=development + COOKIE_SECURE=false setzen, dann
                             docker compose up -d --build
+
+## Datensicherung / Update
+
+Vor jedem Versions-Update die DB der laufenden (alten) Version sichern und nach
+dem Hochziehen der neuen Version wieder einspielen:
+
+    bash backup.sh                                  # -> backups/praxiszeit_<ts>.sql.gz
+    # ... neue Version entpacken, .env + backups/ uebernehmen, Stack starten ...
+    bash restore.sh backups/praxiszeit_<ts>.sql.gz  # DB einspielen
+    docker compose up -d backend                    # Alembic-Migrationen -> Schema auf head
+
+Die Backups sind gzip-komprimierte Plain-SQL-Dumps und lassen sich auch per
+\`gunzip -c <datei>.sql.gz | docker compose exec -T db psql -U praxiszeit praxiszeit\` einspielen.
 
 Volle Anleitung: https://github.com/phash/praxiszeit/blob/master/docs/INSTALL-DOCKER.md
 DOCKEREOF
@@ -899,7 +927,8 @@ EOF
 
 $BUILD_WINDOWS && cat << EOF
   Windows-Installation/Update (empfohlen, ab 1.4.0):
-    1. ZIP entpacken
+    1. praxiszeit-${APP_VERSION}-setup-windows-x64.exe herunterladen
+       (eigenes Artefakt — NICHT in der ZIP enthalten)
     2. setup.exe (als Administrator) doppelklicken
        -> erkennt automatisch Erstinstallation, Update oder Reparatur
 

--- a/tools/docker/backup.sh
+++ b/tools/docker/backup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# PraxisZeit — Docker-DB-Backup (Plain-SQL-Dump + gzip).
+#
+# Erwartet, dass es NEBEN der docker-compose.yml + .env liegt (im Docker-Bundle
+# der Fall). Sichert die LAUFENDE Datenbank nach ./backups/praxiszeit_<ts>.sql.gz.
+#
+# VOR einem Versions-Update ausfuehren (DB der Vorversion sichern), danach mit
+# restore.sh wieder einspielen. Der Stack muss laufen (docker compose up).
+#
+# Format: gzip-komprimierter Plain-SQL-Dump (NICHT pg_dump -Fc — das waere doppelt
+# komprimiert und liesse sich nicht wie dokumentiert per gunzip|psql einspielen).
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [ ! -f .env ]; then
+    echo "FEHLER: .env nicht gefunden — zuerst 'bash generate-secrets.sh' ausfuehren." >&2
+    exit 1
+fi
+
+# DB-Name/-User aus der .env lesen (Default = praxiszeit), ohne die ganze .env zu
+# sourcen (vermeidet Probleme mit Sonderzeichen in anderen Werten).
+PG_USER="$(grep -E '^POSTGRES_USER=' .env | head -1 | cut -d= -f2-)"
+PG_DB="$(grep -E '^POSTGRES_DB=' .env | head -1 | cut -d= -f2-)"
+PG_USER="${PG_USER:-praxiszeit}"
+PG_DB="${PG_DB:-praxiszeit}"
+
+BACKUP_DIR="./backups"
+mkdir -p "$BACKUP_DIR"
+OUT="${BACKUP_DIR}/praxiszeit_$(date +%Y%m%d_%H%M%S).sql.gz"
+
+echo "Sichere Datenbank '${PG_DB}' (User '${PG_USER}') ..."
+if docker compose exec -T db pg_dump -U "$PG_USER" --clean --if-exists "$PG_DB" | gzip > "$OUT"; then
+    # Leeren/abgebrochenen Dump erkennen (1.8.12-Lehre): gzip muss intakt sein und
+    # entpackt mindestens ein Byte liefern, sonst war der Dump nicht erfolgreich.
+    if ! gzip -t "$OUT" 2>/dev/null || [ -z "$(gzip -dc "$OUT" 2>/dev/null | head -c 1)" ]; then
+        echo "FEHLER: Backup ist leer/ungueltig — wird geloescht." >&2
+        rm -f "$OUT"
+        exit 1
+    fi
+    echo "Backup erstellt: ${OUT} ($(du -h "$OUT" | cut -f1))"
+else
+    echo "FEHLER: Backup fehlgeschlagen." >&2
+    rm -f "$OUT"
+    exit 1
+fi

--- a/tools/docker/restore.sh
+++ b/tools/docker/restore.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PraxisZeit — Docker-DB-Restore (Plain-SQL aus gzip-Dump).
+#
+# Spielt ein mit backup.sh erzeugtes praxiszeit_<ts>.sql.gz wieder ein.
+# Erwartet, dass es NEBEN der docker-compose.yml + .env liegt (Docker-Bundle).
+#
+#   bash restore.sh backups/praxiszeit_<ts>.sql.gz
+#
+# Typischer Update-Ablauf:
+#   1. In der ALTEN Version:  bash backup.sh
+#   2. Neue Version entpacken, .env + backups/ uebernehmen, Stack starten
+#   3. In der NEUEN Version:  bash restore.sh backups/praxiszeit_<ts>.sql.gz
+#   4. docker compose up -d backend   (Alembic-Migrationen heben das Schema auf head)
+#
+# Der Stack muss laufen. Der Dump ist mit --clean --if-exists erzeugt, ueberschreibt
+# also die vorhandenen Tabellen.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+FILE="${1:-}"
+if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
+    echo "Aufruf: bash restore.sh <pfad/zu/praxiszeit_*.sql.gz>" >&2
+    exit 1
+fi
+if ! gzip -t "$FILE" 2>/dev/null; then
+    echo "FEHLER: '$FILE' ist kein gueltiges gzip-Archiv." >&2
+    exit 1
+fi
+if [ ! -f .env ]; then
+    echo "FEHLER: .env nicht gefunden — zuerst 'bash generate-secrets.sh' ausfuehren." >&2
+    exit 1
+fi
+
+PG_USER="$(grep -E '^POSTGRES_USER=' .env | head -1 | cut -d= -f2-)"
+PG_DB="$(grep -E '^POSTGRES_DB=' .env | head -1 | cut -d= -f2-)"
+PG_USER="${PG_USER:-praxiszeit}"
+PG_DB="${PG_DB:-praxiszeit}"
+
+echo "Spiele '${FILE}' in Datenbank '${PG_DB}' (User '${PG_USER}') ein ..."
+gunzip -c "$FILE" | docker compose exec -T db psql -U "$PG_USER" -d "$PG_DB"
+echo "Restore abgeschlossen."
+echo "Backend neu starten, damit Migrationen laufen: docker compose up -d backend"


### PR DESCRIPTION
## Was

Zwei Release-Tooling-Verbesserungen an `tools/build-release.sh`, in dieser Session beim 1.8.14-Release aufgefallen:

### 1. Docker-Backup/Restore-Skripte ins Bundle
Das Docker-Bundle (`--docker-only`) lieferte bisher compose + `.env.example` + `generate-secrets.sh`, aber **kein Backup-Tool** — ein Kunde konnte die DB der laufenden Version vor einem Update nicht sichern/zurückspielen.

- **`tools/docker/backup.sh`** — Plain-SQL `pg_dump --clean --if-exists | gzip` → `backups/praxiszeit_<ts>.sql.gz`. Bewusst **kein `-Fc`** (das war der doppelt-komprimiert-Bug aus 1.8.11/#222), erkennt leere/abgebrochene Dumps.
- **`tools/docker/restore.sh`** — `gunzip -c | docker compose exec -T db psql`.
- `build-release.sh` kopiert beide ins Bundle (+`chmod +x`) und dokumentiert den Ablauf `backup → update → restore → docker compose up -d backend` (Migrationen) im `DOCKER-README`.

### 2. `windows-x64.zip` Dedup-Guard
Die portable/Updater-ZIP bettete zusätzlich die ~500 MB große `setup.exe` ein → **~1 GB statt ~490 MB**, Payload doppelt (real bei 1.8.13 **und** 1.8.14 passiert). `setup.exe` wird ausschließlich als eigenes Artefakt `praxiszeit-*-setup-windows-x64.exe` ausgeliefert.

- Phase 5b kopiert die `setup.exe` nicht mehr in die ZIP.
- Regression-Guard bricht den Build ab, falls `setup.exe` doch in der ZIP landet.

## Verifikation

E2e getestet (lokal CachyOS-Docker **und** auf .131 Linux Mint, nativ + Docker):
1.8.13 hochfahren → `backup.sh` → 1.8.14 frisch (neuer Admin geht, alter abgelehnt) → `restore.sh` des 1.8.13-Dumps → **alter Admin loggt ein, neuer weg, Version weiterhin 1.8.14** = DB der Vorversion erhalten. Linux-Tarball gegen 4 Distros validiert. Beide Skripte `bash -n`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
