### PR TITLE
fix(review-2026-06-23): Hardening aus intensivem Code-/Security-/ArbZG-Review

### DIFF
--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -76,13 +76,20 @@ def list_absences(
         current_user.role == UserRole.ADMIN
         and user_id
         and str(user_id) != str(current_user.id)
-        and any(a.type in _MASKED_ABSENCE_TYPES for a in absences)
     ):
+        # #208 / Art. 9 + Art. 5(2): JEDEN gezielten Admin-Lesezugriff auf fremde
+        # Abwesenheiten protokollieren (eine Zeile pro Request) — nicht nur, wenn
+        # Gesundheitsdaten IM ERGEBNIS landen. Sonst haengt die Spur am Inhalt:
+        # eine gezielte Suche nach Krankmeldungen, die (noch) nichts findet,
+        # bliebe unprotokolliert.
+        sensitive = any(a.type in _MASKED_ABSENCE_TYPES for a in absences)
         db.add(TimeEntryAuditLog(
             time_entry_id=None,
             user_id=user_id,
             changed_by=current_user.id,
-            action="health_data_read",
+            action="health_data_read" if sensitive else "absence_list_read",
+            new_note=("Admin-Lesezugriff auf fremde Abwesenheiten "
+                      + ("inkl. Gesundheitsdaten" if sensitive else "ohne Gesundheitsdaten")),
             source="dsgvo",
             tenant_id=current_user.tenant_id,
         ))
@@ -363,6 +370,13 @@ def create_absence(
 
     # For vacation, check remaining vacation days (per year for cross-year ranges)
     if absence_data.type == AbsenceType.VACATION:
+        # BUG-3 (Review 2026-06-23): Budget-Check + Insert atomar machen. Ohne Lock
+        # koennen zwei gleichzeitige Urlaubsbuchungen fuer denselben MA beide
+        # remaining_days lesen, beide den Check passieren und das Budget ueberziehen
+        # (der per-Datum-with_for_update unten verhindert nur Doppelbuchungen am
+        # selben Tag, nicht den Budget-Overrun ueber verschiedene Tage). Die
+        # User-Zeile sperren serialisiert die Urlaubsbuchung pro MA bis zum Commit.
+        db.query(User).filter(User.id == target_user.id).with_for_update().first()
         # Group dates by year for budget check
         dates_by_year = {}
         for d in dates_to_create:

--- a/backend/app/routers/admin_vacations.py
+++ b/backend/app/routers/admin_vacations.py
@@ -166,11 +166,14 @@ def review_vacation_request(
         )
 
     # Approve: create absence entries (same logic as create_absence in absences.py)
-    # F-026: explicit tenant scoping
+    # F-026: explicit tenant scoping. BUG-3 (Review 2026-06-23): with_for_update
+    # sperrt die User-Zeile -> zwei gleichzeitige Genehmigungen fuer denselben MA
+    # serialisieren, sonst koennten beide den Urlaubsbudget-Check passieren und
+    # das Budget ueberziehen.
     target_user = db.query(User).filter(
         User.id == vr.user_id,
         User.tenant_id == current_user.tenant_id,
-    ).first()
+    ).with_for_update().first()
     if not target_user:
         raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, UploadFile, File, status
 from fastapi.responses import JSONResponse
+from urllib.parse import quote
 from app.core.limiter import limiter
 from app.core import totp_crypto
 from sqlalchemy.orm import Session
@@ -539,7 +540,12 @@ def export_my_data(
     return JSONResponse(
         content=data,
         headers={
-            "Content-Disposition": f'attachment; filename="PraxisZeit_Datenauszug_{current_user.username}.json"',
+            # Review 2026-06-23: username ist nicht zeichen-restringiert (kann " /
+            # Sonderzeichen enthalten) -> RFC-5987-konform encoden statt roh in den
+            # Header zu interpolieren.
+            "Content-Disposition": "attachment; filename*=UTF-8''" + quote(
+                f"PraxisZeit_Datenauszug_{current_user.username}.json"
+            ),
             "Content-Type": "application/json; charset=utf-8",
         }
     )
@@ -554,7 +560,9 @@ async def update_profile_picture(
     db: Session = Depends(get_db)
 ):
     """Upload profile picture. Max 500KB, JPEG or PNG only. Magic bytes verified."""
-    contents = await file.read()
+    # Review 2026-06-23: nur bis zur Grenze + 1 Byte lesen, statt den ganzen Body
+    # in den Speicher zu ziehen und erst danach zu pruefen (Memory-DoS-Verstaerker).
+    contents = await file.read(512_001)
     if len(contents) > 512_000:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Bild zu groß (max. 500 KB)")
 

--- a/backend/app/routers/company_closures.py
+++ b/backend/app/routers/company_closures.py
@@ -160,6 +160,11 @@ def _create_closure_absences(
                         employee, workday, weekly_hours=weekly_hours
                     )
                 ),
+                # #205-Konsistenz (Review 2026-06-23): Betriebsferien sind immer
+                # volle Tage -> half_day=False, damit get_vacation_account den
+                # tagebasierten (WHChange-stabilen) Pfad nimmt statt der Legacy-
+                # Stundenlogik (die bei spaeterer Stundenaenderung driften wuerde).
+                half_day=False,
                 note=f"Betriebsferien: {closure.name}",
                 closure_id=closure.id,
             )

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -9,6 +9,7 @@ Routenmuster ``/api/me/*`` ist reserviert für Self-Service ohne Admin-Rolle.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
@@ -87,5 +88,7 @@ def data_export(
     return StreamingResponse(
         iter([blob]),
         media_type="application/json",
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        # Review 2026-06-23: filename enthaelt den username (nicht zeichen-
+        # restringiert) -> RFC-5987-encoden statt roh interpolieren.
+        headers={"Content-Disposition": "attachment; filename*=UTF-8''" + quote(filename)},
     )

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -513,7 +513,7 @@ def get_rest_time_violations(
     Default minimum rest time: 11 hours (German law ArbZG §5).
     """
     violations = rest_time_service.check_all_users_violations(
-        db, year, month, min_rest_hours
+        db, year, month, min_rest_hours, tenant_id=current_user.tenant_id
     )
     return {
         "year": year,

--- a/backend/app/routers/time_entries.py
+++ b/backend/app/routers/time_entries.py
@@ -391,6 +391,23 @@ def clock_out(
     db.commit()
     db.refresh(open_entry)
 
+    # H-2 (§16 ArbZG / EuGH C-55/18, Review 2026-06-23): jeden normalen
+    # Ausstempelvorgang protokollieren — bisher nur bei break_waiver. Ohne Audit
+    # zeigte ein spaeteres Admin-Edit als "original" die Admin-gesetzte Zeit statt
+    # des echten Stempelzeitpunkts. Quelle 'clock_out' (<= varchar(40)).
+    _create_audit_log(
+        db,
+        open_entry.id,
+        open_entry.user_id,
+        current_user.id,
+        action="update",
+        new_entry=open_entry,
+        source="clock_out",
+        tenant_id=current_user.tenant_id,
+    )
+    db.commit()
+    db.refresh(open_entry)
+
     clock_out_warnings: list[str] = []
     if not exempt:
         # ArbZG §4: break validation (warning only, don't block clock-out)
@@ -535,7 +552,9 @@ def get_time_entry(
 
     # Check permissions
     if entry.user_id != current_user.id and current_user.role != UserRole.ADMIN:
-        raise HTTPException(status_code=403, detail="Zugriff verweigert")
+        # #120 (Review 2026-06-23): 404 statt 403 — ein fremder Same-Tenant-Eintrag
+        # wird wie ein unbekannter behandelt (kein Existenz-Leak via Response-Code).
+        raise HTTPException(status_code=404, detail="Zeiteintrag nicht gefunden")
 
     response = TimeEntryResponse.model_validate(entry)
     _enrich_response(response, entry, current_user, db)
@@ -773,7 +792,9 @@ def update_time_entry(
 
     # Check permissions
     if entry.user_id != current_user.id and current_user.role != UserRole.ADMIN:
-        raise HTTPException(status_code=403, detail="Zugriff verweigert")
+        # #120 (Review 2026-06-23): 404 statt 403 — ein fremder Same-Tenant-Eintrag
+        # wird wie ein unbekannter behandelt (kein Existenz-Leak via Response-Code).
+        raise HTTPException(status_code=404, detail="Zeiteintrag nicht gefunden")
 
     # Edit protection: employees can only edit today's entries
     if current_user.role != UserRole.ADMIN and entry.date != _today_local():
@@ -1014,7 +1035,9 @@ def delete_time_entry(
 
     # Check permissions
     if entry.user_id != current_user.id and current_user.role != UserRole.ADMIN:
-        raise HTTPException(status_code=403, detail="Zugriff verweigert")
+        # #120 (Review 2026-06-23): 404 statt 403 — ein fremder Same-Tenant-Eintrag
+        # wird wie ein unbekannter behandelt (kein Existenz-Leak via Response-Code).
+        raise HTTPException(status_code=404, detail="Zeiteintrag nicht gefunden")
 
     # Edit protection: employees can only delete today's entries
     if current_user.role != UserRole.ADMIN and entry.date != _today_local():

--- a/backend/app/services/journal_service.py
+++ b/backend/app/services/journal_service.py
@@ -132,9 +132,13 @@ def get_journal(db: Session, user: User, year: int, month: int) -> Dict[str, Any
         # (#195; das Tagessoll ist via _eff_daily_target schon 0). Sonst weicht die
         # Summe der Tageszeilen vom angezeigten Monats-Ist ab, sobald ein TimeEntry/
         # SICK ausserhalb des Fensters liegt (Rehire/Import/Datumskorrektur). Die
-        # Roh-Eintraege bleiben sichtbar (§16), zaehlen aber 0.
+        # Roh-Eintraege bleiben sichtbar (§16), zaehlen aber 0. target_hours wird
+        # ebenfalls genullt: auf einem out-of-window MISCH-Tag (Eintrag+Absence)
+        # waere target = _eff_daily_target(0) − reducing_sum negativ -> sonst ein
+        # phantom-positiver Tages-Saldo (Review 2026-06-23).
         if not calculation_service._within_employment_window(user, d):
             actual_hours = Decimal("0")
+            target_hours = Decimal("0")
 
         balance = actual_hours - target_hours
 

--- a/backend/app/services/lifecycle_service.py
+++ b/backend/app/services/lifecycle_service.py
@@ -58,6 +58,11 @@ VACATION_AUDIT_RETENTION_DAYS = 730
 VACATION_AUDIT_SOURCES = (
     "vacation_request_edit",
     "vacation_request_cancel",
+    # #208 / Art. 5(1)(e): auch die Abwesenheits-Buchungs-/Genehmigungs-Audits
+    # dokumentieren den Antrags-Workflow (nicht die ArbZG-§16-Zeitaufzeichnung)
+    # und werden nach 730 Tagen mitgepurged, statt unbegrenzt zu akkumulieren.
+    "absence_creation",
+    "absence_request_approval",
 )
 
 
@@ -342,6 +347,11 @@ def _time_entry_dict(te: TimeEntry) -> dict[str, Any]:
         "date": te.date.isoformat() if te.date else None,
         "start_time": str(te.start_time) if te.start_time else None,
         "end_time": str(te.end_time) if te.end_time else None,
+        # §16 ArbZG (Review 2026-06-23): die ungekappten Rohstempel sind die
+        # eigentliche Arbeitszeitaufzeichnung vor der Work-Window-Kappung (#201)
+        # und gehoeren in den Pflicht-/Auskunfts-Export (wie im MA-Self-Export).
+        "raw_start_time": str(te.raw_start_time) if getattr(te, "raw_start_time", None) else None,
+        "raw_end_time": str(te.raw_end_time) if getattr(te, "raw_end_time", None) else None,
         "break_minutes": te.break_minutes,
         "note": te.note,
         # §10 ArbZG: Begruendung fuer Sonn-/Feiertagsarbeit — Pflichtbestandteil

--- a/backend/app/services/rest_time_service.py
+++ b/backend/app/services/rest_time_service.py
@@ -105,7 +105,8 @@ def check_all_users_violations(
     db: Session,
     year: int,
     month: Optional[int] = None,
-    min_rest_hours: Optional[float] = None
+    min_rest_hours: Optional[float] = None,
+    tenant_id=None,
 ) -> List[Dict]:
     """
     Check rest time violations for all active employees.
@@ -113,7 +114,17 @@ def check_all_users_violations(
     Returns list of violations grouped by employee.
     """
     from app.models import UserRole
-    users = db.query(User).filter(User.is_active == True).all()
+    # H-1 (Review 2026-06-23): §18 ArbZG — exempt_from_arbzg-MA (leitende
+    # Angestellte) gehoeren NICHT in den Ruhezeit-Report (der Echtzeit-Check beim
+    # Einstempeln schliesst sie bereits aus). F-026: zusaetzlich explizit auf den
+    # Tenant scopen (belt-and-suspenders ueber RLS).
+    user_query = db.query(User).filter(
+        User.is_active == True,
+        User.exempt_from_arbzg == False,
+    )
+    if tenant_id is not None:
+        user_query = user_query.filter(User.tenant_id == tenant_id)
+    users = user_query.all()
 
     all_violations = []
     for user in users:


### PR DESCRIPTION
## Intensiver 3-Agenten-Review (Security / Correctness / ArbZG+DSGVO)

**Keine Critical/High in der Tenant-Isolation** — die ist solide (RLS + explizite Filter, JWT, Lockout, TOTP-Crypto, Audit-HMAC alle verifiziert). Behoben (bis low):

### ArbZG / DSGVO
- **§16:** `clock_out` schrieb beim **normalen** Ausstempeln keinen Audit-Log (nur bei break_waiver) → jeder Punch-out wird jetzt protokolliert.
- **§5/§18:** `rest_time_service.check_all_users_violations` schloss `exempt_from_arbzg`-MA nicht aus + kein Tenant-Filter → ergänzt.
- **§16:** `raw_start/raw_end_time` fehlten im Superadmin-Tenant-Export.
- **Art.5(1)e (#208):** `absence_creation`/`_request_approval`-Audits jetzt im 730-Tage-Purge.
- **Art.9 (#208):** Admin-Lesezugriff auf fremde Abwesenheiten wird **immer** protokolliert (kein inhaltsbasiertes Orakel).

### Korrektheit
- **Journal:** out-of-window-Tage nullen jetzt auch `target_hours` (Misch-Tag → negativer Soll → phantom-positiver Saldo; Folge meines #198).
- **Betriebsferien:** Absences setzen `half_day=False` (#205-Konsistenz — sonst Legacy-Pfad → Drift bei Stundenänderung).
- **Urlaubsbudget-Race:** Budget-Check + Insert per `with_for_update` auf der User-Zeile serialisiert (create_absence + review_vacation_request) → kein Budget-Overrun bei gleichzeitigen Buchungen.

### Security
- **#120-Vervollständigung:** 3 Owner-Check-403 auf time-entry-by-id → 404 (kein Existenz-Leak).
- **Avatar-Upload:** nur bis Limit+1 Byte lesen (Memory-DoS-Verstärker).
- **Export-Header:** username RFC-5987-encoden (auth/me).

## Verifikation

Volle Backend-Suite **954 passed** (die 15 UTC-Mitternachts-Flakes grün mit `TZ=Europe/Berlin`).

Refs #208 (Art.5/Art.9-Items erledigt; A07-Lockout korrekt SaaS-gegated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
