### PR TITLE
feat(native): #177 libxml2.so.2 ins Linux-Bundle (Rolling-Distro-Support)

### DIFF
--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -107,15 +107,17 @@ install_runtime_deps() {
     fi
 
     # Rolling-Distro-Soname-Check: theseus' postgres linkt gegen libxml2.so.2.
-    # Arch/CachyOS liefern ab libxml2 2.14 nur noch libxml2.so.16 -> der
-    # PG-Start wuerde mit "libxml2.so.2: cannot open shared object file"
-    # scheitern. Frueh + klar abbrechen statt im Dienst-Crash-Loop zu landen.
+    # Arch/CachyOS liefern ab libxml2 2.14 nur noch libxml2.so.16.
+    # #177: Das Bundle bringt libxml2.so.2 jetzt in bin/postgresql/lib/ mit (PG
+    # findet sie via RPATH/LD_LIBRARY_PATH). Daher NUR abbrechen, wenn WEDER das
+    # Bundle NOCH das System die .so.2 hat (frueh + klar statt opaker Crash-Loop).
     ldcache=$(ldconfig -p 2>/dev/null || true)   # nach apt/dnf/zypper/pacman neu einlesen
-    if ! grep -qE "^[[:space:]]*libxml2\.so\.2\b" <<<"$ldcache"; then
-        error "libxml2.so.2 ist auf diesem System nicht verfuegbar."
-        error "Vermutlich eine Rolling-Distro (z.B. Arch/CachyOS) mit libxml2 >= 2.14"
-        error "(nur libxml2.so.16). Die mitgelieferte PostgreSQL benoetigt aber"
-        error "libxml2.so.2. Unterstuetzt: Debian 12+, Ubuntu 22.04+, RHEL/Rocky/Alma 9+."
+    bundled_libxml2="$(cd "$(dirname "$0")" && pwd)/bin/postgresql/lib/libxml2.so.2"
+    if [ ! -f "$bundled_libxml2" ] && ! grep -qE "^[[:space:]]*libxml2\.so\.2\b" <<<"$ldcache"; then
+        error "libxml2.so.2 fehlt — weder im Bundle (bin/postgresql/lib/) noch im System."
+        error "Vermutlich ein unvollstaendiges Paket auf einer Rolling-Distro (Arch/CachyOS)."
+        error "Unterstuetzt: Debian 12+, Ubuntu 22.04+, RHEL/Rocky/Alma 9+ (System-libxml2),"
+        error "Rolling-Distros via gebuendelte libxml2.so.2."
         exit 1
     fi
 }

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -567,6 +567,37 @@ if [ "$BUILD_LINUX" = true ]; then
     fi
     info "PostgreSQL ${POSTGRESQL_VERSION} entpackt (glibc-2.34-portabel)"
 
+    # #177: theseus-PG linkt libxml2.so.2; Rolling-Distros (Arch/CachyOS) liefern
+    # nur noch libxml2.so.16 -> PG laedt nicht (Crash-Loop). libxml2.so.2 aus
+    # rockylinux:9 buendeln (glibc-2.34, gebaut OHNE ICU -> nur base libs
+    # libz/liblzma/libm/libc), abgelegt in bin/postgresql/lib/, das pg_env() per
+    # LD_LIBRARY_PATH-Prepend findet -> Native-Install wird distro-unabhaengig.
+    if command -v docker &>/dev/null; then
+        info "Buendle libxml2.so.2 (Rolling-Distro-Support, #177)..."
+        if docker run --rm rockylinux:9 sh -c \
+                'dnf install -y -q libxml2 >/dev/null 2>&1 && cat "$(readlink -f /usr/lib64/libxml2.so.2)"' \
+                > "${LINUX_DIR}/bin/postgresql/lib/libxml2.so.2" 2>/dev/null \
+           && [ -s "${LINUX_DIR}/bin/postgresql/lib/libxml2.so.2" ]; then
+            # Sanity: glibc <= Baseline (sonst wuerde es die unterstuetzten Distros
+            # brechen) — derselbe Check wie fuer das postgres-Binary.
+            if ! check_glibc_compat "${LINUX_DIR}/bin/postgresql/lib/libxml2.so.2"; then
+                error "Gebuendeltes libxml2.so.2 ueberschreitet die glibc-Baseline — Abbruch."
+                exit 1
+            fi
+            # Defensive: keine ICU-Abhaengigkeit (sonst kaskadiert das Soname-Problem)
+            if command -v objdump &>/dev/null && objdump -p "${LINUX_DIR}/bin/postgresql/lib/libxml2.so.2" 2>/dev/null | grep -qi 'libicu'; then
+                error "Gebuendeltes libxml2.so.2 haengt an ICU — falsche Quelle, Abbruch."
+                exit 1
+            fi
+            info "libxml2.so.2 gebuendelt ($(du -h "${LINUX_DIR}/bin/postgresql/lib/libxml2.so.2" | cut -f1), glibc-2.34, ohne ICU)"
+        else
+            rm -f "${LINUX_DIR}/bin/postgresql/lib/libxml2.so.2"
+            warn "libxml2.so.2 konnte nicht gebuendelt werden — Rolling-Distros bleiben unsupported (install.sh-Fail-Fast greift)."
+        fi
+    else
+        warn "docker fehlt -> libxml2.so.2 NICHT gebuendelt (#177); Rolling-Distros bleiben unsupported."
+    fi
+
     info "Erstelle Tarball..."
     tar -czf "${DIST_DIR}/praxiszeit-${APP_VERSION}-linux-x64.tar.gz" \
         -C "${LINUX_DIR}" .

--- a/tools/validate-release.sh
+++ b/tools/validate-release.sh
@@ -32,6 +32,10 @@ DISTROS=(
     "ubuntu:22.04"
     "debian:12"
     "rockylinux:9"
+    # #177: Rolling-Distro. Arch/CachyOS liefern libxml2 nur noch als .so.16;
+    # der Test beweist, dass das ins Bundle gelegte libxml2.so.2 den PG-Start
+    # trotzdem traegt (System-libxml2 wird hier bewusst NICHT installiert).
+    "archlinux:latest"
 )
 
 FAILED=()
@@ -45,6 +49,11 @@ for distro in "${DISTROS[@]}"; do
             ;;
         rockylinux:*|almalinux:*|fedora:*)
             INSTALL_CMD='dnf install -y -q libxml2 openssl-libs krb5-libs libzstd lz4-libs readline libbrotli shadow-utils >/dev/null'
+            ;;
+        archlinux:*)
+            # Bewusst OHNE libxml2: Arch liefert nur .so.16; das gebuendelte
+            # libxml2.so.2 muss den PG-Start tragen (#177). shadow ist in base.
+            INSTALL_CMD='pacman -Sy --noconfirm --needed openssl krb5 zstd lz4 readline brotli >/dev/null 2>&1'
             ;;
         *)
             INSTALL_CMD='true'


### PR DESCRIPTION
## Problem (#177)

theseus-PG linkt `libxml2.so.2`; Arch/CachyOS liefern ab libxml2 2.14 nur noch `libxml2.so.16` → PG-Start scheitert (`cannot open shared object file`), Native-Install dort unsupported.

## Fix

`libxml2.so.2` aus **rockylinux:9** ins Bundle (`bin/postgresql/lib/`). Ideale Quelle: **glibc-2.34** (= Bundle-Baseline) und gebaut **ohne ICU** (nur `libz`/`liblzma`/`libm`/`libc`) → keine Soname-Kaskade. PG findet sie via RPATH / `pg_env()`-`LD_LIBRARY_PATH`. Build prüft glibc-Compat + No-ICU.

- `validate-release.sh`: **archlinux:latest** als 5. Distro (System-libxml2 bewusst nicht installiert).
- `install.sh`: Fail-Fast nur noch, wenn **weder Bundle noch System** `.so.2` haben (vorher brach es auf Arch fälschlich ab).

## Verifikation

- **CachyOS** (System nur `libxml2.so.16`): gebündeltes `postgres --version` läuft. **Negativkontrolle** (Bundle-lib gelöscht) → exakt der #177-Fehler.
- `validate-release.sh`: **alle 5 Distros inkl. archlinux:latest grün**.

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)
