### PR TITLE
fix(prod-review): Frontend-Härtung (Object-URL-Leaks, NaN, Doppelklick, URL-Guard)

### DIFF
--- a/frontend/src/components/StampWidget.tsx
+++ b/frontend/src/components/StampWidget.tsx
@@ -70,6 +70,7 @@ export default function StampWidget({ variant = 'inline', onSuccess }: StampWidg
   }, [status?.is_clocked_in, variant]);
 
   const handleClockIn = async () => {
+    if (acting) return;  // synchroner Doppelklick-Schutz (setActing ist async, disabled greift zu spät)
     setActing(true);
     try {
       const res = await apiClient.post('/time-entries/clock-in', {});
@@ -99,6 +100,7 @@ export default function StampWidget({ variant = 'inline', onSuccess }: StampWidg
       setShowBreakInput(true);
       return;
     }
+    if (acting) return;  // synchroner Doppelklick-Schutz (setActing ist async)
     // #199: §4-Pausenpflicht — bei >6h Netto und unzureichender Pause die Pause
     // nacherfassen ODER eine dokumentierte Ausnahme verlangen, statt still mit
     // Warn-Toast durchzuwinken. (Aggregat mehrerer Tagesblöcke prüft das Backend.)

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react';
 import { useAuthStore } from '../stores/authStore';
 import apiClient from '../api/client';
+import { downloadBlob } from '../utils/downloadBlob';
 import { Lock, Save, Palette, User as UserIcon, Download, ShieldCheck, ShieldOff, Smartphone, Copy, CheckCircle, Camera, Trash2, ChevronDown, ChevronUp } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import PasswordInput from '../components/PasswordInput';
@@ -177,13 +178,7 @@ export default function Profile() {
     try {
       const response = await apiClient.get('/me/data-export', { responseType: 'blob' });
       const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-      const url = window.URL.createObjectURL(new Blob([response.data], { type: 'application/json' }));
-      const link = document.createElement('a');
-      link.href = url;
-      link.setAttribute('download', `PraxisZeit_MeineDaten_${user?.username}_${ts}.json`);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
+      downloadBlob(response.data, `PraxisZeit_MeineDaten_${user?.username}_${ts}.json`, 'application/json');
       toast.success('Auskunfts-Export heruntergeladen');
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Datenexport'));

--- a/frontend/src/pages/admin/Backups.tsx
+++ b/frontend/src/pages/admin/Backups.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import apiClient from '../../api/client';
+import { downloadBlob } from '../../utils/downloadBlob';
 import { Database, Download, Trash2, Play, Save, Clock, HardDrive } from 'lucide-react';
 import { useToast } from '../../contexts/ToastContext';
 import LoadingSpinner from '../../components/LoadingSpinner';
@@ -88,14 +89,7 @@ export default function Backups() {
   const handleDownload = async (filename: string) => {
     try {
       const res = await apiClient.get(`/admin/backups/${filename}/download`, { responseType: 'blob' });
-      const url = window.URL.createObjectURL(new Blob([res.data]));
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      window.URL.revokeObjectURL(url);
+      downloadBlob(res.data, filename, 'application/gzip');
     } catch (error) {
       toast.error(getErrorMessage(error, 'Download fehlgeschlagen'));
     }

--- a/frontend/src/pages/admin/Billing.tsx
+++ b/frontend/src/pages/admin/Billing.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { CreditCard, ArrowUpCircle, AlertTriangle, Download, FileText, Pause, Trash2, UserCheck } from 'lucide-react';
 import apiClient from '../../api/client';
 import { getErrorMessage } from '../../utils/errorMessage';
+import { safeHttpUrl } from '../../utils/url';
 import { useConfirm } from '../../hooks/useConfirm';
 import ConfirmDialog from '../../components/ConfirmDialog';
 
@@ -92,7 +93,9 @@ export default function Billing() {
         success_url: `${window.location.origin}/admin/billing?success=1`,
         cancel_url: `${window.location.origin}/admin/billing?canceled=1`,
       });
-      window.location.href = data.url;
+      const safeUrl = safeHttpUrl(data.url);  // Review 2026-06-23: kein offener Redirect
+      if (safeUrl) window.location.href = safeUrl;
+      else setError('Ungültige Weiterleitungs-URL vom Server erhalten.');
     } catch (err: any) {
       setError(getErrorMessage(err, 'Checkout fehlgeschlagen'));
     }
@@ -103,7 +106,9 @@ export default function Billing() {
       const { data } = await apiClient.post<{ url: string }>('/billing/portal', {
         return_url: `${window.location.origin}/admin/billing`,
       });
-      window.location.href = data.url;
+      const safeUrl = safeHttpUrl(data.url);  // Review 2026-06-23: kein offener Redirect
+      if (safeUrl) window.location.href = safeUrl;
+      else setError('Ungültige Weiterleitungs-URL vom Server erhalten.');
     } catch (err: any) {
       setError(getErrorMessage(err, 'Kundenportal nicht erreichbar'));
     }
@@ -306,9 +311,9 @@ export default function Billing() {
                     {(inv.amount_cents / 100).toFixed(2)} {inv.currency.toUpperCase()} · {inv.status}
                   </p>
                 </div>
-                {inv.hosted_invoice_url && (
+                {safeHttpUrl(inv.hosted_invoice_url) && (
                   <a
-                    href={inv.hosted_invoice_url}
+                    href={safeHttpUrl(inv.hosted_invoice_url) ?? undefined}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-primary hover:underline"

--- a/frontend/src/pages/admin/ChangeRequests.tsx
+++ b/frontend/src/pages/admin/ChangeRequests.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { format, subMonths, startOfMonth, endOfMonth, startOfYear, endOfYear, subYears } from 'date-fns';
 import apiClient from '../../api/client';
 import { AlertCircle, Check, X } from 'lucide-react';
@@ -137,7 +137,13 @@ export default function AdminChangeRequests() {
     }
   };
 
+  // Review 2026-06-23: synchroner Doppelklick-Schutz (Einzel-Approve/Reject; der
+  // Bulk-Pfad ist via bulkProcessing bereits geschützt).
+  const actionLock = useRef(false);
+
   const handleApprove = async (id: string) => {
+    if (actionLock.current) return;
+    actionLock.current = true;
     try {
       await apiClient.post(`/admin/change-requests/${id}/review`, {
         action: 'approve',
@@ -146,10 +152,14 @@ export default function AdminChangeRequests() {
       fetchRequests();
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Genehmigen'));
+    } finally {
+      actionLock.current = false;
     }
   };
 
   const handleReject = async (id: string) => {
+    if (actionLock.current) return;
+    actionLock.current = true;
     try {
       await apiClient.post(`/admin/change-requests/${id}/review`, {
         action: 'reject',
@@ -161,6 +171,8 @@ export default function AdminChangeRequests() {
       fetchRequests();
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Ablehnen'));
+    } finally {
+      actionLock.current = false;
     }
   };
 

--- a/frontend/src/pages/admin/Reports.tsx
+++ b/frontend/src/pages/admin/Reports.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { format } from 'date-fns';
 import { Download, Calendar, FileText, Clock, AlertTriangle, ChevronDown, ChevronUp, Sun } from 'lucide-react';
 import apiClient from '../../api/client';
+import { downloadBlob } from '../../utils/downloadBlob';
 import { useToast } from '../../contexts/ToastContext';
 import { parseHours } from '../../utils/formatters';
 
@@ -176,13 +177,7 @@ export default function Reports() {
       const response = await apiClient.get(`/admin/reports/export?month=${selectedMonth}${healthParam}`, {
         responseType: 'blob',
       });
-      const url = window.URL.createObjectURL(new Blob([response.data]));
-      const link = document.createElement('a');
-      link.href = url;
-      link.setAttribute('download', `PraxisZeit_Monatsreport_${selectedMonth}.xlsx`);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
+      downloadBlob(response.data, `PraxisZeit_Monatsreport_${selectedMonth}.xlsx`);
     } catch {
       toast.error('Export fehlgeschlagen. Bitte versuchen Sie es erneut.');
     } finally {
@@ -197,13 +192,7 @@ export default function Reports() {
       const response = await apiClient.get(`/admin/reports/export-yearly?year=${selectedYear}${healthParam}`, {
         responseType: 'blob',
       });
-      const url = window.URL.createObjectURL(new Blob([response.data]));
-      const link = document.createElement('a');
-      link.href = url;
-      link.setAttribute('download', `PraxisZeit_Jahresreport_${selectedYear}.xlsx`);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
+      downloadBlob(response.data, `PraxisZeit_Jahresreport_${selectedYear}.xlsx`);
     } catch (error) {
       toast.error('Export fehlgeschlagen. Bitte versuchen Sie es erneut.');
     } finally {
@@ -218,13 +207,7 @@ export default function Reports() {
       const response = await apiClient.get(`/admin/reports/export-yearly-classic?year=${selectedYear}${healthParam}`, {
         responseType: 'blob',
       });
-      const url = window.URL.createObjectURL(new Blob([response.data]));
-      const link = document.createElement('a');
-      link.href = url;
-      link.setAttribute('download', `PraxisZeit_Jahresreport_Classic_${selectedYear}.xlsx`);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
+      downloadBlob(response.data, `PraxisZeit_Jahresreport_Classic_${selectedYear}.xlsx`);
     } catch (error) {
       toast.error('Export fehlgeschlagen. Bitte versuchen Sie es erneut.');
     } finally {
@@ -239,13 +222,7 @@ export default function Reports() {
       const response = await apiClient.get(`/admin/reports/export-pdf?month=${selectedMonth}${healthParam}`, {
         responseType: 'blob',
       });
-      const url = window.URL.createObjectURL(new Blob([response.data]));
-      const link = document.createElement('a');
-      link.href = url;
-      link.setAttribute('download', `PraxisZeit_Monatsreport_${selectedMonth}.pdf`);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
+      downloadBlob(response.data, `PraxisZeit_Monatsreport_${selectedMonth}.pdf`);
     } catch {
       toast.error('PDF-Export fehlgeschlagen. Bitte versuchen Sie es erneut.');
     } finally {
@@ -260,13 +237,7 @@ export default function Reports() {
       const response = await apiClient.get(`/admin/reports/export-ods?month=${selectedMonth}${healthParam}`, {
         responseType: 'blob',
       });
-      const url = window.URL.createObjectURL(new Blob([response.data]));
-      const link = document.createElement('a');
-      link.href = url;
-      link.setAttribute('download', `PraxisZeit_Monatsreport_${selectedMonth}.ods`);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
+      downloadBlob(response.data, `PraxisZeit_Monatsreport_${selectedMonth}.ods`);
     } catch {
       toast.error('ODS-Export fehlgeschlagen. Bitte versuchen Sie es erneut.');
     } finally {
@@ -280,13 +251,7 @@ export default function Reports() {
       const response = await apiClient.get(`/admin/reports/export-yearly-ods?year=${selectedYear}`, {
         responseType: 'blob',
       });
-      const url = window.URL.createObjectURL(new Blob([response.data]));
-      const link = document.createElement('a');
-      link.href = url;
-      link.setAttribute('download', `PraxisZeit_Jahresreport_${selectedYear}.ods`);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
+      downloadBlob(response.data, `PraxisZeit_Jahresreport_${selectedYear}.ods`);
     } catch {
       toast.error('ODS-Export fehlgeschlagen. Bitte versuchen Sie es erneut.');
     } finally {
@@ -300,13 +265,7 @@ export default function Reports() {
       const response = await apiClient.get(`/admin/reports/export-yearly-classic-ods?year=${selectedYear}`, {
         responseType: 'blob',
       });
-      const url = window.URL.createObjectURL(new Blob([response.data]));
-      const link = document.createElement('a');
-      link.href = url;
-      link.setAttribute('download', `PraxisZeit_Jahresreport_Classic_${selectedYear}.ods`);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
+      downloadBlob(response.data, `PraxisZeit_Jahresreport_Classic_${selectedYear}.ods`);
     } catch {
       toast.error('ODS-Export fehlgeschlagen. Bitte versuchen Sie es erneut.');
     } finally {
@@ -426,7 +385,7 @@ export default function Reports() {
               <input
                 type="number"
                 value={selectedYear}
-                onChange={(e) => setSelectedYear(parseInt(e.target.value))}
+                onChange={(e) => setSelectedYear(parseInt(e.target.value) || new Date().getFullYear())}
                 min="2020"
                 max="2050"
                 className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"

--- a/frontend/src/pages/admin/VacationApprovals.tsx
+++ b/frontend/src/pages/admin/VacationApprovals.tsx
@@ -93,17 +93,28 @@ export default function VacationApprovals() {
     }
   };
 
+  // Review 2026-06-23: synchroner Doppelklick-Schutz — ein schneller Doppelklick
+  // schickte sonst zwei Review-POSTs (der zweite wird serverseitig per Precondition
+  // abgelehnt, erzeugt aber einen verwirrenden Fehler-Toast).
+  const actionLock = useRef(false);
+
   const handleApprove = async (id: string) => {
+    if (actionLock.current) return;
+    actionLock.current = true;
     try {
       await apiClient.post(`/admin/vacation-requests/${id}/review`, { action: 'approve' });
       toast.success('Antrag genehmigt');
       fetchRequests();
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Genehmigen'));
+    } finally {
+      actionLock.current = false;
     }
   };
 
   const handleReject = async (id: string) => {
+    if (actionLock.current) return;
+    actionLock.current = true;
     try {
       await apiClient.post(`/admin/vacation-requests/${id}/review`, {
         action: 'reject',
@@ -115,6 +126,8 @@ export default function VacationApprovals() {
       fetchRequests();
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Ablehnen'));
+    } finally {
+      actionLock.current = false;
     }
   };
 

--- a/frontend/src/utils/downloadBlob.ts
+++ b/frontend/src/utils/downloadBlob.ts
@@ -1,0 +1,18 @@
+// Löst einen Browser-Download für Blob-Daten aus und gibt die Object-URL
+// anschließend wieder frei. Review 2026-06-23: die früher überall inline
+// duplizierte Variante rief revokeObjectURL NIE auf -> jeder Export (teils
+// mehrere MB) leakte eine Object-URL für die Lebensdauer der Seite.
+export function downloadBlob(data: BlobPart, filename: string, mimeType?: string): void {
+  const blob = mimeType ? new Blob([data], { type: mimeType }) : new Blob([data]);
+  const url = window.URL.createObjectURL(blob);
+  try {
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', filename);
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  } finally {
+    window.URL.revokeObjectURL(url);
+  }
+}


### PR DESCRIPTION
Produktions-Frontend-Review, Funde bis low.

- **Object-URL-Leak:** Reports (7 Exporte) + Profile riefen nie `revokeObjectURL` → neuer gemeinsamer `downloadBlob()`-Helper (revoke im `finally`); Reports/Profile/Backups nutzen ihn.
- **Reports Jahres-Eingabe:** leeres Feld → `NaN` → `?year=NaN` → 422/500. Fallback auf aktuelles Jahr.
- **Doppelklick-Schutz:** StampWidget (clock-in/out) + VacationApprovals/ChangeRequests (Einzel-Approve/Reject) → synchroner In-Flight-Guard.
- **Open-Redirect-Härtung:** Billing leitet Checkout-/Portal-URL + Rechnungslink durch `safeHttpUrl()`.

tsc/build/vitest(116)/eslint(0 errors) grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF