### PR TITLE
fix(tenant): F-026 explizite Tenant-Filter (Review-Low)

### DIFF
--- a/backend/app/routers/admin_carryovers.py
+++ b/backend/app/routers/admin_carryovers.py
@@ -30,7 +30,8 @@ def list_carryovers(
         raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 
     carryovers = db.query(YearCarryover).filter(
-        YearCarryover.user_id == user_id
+        YearCarryover.user_id == user_id,
+        YearCarryover.tenant_id == current_user.tenant_id,  # F-026
     ).order_by(YearCarryover.year.desc()).all()
 
     return carryovers
@@ -58,6 +59,7 @@ def upsert_carryover(
 
     carryover = db.query(YearCarryover).filter(
         YearCarryover.user_id == user_id,
+        YearCarryover.tenant_id == current_user.tenant_id,  # F-026
         YearCarryover.year == year,
     ).first()
 

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -558,7 +558,8 @@ def list_working_hours_changes(
         raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 
     changes = db.query(WorkingHoursChange).filter(
-        WorkingHoursChange.user_id == user_id
+        WorkingHoursChange.user_id == user_id,
+        WorkingHoursChange.tenant_id == current_user.tenant_id,  # F-026
     ).order_by(WorkingHoursChange.effective_from.desc()).all()
     return changes
 
@@ -577,6 +578,7 @@ def create_working_hours_change(
 
     existing = db.query(WorkingHoursChange).filter(
         WorkingHoursChange.user_id == user_id,
+        WorkingHoursChange.tenant_id == current_user.tenant_id,  # F-026
         WorkingHoursChange.effective_from == change_data.effective_from
     ).first()
 
@@ -598,6 +600,7 @@ def create_working_hours_change(
     if change_data.effective_from <= today_local():
         most_recent = db.query(WorkingHoursChange).filter(
             WorkingHoursChange.user_id == user_id,
+            WorkingHoursChange.tenant_id == current_user.tenant_id,  # F-026
             WorkingHoursChange.effective_from <= today_local()
         ).order_by(WorkingHoursChange.effective_from.desc()).first()
         if most_recent:

--- a/backend/app/routers/company_closures.py
+++ b/backend/app/routers/company_closures.py
@@ -120,6 +120,7 @@ def _create_closure_absences(
             te_by_key.setdefault((entry.user_id, entry.date), []).append(entry)
         for wh in db.query(WorkingHoursChange).filter(
             WorkingHoursChange.user_id.in_(emp_ids),
+            WorkingHoursChange.tenant_id == current_user.tenant_id,  # F-026
         ).order_by(WorkingHoursChange.effective_from).all():
             wh_by_user.setdefault(wh.user_id, []).append(wh)
 

--- a/backend/app/services/journal_service.py
+++ b/backend/app/services/journal_service.py
@@ -24,6 +24,7 @@ def get_journal(db: Session, user: User, year: int, month: int) -> Dict[str, Any
 
     entries = db.query(TimeEntry).filter(
         TimeEntry.user_id == user.id,
+        TimeEntry.tenant_id == user.tenant_id,  # F-026
         date_in_month(TimeEntry.date, year, month),
     ).order_by(TimeEntry.date, TimeEntry.start_time).all()
 
@@ -33,6 +34,7 @@ def get_journal(db: Session, user: User, year: int, month: int) -> Dict[str, Any
 
     absences = db.query(Absence).filter(
         Absence.user_id == user.id,
+        Absence.tenant_id == user.tenant_id,  # F-026
         date_in_month(Absence.date, year, month),
     ).order_by(Absence.date, Absence.type).all()
 


### PR DESCRIPTION
Review-Low: mehrere tenant-scoped Queries filterten nur nach `user_id` und verließen sich allein auf RLS. Explizite `tenant_id`-Filter (belt-and-suspenders) ergänzt in company_closures (WHChange-Preload #204), admin_carryovers (YearCarryover read-before-write), admin_users (WHChange list/existing/most_recent), journal_service (TimeEntry+Absence). Defense-in-Depth, nicht ausnutzbar (RLS bleibt primär). Verifiziert: 50 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)