### PR TITLE
perf(frontend): #147 Code-Splitting der /admin/*-Routen + Help

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, lazy } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { useAuthStore } from './stores/authStore';
 import { useSystemStore } from './stores/systemStore';
@@ -11,20 +11,22 @@ import Dashboard from './pages/Dashboard';
 import TimeTracking from './pages/TimeTracking';
 import AbsenceCalendarPage from './pages/AbsenceCalendarPage';
 import Profile from './pages/Profile';
-import AdminDashboard from './pages/admin/AdminDashboard';
-import Users from './pages/admin/Users';
-import AdminChangeRequests from './pages/admin/ChangeRequests';
-import Reports from './pages/admin/Reports';
-import AuditLog from './pages/admin/AuditLog';
-import AdminAbsences from './pages/admin/AdminAbsences';
-import ErrorMonitoring from './pages/admin/ErrorMonitoring';
-import VacationApprovals from './pages/admin/VacationApprovals';
-import ImportXls from './pages/admin/ImportXls';
-import AdminSettings from './pages/admin/Settings';
-import AdminBilling from './pages/admin/Billing';
-import UserJournal from './pages/admin/UserJournal';
-import Help from './pages/Help';
 import Privacy from './pages/Privacy';
+// #147: Admin-Routen + Help per Code-Splitting lazy laden -> kleineres
+// Initial-Bundle. Der Suspense-Fallback liegt in Layout um den <Outlet />.
+const AdminDashboard = lazy(() => import('./pages/admin/AdminDashboard'));
+const Users = lazy(() => import('./pages/admin/Users'));
+const AdminChangeRequests = lazy(() => import('./pages/admin/ChangeRequests'));
+const Reports = lazy(() => import('./pages/admin/Reports'));
+const AuditLog = lazy(() => import('./pages/admin/AuditLog'));
+const AdminAbsences = lazy(() => import('./pages/admin/AdminAbsences'));
+const ErrorMonitoring = lazy(() => import('./pages/admin/ErrorMonitoring'));
+const VacationApprovals = lazy(() => import('./pages/admin/VacationApprovals'));
+const ImportXls = lazy(() => import('./pages/admin/ImportXls'));
+const AdminSettings = lazy(() => import('./pages/admin/Settings'));
+const AdminBilling = lazy(() => import('./pages/admin/Billing'));
+const UserJournal = lazy(() => import('./pages/admin/UserJournal'));
+const Help = lazy(() => import('./pages/Help'));
 import Layout from './components/Layout';
 import ErrorBoundary from './components/ErrorBoundary';
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, Suspense } from 'react';
 import { Outlet, Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../stores/authStore';
 import { useUIStore } from '../stores/uiStore';
@@ -409,7 +409,17 @@ export default function Layout() {
       <main id="main-content" className="flex-1 overflow-y-auto overflow-x-hidden lg:pt-0 pt-16 pb-20 lg:pb-0 bg-background" tabIndex={-1}>
         <TrialBanner />
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 lg:py-8">
-          <Outlet />
+          {/* #147: Lazy-geladene Routen (admin/* + Help) -> Suspense nur um den
+              Content, damit die Sidebar beim Chunk-Laden stehen bleibt. */}
+          <Suspense
+            fallback={
+              <div role="status" aria-live="polite" className="py-12 text-center text-gray-500">
+                Lädt…
+              </div>
+            }
+          >
+            <Outlet />
+          </Suspense>
         </div>
       </main>
 


### PR DESCRIPTION
## Problem (#147)

Alle `/admin/*`-Seiten + die schwere `Help`-Seite (In-App-Handbuch) lagen statisch im Initial-Bundle (~745–800 KB).

## Fix

- `/admin/*` (12 Seiten) + `Help` via `React.lazy()` als eigene Chunks.
- `Suspense`-Fallback in `Layout` **um den `<Outlet />`** → nur der Content-Bereich zeigt „Lädt…", die Sidebar bleibt stehen.

## Effekt (`npm run build`)

- Initial-Chunk **802 KB → 522 KB** (gzip **201 → 142 KB**)
- Admin-Seiten als On-Demand-Chunks (Users 52 / AdminDashboard 42 / Reports 30 / AdminAbsences 22 / Settings 21 KB …)

## Verifikation

`tsc --noEmit` fehlerfrei · `vitest` **116/116 grün**.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
