### PR TITLE
fix(deps): #139 tzdata buendeln (ZoneInfoNotFound auf Minimal-Images)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -42,3 +42,9 @@ xlwt==1.3.0
 # Issue #126: Daily-Jobs (lifecycle, vacation-audit-purge) via BackgroundScheduler.
 # Pin to 3.x — 4.x is async-only and would require rewriting the registered jobs.
 apscheduler==3.*
+# Issue #139: tzdata gebuendelt mitliefern. zoneinfo (timezone_service.py:
+# ZoneInfo("Europe/Berlin")) braucht eine IANA-DB. Auf Minimal-/Container-/Cloud-
+# Images fehlt das OS-/usr/share/zoneinfo -> harter Boot-Crash (ZoneInfoNotFound).
+# Das pip-Paket liefert die DB als zoneinfo-Fallback mit -> OS-unabhaengig, landet
+# im Docker-Image UND im nativen Bundle (build-release pip-Install).
+tzdata>=2025.1


### PR DESCRIPTION
## Problem (#139)

`timezone_service.py` lädt `ZoneInfo("Europe/Berlin")` beim Import. `zoneinfo` braucht eine IANA-Zeitzonen-DB. Auf **minimalen** Images (Container/Cloud) ohne OS-`/usr/share/zoneinfo` crasht der uvicorn-Start hart:

```
zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key Europe/Berlin'
```

## Fix

`tzdata>=2025.1` zu `backend/requirements.txt` (die vom Issue empfohlene, robusteste Option): das pip-Paket liefert die IANA-DB als `zoneinfo`-Fallback **OS-unabhängig** mit — landet im Docker-Image, im nativen Linux-Bundle (build-release pip-Install) und im macOS-Install-pip.

## Verifikation

`python:3.13-slim`, System-TZ-Pfad geleert (`zoneinfo.reset_tzpath([])`):
- **ohne** `tzdata`: `ZoneInfoNotFoundError` (= der #139-Crash)
- **mit** `tzdata`: `ZoneInfo("Europe/Berlin")` → OK

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
