### PR TITLE
perf(backend): #150 O(Monate²)/N+1 in Overtime-Dashboard + Monatsreport

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.orm import Session
 from datetime import datetime, date, timedelta
+from decimal import Decimal
 from typing import List, Optional
 from app.database import get_db
 from app.models import User, TimeEntry, UserRole
@@ -143,6 +144,12 @@ def get_overtime_account(
     history = []
     now = now_local()
 
+    # #150: das kumulative Konto EINMAL als Single-Pass holen, statt
+    # get_overtime_account pro Monat zu rufen (jede Einzelrufung iteriert ab
+    # Carryover-Start neu -> O(Monate²)). history_map[(y,m)] entspricht bitgenau
+    # get_overtime_account(y,m) (gepinnt: test_overtime_history_matches_account).
+    history_map = calculation_service.get_overtime_history(db, current_user, now.year, now.month)
+
     if first_entry:
         start_year = first_entry.date.year
         start_month = first_entry.date.month
@@ -155,7 +162,7 @@ def get_overtime_account(
             target = calculation_service.get_monthly_target(db, current_user, current_year, current_month)
             actual = calculation_service.get_monthly_actual(db, current_user, current_year, current_month)
             balance = actual - target
-            cumulative = calculation_service.get_overtime_account(db, current_user, current_year, current_month)
+            cumulative = history_map.get((current_year, current_month), Decimal('0.00'))
 
             history.append(OvertimeHistory(
                 year=current_year,
@@ -174,9 +181,7 @@ def get_overtime_account(
                 current_month += 1
 
     # Current balance
-    current_balance = calculation_service.get_overtime_account(
-        db, current_user, now.year, now.month
-    )
+    current_balance = history_map.get((now.year, now.month), Decimal('0.00'))
 
     return OvertimeAccount(
         current_balance=current_balance,

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -77,7 +77,9 @@ def get_monthly_report(
     for user in users:
         target = calculation_service.get_monthly_target(db, user, year, month_num)
         actual = calculation_service.get_monthly_actual(db, user, year, month_num)
-        balance = calculation_service.get_monthly_balance(db, user, year, month_num)
+        # #150: target/actual sind bereits berechnet — get_monthly_balance würde
+        # beide pro User redundant neu laden. Identisch zu dessen (actual-target).quantize.
+        balance = (actual - target).quantize(Decimal('0.01'))
         overtime = calculation_service.get_overtime_account(db, user, year, month_num)
 
         # Get vacation and sick hours for the month (F-033: sargable)

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -561,6 +561,145 @@ def get_overtime_account(db: Session, user: User, up_to_year: int, up_to_month: 
     return total_balance.quantize(Decimal('0.01'))
 
 
+def get_overtime_history(
+    db: Session, user: User, up_to_year: int, up_to_month: int
+) -> Dict[tuple, Decimal]:
+    """Kumulatives Überstundenkonto NACH jedem Monat (Start..up_to) in EINEM Pass.
+
+    Invariante: für jeden Monat (y, m) im Bereich gilt
+        get_overtime_history(...)[(y, m)] == get_overtime_account(db, user, y, m)
+    (gepinnt durch test_overtime_history_matches_account). #150: damit baut das
+    Dashboard seine Monats-History in O(Monate) statt get_overtime_account pro
+    Monat zu rufen (O(Monate²), weil jede Einzelrufung ab Carryover-Start neu
+    iteriert). Leeres Dict bei track_hours=False / keinen Daten.
+
+    Wie get_overtime_account ist ein YearCarryover ein Reset-Punkt: im Januar
+    eines Jahres MIT eigenem Carryover startet der laufende Saldo neu vom
+    Carryover-Wert (spiegelt die "latest carryover <= year"-Auswahl der
+    Einzelfunktion).
+    """
+    if not user.track_hours:
+        return {}
+
+    up_to_date = date(up_to_year, up_to_month, monthrange(up_to_year, up_to_month)[1])
+
+    carryovers: Dict[int, Decimal] = {
+        c.year: Decimal(str(c.overtime_hours))
+        for c in db.query(YearCarryover).filter(YearCarryover.user_id == user.id).all()
+    }
+
+    first_entry = db.query(TimeEntry).filter(
+        TimeEntry.user_id == user.id
+    ).order_by(TimeEntry.date).first()
+    if first_entry is None and not carryovers:
+        return {}
+
+    if first_entry is not None:
+        fe_year, fe_month = first_entry.date.year, first_entry.date.month
+    else:
+        fe_year, fe_month = min(carryovers), 1
+
+    # Start-Punkt = der Carryover, den get_overtime_account fuer den ersten Monat
+    # waehlen wuerde (latest <= fe_year), sonst der erste Time-Entry.
+    applicable = [y for y in carryovers if y <= fe_year]
+    if applicable:
+        start_year, start_month = max(applicable), 1
+        initial_balance = carryovers[start_year]
+    else:
+        start_year, start_month = fe_year, fe_month
+        initial_balance = Decimal('0.00')
+
+    start_date = date(start_year, start_month, 1)
+
+    # --- ein Bulk-Fetch ueber den ganzen Bereich (wie get_overtime_account) ---
+    actual_by_month: Dict[tuple, Decimal] = {}
+    for e in db.query(TimeEntry).filter(
+        TimeEntry.user_id == user.id,
+        TimeEntry.date >= start_date,
+        TimeEntry.date <= up_to_date,
+    ).all():
+        if not _within_employment_window(user, e.date):
+            continue
+        k = (e.date.year, e.date.month)
+        actual_by_month[k] = actual_by_month.get(k, Decimal('0')) + Decimal(str(e.net_hours))
+
+    for ca in db.query(Absence).filter(
+        Absence.user_id == user.id,
+        Absence.date >= start_date,
+        Absence.date <= up_to_date,
+        Absence.type.in_([AbsenceType.TRAINING, AbsenceType.SICK]),
+    ).all():
+        if not _within_employment_window(user, ca.date):
+            continue
+        k = (ca.date.year, ca.date.month)
+        actual_by_month[k] = actual_by_month.get(k, Decimal('0')) + Decimal(str(ca.hours))
+
+    absence_dates = {a.date for a in db.query(Absence).filter(
+        Absence.user_id == user.id,
+        Absence.date >= start_date,
+        Absence.date <= up_to_date,
+        Absence.type.notin_([AbsenceType.TRAINING, AbsenceType.SICK, AbsenceType.OVERTIME]),
+    ).all()}
+
+    holiday_dates = {h.date for h in db.query(PublicHoliday).filter(
+        PublicHoliday.date >= start_date,
+        PublicHoliday.date <= up_to_date,
+        PublicHoliday.tenant_id == user.tenant_id,
+    ).all()}
+
+    wh_changes = db.query(WorkingHoursChange).filter(
+        WorkingHoursChange.user_id == user.id,
+    ).order_by(WorkingHoursChange.effective_from).all()
+
+    special_day_configs: Dict[int, dict] = {}
+
+    def _cfg(yr: int) -> dict:
+        c = special_day_configs.get(yr)
+        if c is None:
+            c = special_days_service.get_special_day_config(db, user.tenant_id, yr)
+            special_day_configs[yr] = c
+        return c
+
+    history: Dict[tuple, Decimal] = {}
+    total_balance = initial_balance
+    cy, cm = start_year, start_month
+
+    while (cy < up_to_year) or (cy == up_to_year and cm <= up_to_month):
+        # Reset im Januar eines Jahres mit eigenem Carryover (ausser dem Start).
+        if cm == 1 and cy in carryovers and (cy, cm) != (start_year, start_month):
+            total_balance = carryovers[cy]
+
+        _, last_day = monthrange(cy, cm)
+        cfg = _cfg(cy)
+        monthly_target = Decimal('0')
+        for day in range(1, last_day + 1):
+            d = date(cy, cm, day)
+            if d.weekday() >= 5:
+                continue
+            if not _within_employment_window(user, d):
+                continue
+            if d in holiday_dates or d in absence_dates:
+                continue
+            weekly_hours = get_weekly_hours_for_date(db, user, d, wh_changes=wh_changes)
+            daily_target = get_daily_target_for_date(user, d, weekly_hours)
+            factor = special_days_service.special_day_target_factor(d, cfg)
+            if factor is not None:
+                daily_target = daily_target * factor
+            monthly_target += daily_target
+
+        monthly_actual = actual_by_month.get((cy, cm), Decimal('0'))
+        total_balance += (monthly_actual - monthly_target)
+        history[(cy, cm)] = total_balance.quantize(Decimal('0.01'))
+
+        if cm == 12:
+            cm = 1
+            cy += 1
+        else:
+            cm += 1
+
+    return history
+
+
 def get_ytd_summary(db: Session, user: User, year: int = None) -> Dict:
     """
     Calculate year-to-date summary from Jan 1 to today.

--- a/backend/tests/test_calculations_extended.py
+++ b/backend/tests/test_calculations_extended.py
@@ -401,3 +401,60 @@ def test_overtime_account_cumulates_across_months(db, test_user):
     assert result < Decimal('0')
     # Verify both months are included: if only Jan were counted, result would be > -175
     assert result < Decimal('-175')
+
+
+# ---------------------------------------------------------------------------
+# #150: get_overtime_history (Single-Pass) muss bitgenau get_overtime_account
+# pro Monat reproduzieren — sonst aendert das Dashboard payroll-relevante Zahlen.
+# ---------------------------------------------------------------------------
+def test_overtime_history_matches_account(db, test_user):
+    """history[(y,m)] == get_overtime_account(y,m) fuer JEDEN Monat im Bereich —
+    ueber zwei Jahre hinweg, inkl. YearCarryover-Reset zum 2025-Jahreswechsel."""
+    from app.models import YearCarryover
+
+    def add_entry(d, start, end, brk=60):
+        db.add(TimeEntry(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID,
+                         date=d, start_time=start, end_time=end, break_minutes=brk))
+
+    # 2024 (vor jedem Carryover) + 2025 (nach Carryover-Reset), gemischte Stunden.
+    add_entry(date(2024, 11, 4), time(8, 0), time(17, 0))   # Mo 8h
+    add_entry(date(2024, 11, 5), time(8, 0), time(18, 30))  # Di 9.5h
+    add_entry(date(2024, 12, 2), time(8, 0), time(16, 0))   # Mo 7h
+    add_entry(date(2025, 1, 6), time(8, 0), time(19, 0))    # Mo 10h
+    add_entry(date(2025, 2, 3), time(8, 0), time(16, 30))   # Mo 7.5h
+    db.add(YearCarryover(tenant_id=DEFAULT_TENANT_ID, user_id=test_user.id,
+                         year=2025, overtime_hours=Decimal('12.50'),
+                         vacation_days=Decimal('0')))
+    db.commit()
+
+    history = calculation_service.get_overtime_history(db, test_user, 2025, 3)
+    assert history, "history darf nicht leer sein"
+    # Deckt den ganzen Anzeigebereich ab (erster Eintrag 2024-11 .. up_to 2025-03).
+    assert (2024, 11) in history and (2025, 3) in history
+    # Bitgenaue Gleichheit pro Monat gegen die (langsame) Einzelfunktion.
+    for (y, m), cumulative in history.items():
+        expected = calculation_service.get_overtime_account(db, test_user, y, m)
+        assert cumulative == expected, f"{y}-{m:02d}: history {cumulative} != account {expected}"
+
+
+def test_overtime_history_matches_account_no_carryover(db, test_user):
+    """Gleiche Invariante ohne jeden Carryover (Start ab erstem Time-Entry)."""
+    db.add(TimeEntry(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID,
+                     date=date(2025, 1, 6), start_time=time(8, 0), end_time=time(18, 0),
+                     break_minutes=60))
+    db.add(TimeEntry(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID,
+                     date=date(2025, 3, 3), start_time=time(8, 0), end_time=time(15, 0),
+                     break_minutes=30))
+    db.commit()
+
+    history = calculation_service.get_overtime_history(db, test_user, 2025, 3)
+    assert history
+    for (y, m), cumulative in history.items():
+        assert cumulative == calculation_service.get_overtime_account(db, test_user, y, m)
+
+
+def test_overtime_history_empty_untracked(db, test_user):
+    """track_hours=False -> leeres Dict (wie get_overtime_account 0.00 liefert)."""
+    test_user.track_hours = False
+    db.commit()
+    assert calculation_service.get_overtime_history(db, test_user, 2025, 3) == {}


### PR DESCRIPTION
## Problem (#150)

- **Dashboard** rief `calculation_service.get_overtime_account` **pro Monat** in der History-Schleife; jede Einzelrufung iteriert ab Carryover-Start neu → **O(Monate²)** + wiederholte Bulk-Fetches.
- **Monatsreport** berechnete pro User `target`+`actual` und rief danach `get_monthly_balance`, das `target`+`actual` **nochmal** lädt.

## Fix

- **Neu `get_overtime_history()`** — kumulatives Konto nach jedem Monat in **einem** Pass (ein Bulk-Fetch; `YearCarryover` als Reset-Punkt, exakt wie `get_overtime_account`). Dashboard holt es einmal, schlägt pro Monat nur noch nach → **O(Monate)**.
- **Reports**: `balance = (actual - target).quantize(0.01)` aus den schon geladenen Werten statt `get_monthly_balance` → 2 schwere Calls je User gespart.

## Sicherheit (payroll-relevant!)

Die Zahlen dürfen sich **nicht** ändern. `get_overtime_history[(y,m)] == get_overtime_account(y,m)` ist bitgenau gepinnt durch **`test_overtime_history_matches_account`** (Zwei-Jahres-Spanne **mit** Carryover-Reset), plus No-Carryover- und untracked-Varianten. `get_monthly_balance` ist definitionsgemäß `(actual-target).quantize(0.01)`.

## Verifikation

`test_calculations` + `test_calculations_extended` + `test_dashboard_track_hours` + `test_paid_leave_reports` → **50 passed**.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
