### PR TITLE
chore(deps): #175 Prometheus v2.54 (EOL) -> v3.12.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,9 @@ services:
   prometheus:
     # F-037: pinned to a specific minor version for reproducible builds.
     # Bump deliberately via Dependabot/Renovate, not via `docker pull`.
-    image: prom/prometheus:v2.54.1
+    # #175: v2.54 war seit 2024-09 EOL -> auf v3 LTS-Linie. Config ist minimal
+    # (global + ein scrape-job) und v3-kompatibel (promtool check config gruen).
+    image: prom/prometheus:v3.12.0
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus


### PR DESCRIPTION
## #175 (Teil-Fix)

`prom/prometheus:v2.54.1` war seit 2024-09 EOL → auf **v3.12.0** gehoben. Unsere `prometheus.yml` ist minimal (global + ein scrape-job); `promtool check config` (v3.12.0) → **SUCCESS**.

Offen (bewusst, im Issue dokumentiert):
- **PG 16.13→16.14:** blockiert (theseus-rs hat keinen 16.14.0-Tag).
- **workalendar→python-holidays:** großer Umbau (16 Bundesländer gegen-testen), separat.
- PyJWT 2.13.* bereits gepinnt.

`#175` bleibt offen für die verbleibenden Posten.

Refs #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
