### PR TITLE
feat(security): #121 Audit-Log Tamper-Evidence (per-Row-HMAC) v1

### DIFF
--- a/backend/alembic/versions/2026_06_22_1200-051_add_audit_row_hash.py
+++ b/backend/alembic/versions/2026_06_22_1200-051_add_audit_row_hash.py
@@ -1,0 +1,33 @@
+"""Add time_entry_audit_logs.row_hash for tamper-evidence (#121).
+
+Per-row HMAC over the audit row content, keyed by a SECRET_KEY-derived value
+(see app/core/audit_integrity.py). Nullable: pre-existing rows have no hash and
+are reported as 'legacy' (not 'tampered') by /api/admin/audit/verify-integrity.
+
+No key-dependent data backfill — it would silently no-op if SECRET_KEY were
+absent at migrate time (same reasoning as migration 050). New rows get a hash
+automatically via the SQLAlchemy before_insert event on the model.
+
+Revision ID: 051_add_audit_row_hash
+Revises: 050_widen_totp_secret
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '051_add_audit_row_hash'
+down_revision = '050_widen_totp_secret'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'time_entry_audit_logs',
+        sa.Column('row_hash', sa.String(64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('time_entry_audit_logs', 'row_hash')

--- a/backend/app/core/audit_integrity.py
+++ b/backend/app/core/audit_integrity.py
@@ -1,0 +1,85 @@
+"""Tamper-evidence for ``time_entry_audit_logs`` (#121, Security-Review P4.2).
+
+Each audit row carries a per-row HMAC (``row_hash``) over its integrity-relevant
+content, keyed by a value DERIVED from ``SECRET_KEY`` via HKDF-SHA256 (same
+pattern as ``app/core/totp_crypto.py``). The key therefore lives OUTSIDE the
+database — ``SECRET_KEY`` is persisted in ``config/.secret-key`` / the
+environment, never in a table — so an attacker who can only WRITE rows (e.g. via
+an SQL-injection elsewhere) cannot forge a valid ``row_hash``, and any post-hoc
+MODIFICATION of an existing audit row's content is detected by
+``GET /api/admin/audit/verify-integrity``.
+
+Scope / limits (v1):
+
+* Detects: modification of audit content + forged rows (without the key). ``id``
+  is part of the hash, so a valid (content, hash) pair cannot be replayed under
+  a different id.
+* ``created_at`` is intentionally NOT hashed (DB-assigned timestamp; excluding it
+  avoids serialization round-trip false-positives between Postgres and the
+  SQLite test engine).
+* A strict ``prev_hash`` hash-CHAIN (which would additionally detect row
+  DELETION via gaps) is deferred: it needs per-tenant insert serialization to
+  avoid concurrency forks. DSGVO Art. 17 deletion intentionally leaves a gap —
+  acceptable per #121.
+* Rotating ``SECRET_KEY`` makes existing ``row_hash`` values unverifiable (same
+  blast radius as session invalidation). Legacy rows (``row_hash IS NULL``,
+  written before this feature) are reported as ``legacy``, not ``tampered``.
+"""
+import hashlib
+import hmac
+import logging
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Versioned context label — changing it (or SECRET_KEY) invalidates old hashes.
+_HKDF_INFO = b"praxiszeit-audit-row-hmac-v1"
+
+# Integrity-relevant fields that round-trip cleanly (UUID/date/time/int/str).
+# created_at is excluded on purpose (see module docstring).
+_HASHED_FIELDS = (
+    "id", "tenant_id", "time_entry_id", "user_id", "changed_by",
+    "action", "source",
+    "old_date", "old_start_time", "old_end_time", "old_break_minutes", "old_note",
+    "new_date", "new_start_time", "new_end_time", "new_break_minutes", "new_note",
+    "change_request_id",
+)
+
+
+def _audit_key() -> bytes:
+    """Derive the 32-byte HMAC key from SECRET_KEY. Cheap (a few hash ops) — not
+    cached so tests that monkeypatch SECRET_KEY get the matching key."""
+    return HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=_HKDF_INFO,
+    ).derive(settings.SECRET_KEY.encode("utf-8"))
+
+
+def _canonical(audit) -> bytes:
+    # NULL und der Leerstring duerfen NICHT kollidieren -> NULL als Sentinel.
+    parts = []
+    for field in _HASHED_FIELDS:
+        value = getattr(audit, field, None)
+        parts.append("\x00" if value is None else str(value))
+    return "|".join(parts).encode("utf-8")
+
+
+def compute_row_hash(audit) -> str:
+    """HMAC-SHA256 hex digest (64 chars) ueber den integritaetsrelevanten Inhalt."""
+    return hmac.new(_audit_key(), _canonical(audit), hashlib.sha256).hexdigest()
+
+
+def verify_row(audit) -> bool:
+    """True wenn der gespeicherte row_hash zum neu berechneten passt.
+
+    Nur fuer Rows MIT row_hash aufrufen (Legacy-Rows ohne Hash sind nicht
+    verifizierbar). Nutzt compare_digest (konstante Zeit)."""
+    return bool(audit.row_hash) and hmac.compare_digest(
+        audit.row_hash, compute_row_hash(audit)
+    )

--- a/backend/app/models/time_entry_audit_log.py
+++ b/backend/app/models/time_entry_audit_log.py
@@ -1,8 +1,11 @@
-from sqlalchemy import Column, String, Date, Time, Integer, Text, DateTime, ForeignKey
+from sqlalchemy import Column, String, Date, Time, Integer, Text, DateTime, ForeignKey, event
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
+import logging
 import uuid
 from app.database import Base
+
+logger = logging.getLogger(__name__)
 
 
 class TimeEntryAuditLog(Base):
@@ -42,5 +45,28 @@ class TimeEntryAuditLog(Base):
 
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
+    # #121: Tamper-Evidence. HMAC-SHA256 (64 Hex-Zeichen) ueber den Row-Inhalt,
+    # mit einem aus SECRET_KEY abgeleiteten Schluessel (siehe app/core/
+    # audit_integrity.py). Nullable: vor diesem Feature geschriebene Rows haben
+    # keinen Hash ("legacy", nicht "tampered").
+    row_hash = Column(String(64), nullable=True)
+
     def __repr__(self):
         return f"<TimeEntryAuditLog(id={self.id}, action={self.action}, user_id={self.user_id})>"
+
+
+@event.listens_for(TimeEntryAuditLog, "before_insert")
+def _audit_set_row_hash(mapper, connection, target):
+    """#121: Bei jedem Insert den row_hash berechnen — zentral hier, statt an den
+    ~15 Audit-Insert-Stellen. id muss vorher feststehen (wird in den Hash gebunden,
+    damit ein gueltiges (Inhalt, Hash)-Paar nicht unter neuer id replayt werden
+    kann); der Python-Default uuid4 ist zur before_insert-Zeit nicht garantiert
+    gesetzt. Lazy-Import, damit das Model-Modul nicht app.config zieht."""
+    if target.id is None:
+        target.id = uuid.uuid4()
+    try:
+        from app.core import audit_integrity
+        target.row_hash = audit_integrity.compute_row_hash(target)
+    except Exception:  # pragma: no cover - ein Hash-Fehler darf den Audit-Insert NIE kippen
+        logger.exception("audit row_hash konnte nicht berechnet werden")
+        target.row_hash = None

--- a/backend/app/routers/admin_time_entries.py
+++ b/backend/app/routers/admin_time_entries.py
@@ -379,3 +379,49 @@ def list_audit_log(
             .all()
         )
     return _enrich_audit_responses(logs, db)
+
+
+@router.get("/audit/verify-integrity")
+def verify_audit_integrity(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    """#121: Tamper-Evidence-Check aller Audit-Rows des Tenants.
+
+    Berechnet pro Row den HMAC neu (Schluessel aus SECRET_KEY abgeleitet) und
+    vergleicht ihn mit dem gespeicherten ``row_hash``. Eine nachtraegliche
+    Manipulation einer Audit-Row (z. B. via SQL-Injection an anderer Stelle)
+    bricht den Hash -> ``tampered``. Vor dem Feature geschriebene Rows ohne Hash
+    sind ``legacy_unhashed`` (nicht verifizierbar, NICHT als Manipulation
+    gewertet). ``intact`` ist true, wenn keine gehashte Row manipuliert wurde.
+    """
+    from app.core import audit_integrity
+
+    checked = ok = tampered = legacy = 0
+    tampered_ids: list[str] = []
+    # F-026: explizit auf den Tenant scopen (zusaetzlich zu RLS). yield_per haelt
+    # den Speicher bei sehr grossen Audit-Tabellen klein.
+    rows = (
+        db.query(TimeEntryAuditLog)
+        .filter(TimeEntryAuditLog.tenant_id == current_user.tenant_id)
+        .yield_per(500)
+    )
+    for row in rows:
+        checked += 1
+        if not row.row_hash:
+            legacy += 1
+        elif audit_integrity.verify_row(row):
+            ok += 1
+        else:
+            tampered += 1
+            if len(tampered_ids) < 100:  # Antwort begrenzen
+                tampered_ids.append(str(row.id))
+
+    return {
+        "checked": checked,
+        "ok": ok,
+        "tampered": tampered,
+        "legacy_unhashed": legacy,
+        "intact": tampered == 0,
+        "tampered_ids": tampered_ids,
+    }

--- a/backend/tests/test_audit_integrity.py
+++ b/backend/tests/test_audit_integrity.py
@@ -1,0 +1,88 @@
+"""#121: Tamper-Evidence der time_entry_audit_logs (HMAC row_hash)."""
+import re
+from datetime import date, time
+
+from app.core import audit_integrity
+from app.models import TimeEntryAuditLog
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _make_audit(db, test_user, test_admin, **overrides):
+    fields = dict(
+        tenant_id=DEFAULT_TENANT_ID,
+        user_id=test_user.id,
+        changed_by=test_admin.id,
+        action="update",
+        source="manual",
+        old_date=date(2026, 1, 6),
+        old_start_time=time(8, 0),
+        old_end_time=time(16, 0),
+        old_break_minutes=30,
+        old_note="vorher",
+        new_date=date(2026, 1, 6),
+        new_start_time=time(8, 0),
+        new_end_time=time(17, 0),
+        new_break_minutes=60,
+        new_note="nachher",
+    )
+    fields.update(overrides)
+    audit = TimeEntryAuditLog(**fields)
+    db.add(audit)
+    db.commit()
+    db.refresh(audit)
+    return audit
+
+
+def test_before_insert_sets_row_hash(db, test_user, test_admin):
+    """Der before_insert-Event setzt automatisch einen 64-stelligen Hex-Hash."""
+    audit = _make_audit(db, test_user, test_admin)
+    assert audit.row_hash is not None
+    assert re.fullmatch(r"[0-9a-f]{64}", audit.row_hash)
+
+
+def test_compute_row_hash_deterministic(db, test_user, test_admin):
+    audit = _make_audit(db, test_user, test_admin)
+    assert audit_integrity.compute_row_hash(audit) == audit_integrity.compute_row_hash(audit)
+
+
+def test_verify_intact_row(db, test_user, test_admin):
+    audit = _make_audit(db, test_user, test_admin)
+    assert audit_integrity.verify_row(audit) is True
+
+
+def test_verify_detects_content_tampering(db, test_user, test_admin):
+    """Nachtraegliche Aenderung des Inhalts (ohne Re-Hash — es gibt KEINEN
+    before_update-Event) bricht die Verifikation."""
+    audit = _make_audit(db, test_user, test_admin)
+    assert audit_integrity.verify_row(audit) is True
+
+    audit.new_note = "HEIMLICH GEAENDERT"
+    db.commit()
+    db.refresh(audit)
+    # row_hash blieb der alte -> Inhalt passt nicht mehr.
+    assert audit.row_hash is not None
+    assert audit_integrity.verify_row(audit) is False
+
+
+def test_verify_detects_forged_hash(db, test_user, test_admin):
+    audit = _make_audit(db, test_user, test_admin)
+    audit.row_hash = "0" * 64  # geraten/gefaelscht ohne Schluessel
+    assert audit_integrity.verify_row(audit) is False
+
+
+def test_id_is_bound_into_hash(db, test_user, test_admin):
+    """Gleicher Inhalt, andere id -> anderer Hash (verhindert Replay unter neuer id)."""
+    a = _make_audit(db, test_user, test_admin)
+    import uuid
+    h_other_id = audit_integrity.compute_row_hash(
+        type("X", (), {**{f: getattr(a, f) for f in audit_integrity._HASHED_FIELDS}, "id": uuid.uuid4()})()
+    )
+    assert h_other_id != a.row_hash
+
+
+def test_legacy_row_without_hash_not_verifiable(db, test_user, test_admin):
+    """Eine Row ohne row_hash (Legacy / vor dem Feature) gilt als nicht
+    verifizierbar — verify_row False, aber NICHT als Manipulation zu werten."""
+    audit = _make_audit(db, test_user, test_admin)
+    audit.row_hash = None
+    assert audit_integrity.verify_row(audit) is False

--- a/docs/specs/security/audit-tamper-resistance.md
+++ b/docs/specs/security/audit-tamper-resistance.md
@@ -1,9 +1,39 @@
 # Audit-Log Tamper-Resistance — Design-Spec
 
 **Issue:** [#121](https://github.com/phash/praxiszeit/issues/121)
-**Status:** Vorschlag · zur Entscheidung
-**Autor:** Claude Opus 4.7
-**Datum:** 24. Mai 2026
+**Status:** **v1 umgesetzt** (per-Row-HMAC) · Hash-CHAIN aufgeschoben
+**Autor:** Claude Opus 4.7 (Design) · Opus 4.8 (v1-Umsetzung)
+**Datum:** 24. Mai 2026 (Design) · 22. Juni 2026 (v1)
+
+---
+
+## Umgesetzt (v1) — was wirklich shipped
+
+v1 implementiert eine **bewusst vereinfachte Variante von Option B**: einen
+**Per-Row-HMAC** (`row_hash`) **ohne** den `prev_hash`-Chain-Teil. Code:
+`backend/app/core/audit_integrity.py`, `backend/tests/test_audit_integrity.py`,
+Migration `051_add_audit_row_hash`.
+
+| Aspekt | Proposal unten (Option B) | v1 (umgesetzt) |
+|---|---|---|
+| Hash pro Row | ✅ `row_hash` | ✅ `row_hash` (HMAC-SHA256, 64 hex) |
+| `prev_hash`-Chain (Löschungs-Detection) | ✅ | ⏸ **aufgeschoben** (Concurrency-Forks ohne Pro-Tenant-Serialisierung) |
+| Schlüssel | separater `AUDIT_HMAC_KEY` / `.audit-hmac-key` | **aus `SECRET_KEY` via HKDF** abgeleitet (kein neues Key-File; Muster wie `totp_crypto.py`) |
+| Hash-Berechnung | `sign_and_insert`-Helper an ~12 Stellen | zentral im `before_insert`-Event (keine Call-Site-Änderung) |
+| Verify | Cron + Tabelle | **Online-Endpoint** `GET /api/admin/audit/verify-integrity` (require_admin, F-026) |
+| `created_at` im Hash | ja | **nein** (DB-Zeitstempel → Round-Trip-Fehlalarm-Risiko zwischen PG/SQLite); `id` ist gebunden |
+
+**Erkannt:** Modifikation von Audit-Inhalt + gefälschte Rows (ohne Schlüssel kein
+gültiger Hash). **Nicht erkannt (v1):** Löschung einzelner Rows (kein Chain-Glied).
+Legacy-Rows ohne Hash gelten als `legacy_unhashed`, nicht `tampered`. `SECRET_KEY`-
+Rotation macht Hashes unverifizierbar (Blast-Radius wie Session-Invalidierung).
+
+**Folge-Schritte (offen):** voller `prev_hash`-Chain (Löschungs-Detection, braucht
+`SELECT … FOR UPDATE` auf den Tenant-Chain-Tail + Bulk-Insert-Sonderpfad),
+optional Append-Only-Role (Option A) als Defense-in-Depth, Cron-Verify + Admin-UI-Card.
+
+Der Rest dieses Dokuments ist die ursprüngliche Options-Abwägung (Stand 05/2026)
+und bleibt als Entscheidungs-Record erhalten.
 
 ---
 


### PR DESCRIPTION
## Problem (#121)

`time_entry_audit_logs` hatte **keinen Integritätsschutz nach dem Schreiben** — eine SQL-Injection an anderer Stelle könnte mit `praxiszeit_app`-Rechten Audit-Rows nachträglich ändern/fälschen. Der interne Review nannte das fälschlich „tamper-resistant".

## v1 — bewusst vereinfachte Option B

- **`row_hash VARCHAR(64)`** (Migration `051`, nullable → Legacy-Rows ohne Hash bleiben lesbar).
- **HMAC-SHA256** über den integritätsrelevanten Row-Inhalt; Schlüssel via **HKDF-SHA256 aus `SECRET_KEY`** abgeleitet (Muster wie `totp_crypto.py`) → liegt außerhalb der DB, kein neues Key-File. `id` ist mitgehasht (kein Replay unter neuer id); `created_at` bewusst **nicht** (DB-Zeitstempel → Round-Trip-Fehlalarme PG↔SQLite).
- Berechnung **zentral im `before_insert`-Event** (keine Änderung an den ~15 Audit-Insert-Stellen); ein Hash-Fehler kippt den Audit-Insert nie.
- **Verify:** `GET /api/admin/audit/verify-integrity` (`require_admin`, F-026, `yield_per`) → `{checked, ok, tampered, legacy_unhashed, intact, tampered_ids}`.

**Erkannt:** Inhalts-Manipulation + gefälschte Rows. **Aufgeschoben** (dokumentiert in der Spec): voller `prev_hash`-Chain (Löschungs-Detection — braucht Pro-Tenant-Insert-Serialisierung) + optionaler Append-Only-Role (Defense-in-Depth). DSGVO Art. 17-Löschung hinterlässt gewollt eine Lücke.

## Migration

`051_add_audit_row_hash` — `add_column row_hash VARCHAR(64) NULL`. Kein key-abhängiger Backfill (würde ohne `SECRET_KEY` zur Migrationszeit no-op-en); neue Rows werden automatisch gehasht. **Auf Prod-PG als Standard-Release-Schritt anwenden.**

## Verifikation

`test_audit_integrity` (7: Event setzt Hash, Determinismus, intakt verifiziert, Inhalts-Tampering/Forgery/id-Swap erkannt, Legacy nicht verifizierbar) + audit-erzeugende Tests (`vacation_cancel`, `absence_cr`) → **31 passed**.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)
