### PR TITLE
fix(installer): #217 Dienst vor Re-Installation stoppen (Text file busy)

### DIFF
--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -257,6 +257,19 @@ fi
 info "Erstelle Verzeichnisse..."
 mkdir -p "${INSTALL_DIR}"/{bin,app,data/db,data/backups,config/ssl,logs}
 
+# Issue #217: Bei einer Re-Installation/Update ueber eine noch LAUFENDE Instanz
+# sind die gebuendelten Binaries (postgres, python3.13) gemappt -> "Text file
+# busy", und das folgende cp scheitert semi-stumm. Darum den Dienst – falls
+# vorhanden und aktiv – vorher stoppen (wird am Ende wieder gestartet). Stoppt
+# zugleich die als Kind laufende PostgreSQL, sodass die Binaries frei sind.
+if systemctl is-active --quiet "${SERVICE_NAME}" 2>/dev/null; then
+    info "Bestehender Dienst '${SERVICE_NAME}' laeuft — wird fuer das Update gestoppt..."
+    systemctl stop "${SERVICE_NAME}"
+    # Kurze Pause: das als Kind laufende postgres gibt die gemappten Binaries
+    # erst nach dem Cgroup-Stop frei (sonst vereinzelt weiter "Text file busy").
+    sleep 2
+fi
+
 info "Kopiere Anwendungsdateien..."
 # The installer package should contain these directories at the same level
 if [ -d "${SCRIPT_DIR}/bin" ]; then


### PR DESCRIPTION
## Problem (#217)

`installer/linux/install.sh` über eine **laufende** Instanz scheitert semi-stumm:

```
[INFO] Kopiere Anwendungsdateien...
cp: cannot create regular file '/opt/praxiszeit/bin/postgresql/bin/postgres': Text file busy
cp: cannot create regular file '/opt/praxiszeit/bin/python/bin/python3.13': Text file busy
```

Die gebündelten Binaries sind im laufenden Dienst gemappt → `cp` bricht ab, der Rest läuft inkonsistent weiter.

## Fix

Vor dem Kopieren der Anwendungsdateien wird ein bereits **aktiver** Dienst automatisch gestoppt:

```bash
if systemctl is-active --quiet "${SERVICE_NAME}" 2>/dev/null; then
    info "Bestehender Dienst '${SERVICE_NAME}' laeuft — wird fuer das Update gestoppt..."
    systemctl stop "${SERVICE_NAME}"
    sleep 2   # Kind-PostgreSQL gibt die gemappten Binaries erst nach Cgroup-Stop frei
fi
```

Der Dienst wird am Ende der Installation ohnehin wieder gestartet.

## Verifikation

E2e auf realem Host (.131, Linux Mint, laufendes natives 1.8.14): Re-Install über den laufenden Dienst → Log zeigt „wird fuer das Update gestoppt", **kein** „Text file busy", Exit 0, Dienst danach `active`, Login `200`.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)
