### PR TITLE
refactor(frontend): #151 gemeinsamer User-Typ statt 4 Duplikate

### DIFF
--- a/frontend/src/pages/admin/ImportXls.tsx
+++ b/frontend/src/pages/admin/ImportXls.tsx
@@ -4,6 +4,7 @@ import apiClient from '../../api/client';
 import { useToast } from '../../contexts/ToastContext';
 import { useConfirm } from '../../hooks/useConfirm';
 import ConfirmDialog from '../../components/ConfirmDialog';
+import type { User } from '../../types/user';
 
 // ── Typen ────────────────────────────────────────────────────────────────────
 
@@ -29,14 +30,6 @@ interface ImportResult {
   skipped: number;
   overwritten: number;
   warnings: string[];
-}
-
-interface User {
-  id: string;
-  first_name: string;
-  last_name: string;
-  username: string;
-  is_active: boolean;
 }
 
 type WizardStep = 'upload' | 'preview' | 'result';

--- a/frontend/src/pages/admin/Users.tsx
+++ b/frontend/src/pages/admin/Users.tsx
@@ -14,44 +14,7 @@ import CarryoverModal from './users/CarryoverModal';
 import WorkingHoursModal from './users/WorkingHoursModal';
 import UserForm from './users/UserForm';
 
-interface User {
-  id: string;
-  username: string;
-  email: string | null;
-  first_name: string;
-  last_name: string;
-  role: 'admin' | 'employee';
-  weekly_hours: number;
-  vacation_days: number;
-  work_days_per_week: number;
-  suggested_vacation_days?: number;
-  track_hours: boolean;
-  exempt_from_arbzg: boolean;
-  is_night_worker: boolean;
-  receives_company_closures: boolean;
-  use_daily_schedule: boolean;
-  hours_monday: number | null;
-  hours_tuesday: number | null;
-  hours_wednesday: number | null;
-  hours_thursday: number | null;
-  hours_friday: number | null;
-  scheduled_start_monday: string | null;
-  scheduled_end_monday: string | null;
-  scheduled_start_tuesday: string | null;
-  scheduled_end_tuesday: string | null;
-  scheduled_start_wednesday: string | null;
-  scheduled_end_wednesday: string | null;
-  scheduled_start_thursday: string | null;
-  scheduled_end_thursday: string | null;
-  scheduled_start_friday: string | null;
-  scheduled_end_friday: string | null;
-  first_work_day: string | null;
-  last_work_day: string | null;
-  is_active: boolean;
-  is_hidden: boolean;
-  deactivated_at: string | null;
-  created_at: string;
-}
+import type { User } from '../../types/user';
 
 interface VacationInfo {
   budget_days: number;

--- a/frontend/src/pages/admin/users/UserForm.tsx
+++ b/frontend/src/pages/admin/users/UserForm.tsx
@@ -7,45 +7,7 @@ import PasswordInput from '../../../components/PasswordInput';
 import { getErrorMessage } from '../../../utils/errorMessage';
 import { parseHours } from '../../../utils/formatters';
 
-interface User {
-  id: string;
-  username: string;
-  email: string | null;
-  first_name: string;
-  last_name: string;
-  role: 'admin' | 'employee';
-  weekly_hours: number;
-  vacation_days: number;
-  work_days_per_week: number;
-  suggested_vacation_days?: number;
-  track_hours: boolean;
-  exempt_from_arbzg: boolean;
-  is_night_worker: boolean;
-  receives_company_closures: boolean;
-  use_daily_schedule: boolean;
-  hours_monday: number | null;
-  hours_tuesday: number | null;
-  hours_wednesday: number | null;
-  hours_thursday: number | null;
-  hours_friday: number | null;
-  scheduled_start_monday: string | null;
-  scheduled_end_monday: string | null;
-  scheduled_start_tuesday: string | null;
-  scheduled_end_tuesday: string | null;
-  scheduled_start_wednesday: string | null;
-  scheduled_end_wednesday: string | null;
-  scheduled_start_thursday: string | null;
-  scheduled_end_thursday: string | null;
-  scheduled_start_friday: string | null;
-  scheduled_end_friday: string | null;
-  first_work_day: string | null;
-  last_work_day: string | null;
-  department?: string | null;
-  is_active: boolean;
-  is_hidden: boolean;
-  deactivated_at: string | null;
-  created_at: string;
-}
+import type { User } from '../../../types/user';
 
 interface UserFormProps {
   editUser: User | null;

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,32 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import apiClient, { setAccessToken, tryRefreshSession } from '../api/client';
-
-interface User {
-  id: string;
-  username: string;
-  email: string | null;
-  first_name: string;
-  last_name: string;
-  role: 'admin' | 'employee';
-  weekly_hours: number;
-  work_days_per_week: number;
-  vacation_days: number;
-  calendar_color: string;
-  track_hours: boolean;
-  exempt_from_arbzg: boolean;  // §18 ArbZG: leitende Angestellte
-  is_active: boolean;
-  totp_enabled: boolean;
-  profile_picture?: string | null;
-  onboarding_completed_at?: string | null;  // NULL = Onboarding noch nicht gesehen
-  created_at: string;
-  use_daily_schedule: boolean;
-  hours_monday: number | null;
-  hours_tuesday: number | null;
-  hours_wednesday: number | null;
-  hours_thursday: number | null;
-  hours_friday: number | null;
-}
+import type { User } from '../types/user';
 
 interface AuthState {
   user: User | null;

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,0 +1,50 @@
+// Issue #151: Eine gemeinsame User-Definition statt drei-/vierfacher Duplikate
+// (authStore, UserForm, Users, ImportXls). Superset passend zum Backend
+// UserListResponse/UserResponse (backend/app/schemas/user.py). Felder, die nicht
+// in JEDER Response enthalten sind (Login liefert z. B. kein profile_picture),
+// sind optional markiert.
+export interface User {
+  id: string;
+  username: string;
+  email: string | null;
+  first_name: string;
+  last_name: string;
+  role: 'admin' | 'employee';
+  weekly_hours: number;
+  vacation_days: number;
+  work_days_per_week: number;
+  track_hours: boolean;
+  exempt_from_arbzg: boolean; // §18 ArbZG: leitende Angestellte
+  is_night_worker: boolean;
+  receives_company_closures: boolean;
+  is_active: boolean;
+  is_hidden: boolean;
+  calendar_color: string;
+  totp_enabled: boolean;
+  use_daily_schedule: boolean;
+  hours_monday: number | null;
+  hours_tuesday: number | null;
+  hours_wednesday: number | null;
+  hours_thursday: number | null;
+  hours_friday: number | null;
+  scheduled_start_monday: string | null;
+  scheduled_end_monday: string | null;
+  scheduled_start_tuesday: string | null;
+  scheduled_end_tuesday: string | null;
+  scheduled_start_wednesday: string | null;
+  scheduled_end_wednesday: string | null;
+  scheduled_start_thursday: string | null;
+  scheduled_end_thursday: string | null;
+  scheduled_start_friday: string | null;
+  scheduled_end_friday: string | null;
+  first_work_day: string | null;
+  last_work_day: string | null;
+  deactivated_at: string | null;
+  created_at: string;
+  // Nicht in jeder Response enthalten:
+  suggested_vacation_days?: number;
+  department?: string | null;
+  profile_picture?: string | null; // aus Login-Response ausgeschlossen (~690 KB)
+  onboarding_completed_at?: string | null; // NULL = Onboarding noch nicht gesehen
+  vacation_carryover_deadline?: string | null;
+}


### PR DESCRIPTION
## Problem (#151)

Das `User`-Interface war **vierfach** definiert (`authStore`, `Users`, `UserForm`, `ImportXls`) und driftete auseinander — `authStore` war schmaler (ohne `is_night_worker`, `first/last_work_day`, `is_hidden`, `deactivated_at`, `scheduled_*`), sodass der Store beim Self-Edit ein schmaleres `/auth/me`-Payload bekam als gerade gesendet.

## Fix

Neu: **`frontend/src/types/user.ts`** mit einem `User`-Superset passend zum Backend `UserListResponse`/`UserResponse`. Felder, die nicht in jeder Response stecken (`profile_picture`, `onboarding_completed_at`, `suggested_vacation_days`, `department`, `vacation_carryover_deadline`), sind optional. Alle 4 Stellen importieren ihn.

Räumt zugleich den Hauptbefund aus **#219** (Code-Duplication) ab.

## Verifikation

- `npx tsc --noEmit` → **fehlerfrei**
- `npx vitest run` → **116/116 grün**

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)
