### PR TITLE
test(deployment-mode): /system/info Leak-Guard um onboarding_enabled ergänzen

### DIFF
--- a/backend/tests/test_deployment_mode.py
+++ b/backend/tests/test_deployment_mode.py
@@ -75,9 +75,12 @@ class TestSystemInfoEndpoint:
 
     def test_response_does_not_leak_internal_state(self, client, onprem_mode):
         # Intentionally tight schema: no env, no ADMIN_EMAIL, no DB status.
+        # onboarding_enabled is a public UI feature-toggle (welcome tour), not
+        # internal state — exposed deliberately so the frontend can branch
+        # pre-login (added with the Onboarding-Admin-Toggle, commit 316ebbf).
         response = client.get("/api/system/info")
         data = response.json()
-        assert set(data.keys()) == {"deployment_mode", "version", "beta"}
+        assert set(data.keys()) == {"deployment_mode", "version", "beta", "onboarding_enabled"}
 
 
 class TestBetaMode:


### PR DESCRIPTION
`/api/system/info` liefert seit `316ebbf` (Onboarding-Admin-Toggle) zusätzlich `onboarding_enabled` (öffentlicher UI-Feature-Toggle, kein interner State). Der Leak-Guard-Test erwartete noch `{deployment_mode, version, beta}` → **rot auf master** (von CI nicht erkannt — PRs laufen nur GitGuardian, kein pytest).

Fix: erwartetes Key-Set um `onboarding_enabled` ergänzt. Verifiziert: `pytest tests/test_deployment_mode.py` → 9 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
