### PR TITLE
docs(claude-md): Versions-Header auf 1.8.15

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.8.14 (Stand 2026-06-22)
+**Aktuelle Version:** 1.8.15 (Stand 2026-06-22)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---


### PR DESCRIPTION
Currency-Bump des CLAUDE.md-Headers nach Release 1.8.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)