### PR TITLE
refactor(frontend): #219 gemeinsame Status-Badge-Config (3 Duplikate -> 1)

### DIFF
--- a/frontend/src/constants/statusConfig.ts
+++ b/frontend/src/constants/statusConfig.ts
@@ -1,0 +1,12 @@
+import { Clock, CheckCircle, XCircle } from 'lucide-react';
+
+// #219: gemeinsame Status-Badge-Konfiguration. Vorher 3x (fast) identisch
+// dupliziert in pages/ChangeRequests, pages/admin/ChangeRequests und
+// pages/admin/VacationApprovals. `withdrawn` wird nur von VacationApprovals
+// genutzt, schadet den anderen aber nicht.
+export const STATUS_CONFIG = {
+  pending: { label: 'Offen', color: 'bg-yellow-100 text-yellow-800', icon: Clock },
+  approved: { label: 'Genehmigt', color: 'bg-green-100 text-green-800', icon: CheckCircle },
+  rejected: { label: 'Abgelehnt', color: 'bg-red-100 text-red-800', icon: XCircle },
+  withdrawn: { label: 'Zurückgezogen', color: 'bg-gray-100 text-gray-600', icon: XCircle },
+} as const;

--- a/frontend/src/pages/ChangeRequests.tsx
+++ b/frontend/src/pages/ChangeRequests.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { format } from 'date-fns';
 import apiClient from '../api/client';
-import { Trash2, Clock, CheckCircle, XCircle, FileEdit } from 'lucide-react';
+import { Trash2, FileEdit } from 'lucide-react';
 import { useToast } from '../contexts/ToastContext';
 import { useConfirm } from '../hooks/useConfirm';
 import ConfirmDialog from '../components/ConfirmDialog';
@@ -37,12 +37,7 @@ interface ChangeRequest {
   created_at: string;
 }
 
-const statusConfig = {
-  pending: { label: 'Offen', color: 'bg-yellow-100 text-yellow-800', icon: Clock },
-  approved: { label: 'Genehmigt', color: 'bg-green-100 text-green-800', icon: CheckCircle },
-  rejected: { label: 'Abgelehnt', color: 'bg-red-100 text-red-800', icon: XCircle },
-};
-
+import { STATUS_CONFIG as statusConfig } from '../constants/statusConfig';
 import { CHANGE_REQUEST_TYPE_LABELS } from '../constants/changeRequestTypes';
 import { ABSENCE_TYPE_LABELS } from '../constants/absenceTypes';
 const typeLabels = CHANGE_REQUEST_TYPE_LABELS;

--- a/frontend/src/pages/admin/ChangeRequests.tsx
+++ b/frontend/src/pages/admin/ChangeRequests.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { format, subMonths, startOfMonth, endOfMonth, startOfYear, endOfYear, subYears } from 'date-fns';
 import apiClient from '../../api/client';
-import { Clock, CheckCircle, XCircle, AlertCircle, Check, X } from 'lucide-react';
+import { AlertCircle, Check, X } from 'lucide-react';
 import { useToast } from '../../contexts/ToastContext';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import { getErrorMessage } from '../../utils/errorMessage';
@@ -43,11 +43,7 @@ interface UserOption {
   last_name: string;
 }
 
-const statusConfig = {
-  pending: { label: 'Offen', color: 'bg-yellow-100 text-yellow-800', icon: Clock },
-  approved: { label: 'Genehmigt', color: 'bg-green-100 text-green-800', icon: CheckCircle },
-  rejected: { label: 'Abgelehnt', color: 'bg-red-100 text-red-800', icon: XCircle },
-};
+import { STATUS_CONFIG as statusConfig } from '../../constants/statusConfig';
 
 import { CHANGE_REQUEST_TYPE_LABELS } from '../../constants/changeRequestTypes';
 import { ABSENCE_TYPE_LABELS } from '../../constants/absenceTypes';

--- a/frontend/src/pages/admin/VacationApprovals.tsx
+++ b/frontend/src/pages/admin/VacationApprovals.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { format } from 'date-fns';
 import apiClient from '../../api/client';
-import { Clock, CheckCircle, XCircle, AlertCircle, Check, X, Trash2, Pencil } from 'lucide-react';
+import { AlertCircle, Check, X, Trash2, Pencil } from 'lucide-react';
 import { useToast } from '../../contexts/ToastContext';
 import { useConfirm } from '../../hooks/useConfirm';
 import ConfirmDialog from '../../components/ConfirmDialog';
@@ -29,12 +29,7 @@ interface VacationRequest {
   created_at: string;
 }
 
-const statusConfig = {
-  pending: { label: 'Offen', color: 'bg-yellow-100 text-yellow-800', icon: Clock },
-  approved: { label: 'Genehmigt', color: 'bg-green-100 text-green-800', icon: CheckCircle },
-  rejected: { label: 'Abgelehnt', color: 'bg-red-100 text-red-800', icon: XCircle },
-  withdrawn: { label: 'Zurückgezogen', color: 'bg-gray-100 text-gray-600', icon: XCircle },
-};
+import { STATUS_CONFIG as statusConfig } from '../../constants/statusConfig';
 
 export default function VacationApprovals() {
   const toast = useToast();


### PR DESCRIPTION
statusConfig war 3x (fast) identisch dupliziert → nach `constants/statusConfig.ts` extrahiert. tsc clean, vitest 116/116. Refs #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)