### PR TITLE
fix(api): #120 404 statt 403 bei fremden Same-Tenant-Ressourcen

### DIFF
--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -509,7 +509,9 @@ def delete_absence(
 
     # Check permissions
     if absence.user_id != current_user.id and current_user.role != UserRole.ADMIN:
-        raise HTTPException(status_code=403, detail="Zugriff verweigert")
+        # #120: 404 statt 403 — fremde (Same-Tenant-)Abwesenheit wird wie eine
+        # unbekannte behandelt, kein Existenz-Leak via Response-Code.
+        raise HTTPException(status_code=404, detail="Abwesenheit nicht gefunden")
 
     # DSGVO Art. 5 Abs. 2: Audit-Log vor Löschung
     audit = TimeEntryAuditLog(

--- a/backend/app/routers/change_requests.py
+++ b/backend/app/routers/change_requests.py
@@ -62,7 +62,8 @@ def create_change_request(
             if not absence:
                 raise HTTPException(status_code=404, detail="Abwesenheit nicht gefunden")
             if absence.user_id != current_user.id:
-                raise HTTPException(status_code=403, detail="Zugriff verweigert")
+                # #120: 404 statt 403 — kein Existenz-Leak fremder Abwesenheiten.
+                raise HTTPException(status_code=404, detail="Abwesenheit nicht gefunden")
 
         # For CREATE/UPDATE: validate required fields
         if data.request_type in ("create", "update"):
@@ -151,7 +152,8 @@ def create_change_request(
         if not entry:
             raise HTTPException(status_code=404, detail="Zeiteintrag nicht gefunden")
         if entry.user_id != current_user.id:
-            raise HTTPException(status_code=403, detail="Zugriff verweigert")
+            # #120: 404 statt 403 — kein Existenz-Leak fremder Zeiteintraege.
+            raise HTTPException(status_code=404, detail="Zeiteintrag nicht gefunden")
 
     # For CREATE, proposed values are required
     if data.request_type == "create":
@@ -356,7 +358,8 @@ def get_change_request(
     if not cr:
         raise HTTPException(status_code=404, detail="Antrag nicht gefunden")
     if cr.user_id != current_user.id and current_user.role != UserRole.ADMIN:
-        raise HTTPException(status_code=403, detail="Zugriff verweigert")
+        # #120: 404 statt 403 — kein Existenz-Leak fremder Antraege.
+        raise HTTPException(status_code=404, detail="Antrag nicht gefunden")
     return _enrich_response(cr, db)
 
 
@@ -371,7 +374,8 @@ def withdraw_change_request(
     if not cr:
         raise HTTPException(status_code=404, detail="Antrag nicht gefunden")
     if cr.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Zugriff verweigert")
+        # #120: 404 statt 403 — kein Existenz-Leak fremder Antraege.
+        raise HTTPException(status_code=404, detail="Antrag nicht gefunden")
     if cr.status != ChangeRequestStatus.PENDING:
         raise HTTPException(status_code=400, detail="Nur offene Anträge können zurückgezogen werden")
 

--- a/backend/app/routers/vacation_requests.py
+++ b/backend/app/routers/vacation_requests.py
@@ -442,7 +442,10 @@ def update_vacation_request(
     if not vr:
         raise HTTPException(status_code=404, detail="Urlaubsantrag nicht gefunden")
     if str(vr.user_id) != str(current_user.id):
-        raise HTTPException(status_code=403, detail="Zugriff verweigert")
+        # #120: 404 statt 403 — ein fremder (Same-Tenant-)Antrag wird wie ein
+        # unbekannter behandelt, damit der Response-Code nicht die Existenz einer
+        # fremden VR-ID im eigenen Tenant verraet (gleiche Meldung wie "not found").
+        raise HTTPException(status_code=404, detail="Urlaubsantrag nicht gefunden")
     if vr.status != VacationRequestStatus.PENDING.value:
         raise HTTPException(
             status_code=400,
@@ -485,7 +488,10 @@ def withdraw_vacation_request(
     if not vr:
         raise HTTPException(status_code=404, detail="Urlaubsantrag nicht gefunden")
     if str(vr.user_id) != str(current_user.id):
-        raise HTTPException(status_code=403, detail="Zugriff verweigert")
+        # #120: 404 statt 403 — ein fremder (Same-Tenant-)Antrag wird wie ein
+        # unbekannter behandelt, damit der Response-Code nicht die Existenz einer
+        # fremden VR-ID im eigenen Tenant verraet (gleiche Meldung wie "not found").
+        raise HTTPException(status_code=404, detail="Urlaubsantrag nicht gefunden")
 
     if vr.status == VacationRequestStatus.PENDING.value:
         db.delete(vr)

--- a/backend/tests/test_vacation_request_cancel.py
+++ b/backend/tests/test_vacation_request_cancel.py
@@ -222,14 +222,15 @@ class TestEmployeeWithdraw:
         resp = employee_client.delete(f"/api/vacation-requests/{vr.id}")
         assert resp.status_code == 400
 
-    def test_withdraw_foreign_request_forbidden(
+    def test_withdraw_foreign_request_returns_404(
         self, db, employee, other_employee, other_employee_client
     ):
-        """Fremden Antrag zurückziehen → 403, auch wenn selbes Tenant."""
+        """#120: Fremden Antrag zurückziehen → 404 (wie unbekannt), auch im
+        selben Tenant — kein Existenz-Leak via Response-Code."""
         vr = _vr(db, employee, VacationRequestStatus.PENDING.value,
                  date.today() + timedelta(days=30))
         resp = other_employee_client.delete(f"/api/vacation-requests/{vr.id}")
-        assert resp.status_code == 403
+        assert resp.status_code == 404
 
     def test_withdraw_only_matching_absence_type_is_deleted(
         self, db, employee, employee_client

--- a/backend/tests/test_vacation_request_edit.py
+++ b/backend/tests/test_vacation_request_edit.py
@@ -228,14 +228,17 @@ class TestEmployeeEdit:
         ).count()
         assert audits == 0
 
-    def test_edit_foreign_request_forbidden(
+    def test_edit_foreign_request_returns_404(
         self, db, employee, other_employee, other_employee_client
     ):
+        # #120: Ein fremder Antrag im selben Tenant wird wie ein unbekannter
+        # behandelt (404 statt 403) — der Response-Code verraet die Existenz
+        # einer fremden VR-ID nicht.
         vr = _vr(db, employee)
         resp = other_employee_client.patch(
             f"/api/vacation-requests/{vr.id}", json={"note": "hack"}
         )
-        assert resp.status_code == 403
+        assert resp.status_code == 404
 
     def test_edit_approved_rejected(self, db, employee, employee_client):
         vr = _vr(db, employee, status_val=VacationRequestStatus.APPROVED.value)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -19,3 +19,20 @@ Use this section to tell people how to report a vulnerability.
 Tell them where to go, how often they can expect to get an update on a
 reported vulnerability, what to expect if the vulnerability is accepted or
 declined, etc.
+
+## API-Konvention: 404 statt 403 bei fremden Ressourcen (#120)
+
+Greift ein Nutzer auf eine Ressource zu, die zwar in seinem Tenant existiert,
+aber **einem anderen Nutzer gehört** (Owner-Check schlägt fehl), antwortet die
+API mit **404 „nicht gefunden"** — nicht mit 403 — und mit **derselben Meldung**
+wie bei einer unbekannten ID. So verrät der Response-Code nicht die Existenz
+einer fremden Ressourcen-ID im eigenen Tenant (kein Enumeration-Oracle, RFC-7235-
+konform; konsistent mit den Admin-Endpoints, die foreign-Tenant ebenfalls 404
+geben). Betrifft die Owner-Checks in `vacation_requests.py`, `absences.py` und
+`change_requests.py`.
+
+**Weiterhin 403** (kein Existenz-Leak) bei reinen **Rollen-/Rechte-Checks**, die
+keine konkrete fremde Ressource referenzieren — z. B. ein Nicht-Admin, der über
+einen Query-Parameter fremde Daten filtern oder eine Ressource für einen anderen
+Nutzer anlegen will (`require_admin`, `absences.py`-`user_id`-Filter/-Anlage).
+


### PR DESCRIPTION
## Problem (#120)

Owner-Check-Fehlschläge lieferten **403** für eine Ressource, die im eigenen Tenant **existiert**, aber einem anderen Nutzer gehört — während unbekannte IDs **404** geben. Der unterschiedliche Code ist ein Enumeration-Oracle (verrät die Existenz fremder IDs) und inkonsistent mit den Admin-Endpoints (foreign-tenant = 404).

## Änderung

7 Owner-Checks auf **bereits geladene** Ressourcen → **404** mit derselben „nicht gefunden"-Meldung wie bei unbekannter ID:
- `vacation_requests.py`: update + withdraw
- `absences.py`: delete
- `change_requests.py`: Absence-CR-Anlage, TimeEntry-CR-Anlage, `get`, `withdraw`

**Bewusst weiter 403** (reine Rollen-/Rechte-Checks, kein Existenz-Leak):
- `absences.py`: Nicht-Admin filtert per `user_id`-Query bzw. legt Abwesenheit für fremden Nutzer an.

`docs/SECURITY.md` um die Konvention ergänzt. Bestehende Tests (foreign → 404) aktualisiert.

## Verifikation

`praxiszeit-backend`-Image, SQLite:
- `test_vacation_request_edit.py` + `test_vacation_request_cancel.py` + `test_absence_cr.py` → **57 passed**
- `test_endpoints.py` (Rollen-403 müssen bleiben) → **44 passed**

## Breaking change

Ja — Response-Code für unautorisierten Zugriff auf fremde own-resources ändert sich 403 → 404. Clients, die auf 403 prüfen, müssen 404 erwarten.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
