### PR TITLE
fix(time-entries): #225 Bearbeiten schlägt mit "Input should be None" fehl

### DIFF
--- a/backend/app/schemas/time_entry.py
+++ b/backend/app/schemas/time_entry.py
@@ -1,13 +1,18 @@
 from pydantic import BaseModel, ConfigDict, Field, field_validator, field_serializer
 from typing import Optional, List
-from datetime import date, time, datetime
+# #225: alias `date` so the field literally named `date` does not shadow the type.
+# With `from datetime import date`, a field `date: Optional[date] = None` makes
+# Pydantic 2.13 resolve the annotation in a namespace where `date` is bound to the
+# default `None` → `Optional[None]` == NoneType → every edit rejected with
+# "Input should be None". holiday.py/vacation_request.py already use this alias.
+from datetime import date as date_type, time, datetime
 from app.services.timezone_service import today_local
 from decimal import Decimal
 from uuid import UUID
 
 
 class TimeEntryBase(BaseModel):
-    date: date
+    date: date_type
     start_time: time
     end_time: time
     break_minutes: int = Field(default=0, ge=0)
@@ -39,7 +44,7 @@ class TimeEntryCreate(TimeEntryBase):
 
 
 class TimeEntryUpdate(BaseModel):
-    date: Optional[date] = None
+    date: Optional[date_type] = None
     start_time: Optional[time] = None
     end_time: Optional[time] = None
     break_minutes: Optional[int] = Field(None, ge=0)
@@ -59,7 +64,7 @@ class TimeEntryUpdate(BaseModel):
 class TimeEntryResponse(BaseModel):
     id: UUID
     user_id: UUID
-    date: date
+    date: date_type
     start_time: time
     end_time: Optional[time] = None
     break_minutes: int = Field(default=0, ge=0)

--- a/backend/tests/test_time_entry_schema.py
+++ b/backend/tests/test_time_entry_schema.py
@@ -1,0 +1,53 @@
+"""Regression tests for the TimeEntry request schemas.
+
+Issue #225: editing a time entry failed with HTTP 422 "Input should be None".
+Root cause: in ``TimeEntryUpdate`` the field is literally named ``date`` AND its
+type is ``date`` (``from datetime import date``). With a ``= None`` default,
+Pydantic 2.13's annotation resolution sees ``date`` bound to ``None`` in the
+class namespace, so ``Optional[date]`` collapses to ``Optional[None]`` ==
+``NoneType`` → every non-null date is rejected with ``none_required``.
+
+The frontend always sends ``date`` in the update body, so every edit broke;
+create worked because ``TimeEntryCreate.date`` has no default (no shadowing).
+"""
+
+from datetime import date as _date
+
+from app.schemas.time_entry import (
+    TimeEntryBase,
+    TimeEntryCreate,
+    TimeEntryResponse,
+    TimeEntryUpdate,
+)
+
+
+def test_update_date_annotation_is_not_nonetype():
+    """The resolved field type must be the date type, never NoneType."""
+    assert TimeEntryUpdate.model_fields["date"].annotation is not type(None)
+
+
+def test_update_accepts_a_real_date_string():
+    """#225: a normal edit (date present) must validate, not raise none_required."""
+    m = TimeEntryUpdate(
+        date="2026-06-22",
+        start_time="08:15",
+        end_time="10:53",
+        break_minutes=0,
+        note="",
+    )
+    assert m.date == _date(2026, 6, 22)
+    assert m.start_time.hour == 8 and m.end_time.hour == 10
+
+
+def test_update_date_still_optional():
+    """Partial updates without a date must remain valid (field stays optional)."""
+    m = TimeEntryUpdate(start_time="09:00", end_time="17:00")
+    assert m.date is None
+
+
+def test_create_and_response_date_roundtrip():
+    """Create/Response date fields keep working (no regression)."""
+    c = TimeEntryCreate(date="2026-06-22", start_time="08:00", end_time="16:00")
+    assert c.date == _date(2026, 6, 22)
+    assert TimeEntryBase.model_fields["date"].annotation is _date
+    assert TimeEntryResponse.model_fields["date"].annotation is _date


### PR DESCRIPTION
Fixes #225

## Symptom
Zeiteintrag per Stift bearbeiten → Zeit ändern → Speichern → Toast **„Input should be None"**, keine Speicherung. Anlegen funktioniert; nur Bearbeiten bricht.

## Root Cause — Feldname `date` shadowt den Typ `date`
In `TimeEntryUpdate` heißt das Feld `date` genauso wie der importierte Typ `date` (`from datetime import date`). Durch den `= None`-Default löst **Pydantic 2.13** die Annotation `Optional[date]` in einem Namespace auf, in dem `date` an `None` gebunden ist → `Optional[None]` == `NoneType` → jeder echte Datumswert wird mit `none_required` abgelehnt.

```
TimeEntryUpdate.model_fields['date'].annotation  ->  <class 'NoneType'>   # vorher
```

Das Frontend sendet beim Edit **immer** `date` → jede Bearbeitung scheiterte. Anlegen ging, weil `TimeEntryCreate.date` keinen Default hat (kein Shadowing). `holiday.py`/`vacation_request.py` nutzen den `date as date_type`-Alias bereits — `time_entry.py` hatte ihn vergessen (Inkonsistenz).

## Fix
- `from datetime import date as date_type` + alle date-Feld-Annotationen (Base/Update/Response) auf `date_type`.
- Regressionstest `tests/test_time_entry_schema.py`.

```
TimeEntryUpdate.model_fields['date'].annotation  ->  typing.Optional[datetime.date]   # nachher
```

## Verifikation
Direkt gegen das Schema verifiziert (Red→Green): `none_required` weg, `'2026-06-22'` wird akzeptiert, Feld bleibt optional. ⚠️ Voll-`pytest` braucht Docker (hier nicht verfügbar) → bitte CI/Docker-Suite laufen lassen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
