### PR TITLE
fix(calc): #198 Ist-Fensterung in Journal-Tageszeilen + Export-Zwischensummen

### DIFF
--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -1036,7 +1036,11 @@ def _create_employee_classic_sheet(wb: Workbook, db: Session, user: User, year: 
             Absence.type == AbsenceType.SICK,
             date_in_month(Absence.date, year, month)
         ).all()
-        sick_hours = sum(float(a.hours) for a in sick_absences)
+        # #198: gefenstert wie das Ist (Row 11 = get_monthly_worked_hours, #195).
+        # Sonst verschoebe eine out-of-window-SICK-Absence den adjusted_target
+        # (Row 10 = target − sick − vacation), ohne die Ist-Seite zu beruehren.
+        sick_hours = sum(float(a.hours) for a in sick_absences
+                         if calculation_service._within_employment_window(user, a.date))
         real_sick = sick_hours  # kept for the masked-case credit on Row 11
         if include_health_data:
             sheet.cell(row=8, column=col).value = sick_hours
@@ -1052,7 +1056,9 @@ def _create_employee_classic_sheet(wb: Workbook, db: Session, user: User, year: 
             Absence.type == AbsenceType.VACATION,
             date_in_month(Absence.date, year, month)
         ).all()
-        vacation_hours = sum(float(a.hours) for a in vacation_absences)
+        # #198: gefenstert wie Ist + sick (Row 10/11-Konsistenz).
+        vacation_hours = sum(float(a.hours) for a in vacation_absences
+                             if calculation_service._within_employment_window(user, a.date))
         sheet.cell(row=9, column=col).value = vacation_hours
         sheet.cell(row=9, column=col).number_format = '0.0'
         sheet.cell(row=9, column=col).alignment = right_align

--- a/backend/app/services/journal_service.py
+++ b/backend/app/services/journal_service.py
@@ -127,6 +127,15 @@ def get_journal(db: Session, user: User, year: int, month: int) -> Dict[str, Any
             actual_hours = time_hours
             target_hours = _eff_daily_target(d)
 
+        # #198: Tage ausserhalb des Beschaeftigungsfensters (vor first_work_day /
+        # nach last_work_day) zaehlen kein Ist — symmetrisch zu get_monthly_actual
+        # (#195; das Tagessoll ist via _eff_daily_target schon 0). Sonst weicht die
+        # Summe der Tageszeilen vom angezeigten Monats-Ist ab, sobald ein TimeEntry/
+        # SICK ausserhalb des Fensters liegt (Rehire/Import/Datumskorrektur). Die
+        # Roh-Eintraege bleiben sichtbar (§16), zaehlen aber 0.
+        if not calculation_service._within_employment_window(user, d):
+            actual_hours = Decimal("0")
+
         balance = actual_hours - target_hours
 
         days.append({

--- a/backend/tests/test_journal_service.py
+++ b/backend/tests/test_journal_service.py
@@ -3,7 +3,7 @@ import pytest
 from decimal import Decimal
 from datetime import date, time
 from app.models import TimeEntry, Absence, AbsenceType, PublicHoliday
-from app.services import journal_service
+from app.services import journal_service, calculation_service
 from tests.conftest import DEFAULT_TENANT_ID
 
 
@@ -113,3 +113,22 @@ def test_journal_user_info_included(db, test_user):
     result = journal_service.get_journal(db, test_user, 2026, 3)
     assert result["user"]["first_name"] == test_user.first_name
     assert result["user"]["last_name"] == test_user.last_name
+
+
+def test_journal_day_actuals_windowed_match_monthly_actual(db, test_user):
+    """#198: Ein TimeEntry VOR first_work_day darf das Tages-Ist nicht aufblaehen.
+    Summe der Tageszeilen muss dem (gefensterten) Monats-Ist entsprechen."""
+    test_user.first_work_day = date(2026, 3, 16)  # Eintritt Mitte Maerz
+    db.commit()
+    _make_entry(db, test_user, date(2026, 3, 9), 8, 16)    # Mo, VOR Eintritt (out-of-window)
+    _make_entry(db, test_user, date(2026, 3, 23), 8, 16)   # Mo, nach Eintritt (zaehlt)
+
+    result = journal_service.get_journal(db, test_user, 2026, 3)
+    sum_day_actual = round(sum(d["actual_hours"] for d in result["days"]), 2)
+    monthly_actual = round(float(calculation_service.get_monthly_actual(db, test_user, 2026, 3)), 2)
+    assert sum_day_actual == monthly_actual
+
+    mar9 = next(d for d in result["days"] if d["date"] == "2026-03-09")
+    assert mar9["actual_hours"] == 0.0   # out-of-window -> kein Ist
+    mar23 = next(d for d in result["days"] if d["date"] == "2026-03-23")
+    assert mar23["actual_hours"] == 8.0  # in-window -> zaehlt


### PR DESCRIPTION
## Problem (#198, Folge #195)

#195 fensterte das Monats-Ist, aber zwei eigenständige Aggregationen nicht:
1. **journal_service** Tageszeilen → `Σ Tageszeilen ≠ Monats-Ist` bei out-of-window-`TimeEntry`/SICK.
2. **export_service** (klassischer Jahresreport): `actual` (Row 11) gefenstert, `sick`/`vacation` (Row 8/9, → `adjusted_target` Row 10) nicht → Saldo verschiebt sich.

## Fix

Beide Stellen wenden `_within_employment_window` an (symmetrisch zu `get_monthly_actual`). Roh-Einträge bleiben im Journal sichtbar (§16), zählen aber 0.

Reine Anzeige-/Zwischensummen-Konsistenz bei anomalen Daten (Rehire/Import) — kein Daten-/Budget-Fehler.

## Verifikation

Neuer Journal-Test (`Σ Tageszeilen == get_monthly_actual` mit out-of-window-Eintrag) + `journal`/`paid_leave_reports`/`export_service`-Suiten → **40 passed**.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)
