### PR TITLE
fix(review-round2): ABBA-Lock-Reihenfolge + HMAC-Kanonisierung haerten

### DIFF
--- a/backend/app/core/audit_integrity.py
+++ b/backend/app/core/audit_integrity.py
@@ -36,8 +36,11 @@ from app.config import settings
 
 logger = logging.getLogger(__name__)
 
-# Versioned context label — changing it (or SECRET_KEY) invalidates old hashes.
-_HKDF_INFO = b"praxiszeit-audit-row-hmac-v1"
+# Versioned context label — changing it (or SECRET_KEY) invalidiert alte Hashes.
+# v2 (Review 2026-06-23, 2. Schleife): laengen-praefigierte Kanonisierung statt
+# '|'-Join (Delimiter-Injection-Haertung). #121 ist noch nicht released -> es gibt
+# keine bestehenden row_hashes, die das invalidieren wuerde.
+_HKDF_INFO = b"praxiszeit-audit-row-hmac-v2"
 
 # Integrity-relevant fields that round-trip cleanly (UUID/date/time/int/str).
 # created_at is excluded on purpose (see module docstring).
@@ -62,12 +65,19 @@ def _audit_key() -> bytes:
 
 
 def _canonical(audit) -> bytes:
-    # NULL und der Leerstring duerfen NICHT kollidieren -> NULL als Sentinel.
+    # Laengen-praefigiert + feldbenannt: ein '|' / Newline im Wert (nur die
+    # *_note-Felder sind Freitext) kann die Feldgrenzen nicht verschieben, und
+    # eine Umsortierung der Felder ist ausgeschlossen. NULL ('N') und der
+    # Leerstring ('0:') bleiben unterscheidbar.
     parts = []
     for field in _HASHED_FIELDS:
         value = getattr(audit, field, None)
-        parts.append("\x00" if value is None else str(value))
-    return "|".join(parts).encode("utf-8")
+        if value is None:
+            parts.append(f"{field}:N")
+        else:
+            s = str(value)
+            parts.append(f"{field}:{len(s)}:{s}")
+    return "\n".join(parts).encode("utf-8")
 
 
 def compute_row_hash(audit) -> str:

--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -322,6 +322,14 @@ def create_absence(
             detail="Keine gültigen Arbeitstage im angegebenen Zeitraum"
         )
 
+    # BUG-3 / Review 2026-06-23 (2. Schleife): die User-Zeile ZUERST sperren —
+    # VOR den per-Datum-Absence-Locks unten — damit beide Urlaubs-Buchungspfade
+    # (create_absence + review_vacation_request) dieselbe Lock-Reihenfolge
+    # (User -> Absence) nutzen und kein ABBA-Deadlock moeglich ist. Der Lock
+    # serialisiert zugleich den Budget-Check + Insert pro MA (kein Budget-Overrun).
+    if absence_data.type == AbsenceType.VACATION:
+        db.query(User).filter(User.id == target_user.id).with_for_update().first()
+
     # Check for existing absences (any type — no double-booking allowed).
     # F-028: with_for_update() on the existence probe closes the race window
     # between this check and the INSERT below. The DB-level unique constraint
@@ -368,15 +376,10 @@ def create_absence(
             detail="Alle Tage im Zeitraum haben bereits eine Abwesenheit dieses Typs"
         )
 
-    # For vacation, check remaining vacation days (per year for cross-year ranges)
+    # For vacation, check remaining vacation days (per year for cross-year ranges).
+    # Die User-Zeile ist oben bereits per with_for_update gesperrt (BUG-3 +
+    # ABBA-Fix) -> Budget-Check + Insert sind pro MA serialisiert.
     if absence_data.type == AbsenceType.VACATION:
-        # BUG-3 (Review 2026-06-23): Budget-Check + Insert atomar machen. Ohne Lock
-        # koennen zwei gleichzeitige Urlaubsbuchungen fuer denselben MA beide
-        # remaining_days lesen, beide den Check passieren und das Budget ueberziehen
-        # (der per-Datum-with_for_update unten verhindert nur Doppelbuchungen am
-        # selben Tag, nicht den Budget-Overrun ueber verschiedene Tage). Die
-        # User-Zeile sperren serialisiert die Urlaubsbuchung pro MA bis zum Commit.
-        db.query(User).filter(User.id == target_user.id).with_for_update().first()
         # Group dates by year for budget check
         dates_by_year = {}
         for d in dates_to_create:


### PR DESCRIPTION
**2. Review-Schleife** (keine Critical/High/Medium). Zwei Low-Funde:

- **ABBA-Deadlock:** mein BUG-3-Fix sperrte Absence-Zeilen→User in `create_absence`, aber User→Absence in `review_vacation_request` → Deadlock-Möglichkeit bei gleichzeitiger Buchung+Genehmigung desselben MA. Jetzt **beide** User-zuerst.
- **Audit-HMAC:** `_canonical` jointe mit `|` → ein `|`/Newline im Freitext-Note konnte (theoretisch, nur mit Schlüssel) Feldgrenzen verschieben. Jetzt längen-präfigiert + feldbenannt (v2). #121 noch nicht released → keine bestehenden Hashes invalidiert.

Verifiziert: **86 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)