### PR TITLE
docs(1.9.0): an die Realität angleichen + #213-Backup dokumentieren

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.8.15 (Stand 2026-06-22)
+**Aktuelle Version:** 1.9.0 (Stand 2026-06-23)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---
@@ -171,7 +171,7 @@ Nach nginx.conf / Frontend-Änderungen: `docker compose build frontend && docker
 - **`time_entry_audit_logs.source` UND `action` sind `varchar(40)`** (Migrationen 037 bzw. 044). Neue Marker müssen <40 Zeichen sein, sonst 500 beim INSERT (`StringDataRightTruncation`) — **SQLite-Tests fangen das NICHT** (ignorieren varchar-Länge), gegen Prod-DB-Kopie / Postgres prüfen. Source-Werte u. a.: `manual`, `import`, `change_request`, `vacation_request_cancel`, `break_waiver`, `dsgvo`, `license_startup`.
 - **`backend/create_handbuch_testdata.py`** ist multi-tenant-aware: ruft `set_superadmin_context(db)` auf + setzt `tenant_id=TENANT_ID` an User/TimeEntry/Absence/ChangeRequest. Wer das Script forkt für andere Seed-Daten muss beides mitnehmen, sonst RLS-Violation beim INSERT.
 - **Container-File-Updates aus fremdem cwd:** `docker compose cp` resolved Host-Pfade **relativ zum cwd**. Aus `e2e/` heraus → `lstat e2e/backend/...: no such file`. Lösung: `docker cp <host-abs-path> praxiszeit-backend-1:/app/<path>`.
-- **fastapi auf `0.136.*` cappen — NICHT auf 0.137+ bumpen (1.8.10):** FastAPI 0.137 führt `_IncludedRouter`-Routen (ohne `.path`) ein; `prometheus-fastapi-instrumentator` 8.0.0 macht ungeschützt `route.path` → **HTTP 500 auf Login + JEDEM included-Router-Endpoint** (`/api/health` ist Top-Level → 200, maskiert es). Upstream offen: instrumentator #370/#371. Erst auf 0.137+ zurück, wenn der Instrumentator-Fix released ist. Pin-Kommentar steht in `backend/requirements.txt`.
+- **fastapi-Cap aufgehoben → `0.138.*` (1.9.0):** Der 0.137-Crash (HTTP 500 auf Login + jedem included-Router-Endpoint) kam daher, dass `prometheus-fastapi-instrumentator` 8.0.0 ungeschützt `route.path` las, während FastAPI 0.137 `_IncludedRouter`-Routen (ohne `.path`) in `app.routes` einführte. **Instrumentator 8.0.1 guardet das jetzt** (`routing.py:57` `if hasattr(route, "path")`) → 0.137+ ist wieder sicher; `prometheus-fastapi-instrumentator>=8.0.1` ist Voraussetzung (Pin in `backend/requirements.txt`). Verifiziert end-to-end (Login + included-Router-Endpoints + `/metrics` + volle Suite). Bei künftigen fastapi-Bumps trotzdem **echten Login + `/metrics` auf einem Realhost prüfen** (instrumentator hängt eng an FastAPIs Routing-Interna).
 
 ### pzweb-Integration (ab 1.5.0)
 

--- a/README.md
+++ b/README.md
@@ -320,15 +320,22 @@ Datenbank-Migrationen werden automatisch beim Start ausgeführt.
 
 ### Backup
 
-**Datenbank-Backup:**
+Am einfachsten über die Admin-Oberfläche: **Admin → Datensicherung** (Native und
+Docker) — manuell auslösen, täglichen Zeitplan + Aufbewahrung konfigurieren,
+Sicherungen herunterladen. Auf der Kommandozeile (Docker):
+
+**Backup** (gzip, damit der Restore zusammenpasst):
 ```bash
-docker compose exec db pg_dump -U praxiszeit praxiszeit > backup.sql
+docker compose exec -T db pg_dump -U praxiszeit --clean --if-exists praxiszeit | gzip > backup.sql.gz
 ```
 
-**Datenbank-Restore:**
+**Restore** (idempotent dank `--clean --if-exists`, kein manuelles Leeren nötig):
 ```bash
-docker compose exec -T db psql -U praxiszeit praxiszeit < backup.sql
+gunzip -c backup.sql.gz | docker compose exec -T db psql -U praxiszeit praxiszeit
 ```
+
+Vollständige Anleitung (Native + Docker, geplante Sicherung, §16-Aufbewahrung):
+[docs/BACKUP.md](docs/BACKUP.md).
 
 ## Compliance & Audits
 

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -4,6 +4,27 @@ PraxisZeit speichert alle Zeitdaten in PostgreSQL. **§16 ArbZG verlangt eine
 Aufbewahrung von mindestens 2 Jahren** — sorgen Sie für Backups und prüfen Sie
 gelegentlich die Wiederherstellung.
 
+## Am einfachsten: über die Admin-Oberfläche (ab 1.9.0)
+
+**Admin → Datensicherung** (Menüpunkt links). Funktioniert in **beiden**
+Varianten (Native **und** Docker), ohne Kommandozeile:
+
+- **Sofort sichern** — erzeugt umgehend ein vollständiges, komprimiertes Backup
+  (`praxiszeit_<zeitstempel>.sql.gz`, Plain-SQL mit `--clean --if-exists`).
+- **Geplante Sicherung** — täglich zur eingestellten Stunde aktivieren, mit
+  Aufbewahrungsdauer (Tage) und optionalem Speicherort.
+- **Liste** — vorhandene Backups herunterladen oder löschen.
+
+> **Wo liegen die Backups?** Docker: im Volume `praxiszeit_backups`
+> (`/app/backups` im Backend-Container). Native: im konfigurierten
+> `data/backups/`. Für eine externe Kopie laden Sie die Datei über die Liste
+> herunter oder sichern das Volume/Verzeichnis zusätzlich extern (s. u.).
+>
+> **Native-Hinweis:** Die *geplante* Sicherung läuft nativ weiterhin über den
+> OS-Timer (systemd/launchd/Task, s. u.) — die In-App-Zeitplan-Einstellung steuert
+> die **Docker**-Variante. Der **manuelle** Trigger + die Liste funktionieren auf
+> beiden.
+
 ## Automatisches Backup — pro Variante
 
 | Variante | Automatisch? | Wie / wann | Ablage |
@@ -11,7 +32,7 @@ gelegentlich die Wiederherstellung.
 | **Native Linux** | ✅ ja | systemd-Timer `praxiszeit-backup.timer`, täglich **02:00** | `<install>/data/backups/` |
 | **Native Windows** | ✅ ja | Scheduled Task `PraxisZeit-Backup`, täglich **03:00** (ruft `backup.bat`) | `C:\PraxisZeit\data\backups\` |
 | **Native macOS** | ✅ ja | launchd `de.praxiszeit.backup.plist`, täglich **03:00** | `/usr/local/praxiszeit/data/backups/` |
-| **Docker** | ❌ **nein** | nur manuell bzw. per Host-Cron (s. u.) | wohin Sie den Dump schreiben |
+| **Docker** | ✅ optional | In-App **Datensicherung** aktivieren (täglich), oder Host-Cron (s. u.) | Volume `praxiszeit_backups` bzw. wohin Sie den Dump schreiben |
 
 > **Native:** Das Backup ruft intern `praxiszeit-server.py backup`. Der Dienst
 > muss dafür **nicht** gestoppt werden (Online-Dump, Plain-SQL `pg_dump` + gzip).
@@ -19,8 +40,10 @@ gelegentlich die Wiederherstellung.
 > §16 auf z. B. `730` (= 2 Jahre) erhöhen, oder zusätzlich Jahresarchive extern
 > ablegen).
 >
-> **Docker hat KEIN eingebautes Auto-Backup** — richten Sie einen Host-Cron ein
-> (siehe unten) oder ziehen Sie regelmäßig ein manuelles Backup.
+> **Docker:** Ab 1.9.0 kann der Admin in **Datensicherung** eine tägliche
+> Sicherung aktivieren (läuft im Backend per Scheduler, Ablage im Volume
+> `praxiszeit_backups`). Alternativ/zusätzlich ein Host-Cron (s. u.) oder das
+> mitgelieferte Script `tools/docker/backup.sh` (im Docker-Bundle).
 
 ---
 
@@ -50,11 +73,21 @@ ls -la /opt/praxiszeit/data/backups/          # Windows: dir C:\PraxisZeit\data\
 
 ### Docker
 
-Direkter DB-Dump aus dem `db`-Container (Dienst läuft weiter):
+Am einfachsten über die Admin-Oberfläche (**Datensicherung → Jetzt sichern**,
+s. o.). Auf der Kommandozeile gibt es im Docker-Bundle das geprüfte Script
+(empfohlen — gzip + Integritätsprüfung) — aus dem Verzeichnis neben der
+`docker-compose.yml`/`​.env` ausführen:
 
 ```bash
-docker compose exec -T db pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" \
-    > backup-$(date +%F).sql
+bash backup.sh                       # -> ./backups/praxiszeit_<ts>.sql.gz
+```
+
+Oder direkt aus dem `db`-Container (Dienst läuft weiter) — **mit gzip**, damit der
+Restore mit `gunzip -c | psql` zusammenpasst:
+
+```bash
+docker compose exec -T db pg_dump -U "$POSTGRES_USER" --clean --if-exists "$POSTGRES_DB" \
+    | gzip > backup-$(date +%F).sql.gz
 ```
 
 **Automatisieren per Host-Cron** (empfohlen, da Docker kein Auto-Backup hat) —
@@ -100,16 +133,27 @@ restore-backup.bat data\backups\<datei>.sql.gz
 
 ### Docker
 
+Mit dem mitgelieferten Script (empfohlen — entpackt + spielt ein), aus dem
+Verzeichnis neben der `docker-compose.yml` ausführen:
+
 ```bash
-# .sql.gz vorher entpacken: gunzip pz_<datum>.sql.gz
-docker compose exec -T db psql -U "$POSTGRES_USER" "$POSTGRES_DB" < backup.sql
+bash restore.sh backups/praxiszeit_<ts>.sql.gz
+```
+
+Oder von Hand — das `.sql.gz` **direkt** durch `psql` leiten (nicht vorher als
+Datei entpacken). Da die Dumps mit `--clean --if-exists` erzeugt werden, ist der
+Restore idempotent (vorhandene Objekte werden gedroppt und neu angelegt) — ein
+manuelles Leeren der DB ist **nicht** nötig:
+
+```bash
+gunzip -c backup.sql.gz | docker compose exec -T db psql -U "$POSTGRES_USER" "$POSTGRES_DB"
 ```
 
 ---
 
 ## Compliance-Checkliste (§16 ArbZG)
 
-- [ ] Automatisches Backup aktiv (Native: ja ab Installation; **Docker: Host-Cron einrichten**)
+- [ ] Automatisches Backup aktiv (Native: ja ab Installation; **Docker: in der Admin-Oberfläche *Datensicherung* aktivieren** oder Host-Cron)
 - [ ] Aufbewahrung deckt **mind. 2 Jahre** ab (`retention_days` erhöhen oder Jahresarchive extern)
 - [ ] Backup-Ziel liegt **nicht nur** auf demselben Server (externe Kopie)
 - [ ] Restore regelmäßig testen

--- a/docs/INSTALL-DOCKER.md
+++ b/docs/INSTALL-DOCKER.md
@@ -26,8 +26,8 @@ Dateien (inkl. `docker-compose.yml`) zu kommen:
 
 ```bash
 # 1. Bundle entpacken (enthält einen Top-Level-Ordner praxiszeit-X.Y.Z/)
-tar xzf praxiszeit-1.8.11-docker.tar.gz
-cd praxiszeit-1.8.11
+tar xzf praxiszeit-1.9.0-docker.tar.gz
+cd praxiszeit-1.9.0
 
 # 2. Secrets erzeugen (.env mit Zufallswerten + komplexem Admin-Passwort)
 bash generate-secrets.sh
@@ -124,15 +124,25 @@ docker compose pull && docker compose up -d --build   # Update (Weg A: neues Bun
 ## Backup (gesetzliche Aufbewahrung, §16 ArbZG)
 
 Die Zeitdaten liegen im Docker-Volume `postgres_data`. **Vor jedem `docker
-compose down -v` und vor Updates** ein DB-Dump ziehen:
+compose down -v` und vor Updates** sichern.
+
+**Am einfachsten:** in der App unter **Admin → Datensicherung** — manuell auslösen
+oder einen täglichen Zeitplan + Aufbewahrung konfigurieren. Die Sicherungen landen
+im Volume `praxiszeit_backups` und lassen sich dort herunterladen.
+
+**Kommandozeile** (gzip, damit der Restore mit `gunzip -c | psql` zusammenpasst):
 
 ```bash
-docker compose exec -T db pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" \
-    > backup-$(date +%F).sql
+docker compose exec -T db pg_dump -U "$POSTGRES_USER" --clean --if-exists "$POSTGRES_DB" \
+    | gzip > backup-$(date +%F).sql.gz
 ```
 
-§16 ArbZG verlangt eine Aufbewahrung von mindestens 2 Jahren. Das Volume
-`postgres_data` daher **niemals ungesichert löschen**.
+Im Docker-Bundle gibt es dafür auch die geprüften Scripts `bash backup.sh` /
+`bash restore.sh` (neben der `docker-compose.yml`). Restore + Details:
+[BACKUP.md](BACKUP.md).
+
+§16 ArbZG verlangt eine Aufbewahrung von mindestens 2 Jahren. Die Volumes
+`postgres_data` + `praxiszeit_backups` daher **niemals ungesichert löschen**.
 
 ---
 

--- a/docs/INSTALL-NATIVE.md
+++ b/docs/INSTALL-NATIVE.md
@@ -24,9 +24,9 @@ Alle Pakete enthalten Python und PostgreSQL — keine Voraussetzungen noetig.
 # 1. Herunterladen + entpacken
 #    Das Tarball entpackt FLACH (kein Top-Level-Ordner) — daher zuerst einen
 #    Zielordner anlegen und mit -C dorthin entpacken:
-mkdir -p praxiszeit-1.8.11
-tar xzf praxiszeit-1.8.11-linux-x64.tar.gz -C praxiszeit-1.8.11
-cd praxiszeit-1.8.11
+mkdir -p praxiszeit-1.9.0
+tar xzf praxiszeit-1.9.0-linux-x64.tar.gz -C praxiszeit-1.9.0
+cd praxiszeit-1.9.0
 
 # 2. Installer starten (als root)
 sudo ./install.sh
@@ -54,7 +54,7 @@ journalctl -u praxiszeit -f          # Live-Logs
 ## Windows-Installation
 
 ```
-1. praxiszeit-1.8.11-windows-x64.zip entpacken nach C:\PraxisZeit\
+1. praxiszeit-1.9.0-windows-x64.zip entpacken nach C:\PraxisZeit\
 
 2. setup.bat als Administrator ausfuehren
    - Installiert PostgreSQL (silent, kein GUI)
@@ -88,13 +88,13 @@ Deinstallation: `uninstall-service.bat` ausfuehren (Datenbank wird beibehalten).
 
 ```bash
 # Tarball entpackt flach — in einen eigenen Ordner entpacken:
-mkdir -p praxiszeit-1.8.11 && cd praxiszeit-1.8.11
+mkdir -p praxiszeit-1.9.0 && cd praxiszeit-1.9.0
 
 # Intel Mac:
-tar xzf ../praxiszeit-1.8.11-macos-x64.tar.gz
+tar xzf ../praxiszeit-1.9.0-macos-x64.tar.gz
 
 # Apple Silicon (M1/M2/M3/M4):
-tar xzf ../praxiszeit-1.8.11-macos-arm64.tar.gz
+tar xzf ../praxiszeit-1.9.0-macos-arm64.tar.gz
 
 # Installer starten (als root)
 sudo ./install.sh

--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -1,6 +1,6 @@
 # PraxisZeit – Handbuch für Administratoren
 
-**Version 2.4 | Stand: Juni 2026 (für PraxisZeit 1.8.11)**
+**Version 2.4 | Stand: Juni 2026 (für PraxisZeit 1.9.0)**
 
 ---
 
@@ -30,6 +30,7 @@
 16. [Änderungsanträge für Abwesenheiten](#16-änderungsanträge-für-abwesenheiten)
 17. [Rechtliche Grundlagen](#17-rechtliche-grundlagen)
 18. [Berechnungsgrundlagen (Anhang)](#18-berechnungsgrundlagen-anhang)
+19. [Datensicherung (Backup & Restore)](#19-datensicherung-backup--restore)
 
 ---
 
@@ -699,7 +700,7 @@ Mitarbeiter können nicht nur Zeiteinträge korrigieren, sondern auch **Abwesenh
 
 ## 18. Berechnungsgrundlagen (Anhang)
 
-> Dieser Anhang erklärt **vollständig und exakt**, wie PraxisZeit Soll-, Ist-, Überstunden- und Urlaubswerte ermittelt – auf dem tatsächlichen Rechenstand der Software (Version 1.8.11). Die ausführliche, code-nahe Referenz mit allen durchgerechneten Beispielen (Teilzeit, individueller Tagesplan, Pro-rata, Historie) steht in [`docs/BERECHNUNGEN.md`](../BERECHNUNGEN.md).
+> Dieser Anhang erklärt **vollständig und exakt**, wie PraxisZeit Soll-, Ist-, Überstunden- und Urlaubswerte ermittelt – auf dem tatsächlichen Rechenstand der Software (Version 1.9.0). Die ausführliche, code-nahe Referenz mit allen durchgerechneten Beispielen (Teilzeit, individueller Tagesplan, Pro-rata, Historie) steht in [`docs/BERECHNUNGEN.md`](../BERECHNUNGEN.md).
 
 ### 18.1 Grundbegriffe
 
@@ -786,5 +787,23 @@ Urlaubskonto = 30 − 4                     = 26 Tage übrig
 
 ---
 
+## 19. Datensicherung (Backup & Restore)
+
+Unter **Admin → Datensicherung** (ab Version 1.9.0) verwalten Sie Backups ohne Kommandozeile — in der Docker- **und** der nativen Installation:
+
+- **Jetzt sichern** — erstellt umgehend ein vollständiges, komprimiertes Backup (`praxiszeit_<Zeitstempel>.sql.gz`, Plain-SQL mit `--clean --if-exists`).
+- **Geplante Sicherung** — tägliche automatische Sicherung zur eingestellten Stunde aktivieren, mit Aufbewahrungsdauer (Tage) und optionalem Speicherort.
+- **Liste** — vorhandene Sicherungen **herunterladen** (für eine externe Kopie) oder löschen.
+
+**Wo:** Docker im Volume `praxiszeit_backups`, native im `data/backups/`-Verzeichnis.
+
+**§16 ArbZG:** Zeitaufzeichnungen mindestens **2 Jahre** aufbewahren — Aufbewahrungsdauer entsprechend setzen, eine Kopie **außerhalb** des Servers vorhalten und vor jedem Update zusätzlich sichern.
+
+> **Native:** Die *geplante* Sicherung läuft weiterhin über den OS-Timer (systemd/launchd/Task); der *manuelle* Trigger und die Liste funktionieren überall.
+
+**Wiederherstellung** (idempotent dank `--clean --if-exists`, kein manuelles Leeren der DB nötig) und alle Kommandozeilen-Varianten: siehe [`docs/BACKUP.md`](../BACKUP.md).
+
+---
+
 *PraxisZeit – Zeiterfassungssystem für Arztpraxen und kleine Unternehmen*
-*Stand: Juni 2026 (Version 2.4, für PraxisZeit 1.8.11)*
+*Stand: Juni 2026 (für PraxisZeit 1.9.0)*

--- a/docs/handbuch/HANDBUCH-MITARBEITER.md
+++ b/docs/handbuch/HANDBUCH-MITARBEITER.md
@@ -1,6 +1,6 @@
 # PraxisZeit – Mitarbeiter-Handbuch
 
-**Version:** 2.3 · **Stand:** Juni 2026 (PraxisZeit 1.8.11)
+**Version:** 2.3 · **Stand:** Juni 2026 (PraxisZeit 1.9.0)
 **System:** PraxisZeit Zeiterfassungssystem
 **Zugangsdaten:** Benutzername und Passwort vom Administrator
 
@@ -540,4 +540,4 @@ Vollständiger Gesetzestext: [https://www.gesetze-im-internet.de/arbzg/](https:/
 
 ---
 
-*PraxisZeit – Zeiterfassungssystem | Mitarbeiter-Handbuch v2.3 | Juni 2026 (PraxisZeit 1.8.11)*
+*PraxisZeit – Zeiterfassungssystem | Mitarbeiter-Handbuch v2.3 | Juni 2026 (PraxisZeit 1.9.0)*

--- a/docs/setup-anleitung.md
+++ b/docs/setup-anleitung.md
@@ -1,6 +1,6 @@
 # Setup-Anleitung PraxisZeit
 
-**Aktuelle Version:** 1.8.11 · **Stand:** Juni 2026
+**Aktuelle Version:** 1.9.0 · **Stand:** Juni 2026
 Für Linux und Windows · Native Installation und Docker-Deployment
 
 > **Maßgebliche, gepflegte Anleitungen:** [INSTALL-NATIVE.md](INSTALL-NATIVE.md)
@@ -401,7 +401,7 @@ docker compose ps                                    # alle 5 Container sollten 
 curl http://localhost/api/health
 # {"status":"healthy","database":"connected"}
 curl http://localhost/api/system/info
-# {"deployment_mode":"onprem","version":"1.8.11"}
+# {"deployment_mode":"onprem","version":"1.9.0"}
 ```
 
 ### 6.5 Im LAN erreichbar machen
@@ -787,4 +787,4 @@ C:\PraxisZeit\                    (Windows)
 
 ---
 
-*PraxisZeit · Version 1.8.11 · © 2026*
+*PraxisZeit · Version 1.9.0 · © 2026*

--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -1,6 +1,6 @@
 # PraxisZeit – Windows-Installation und Erstinbetriebnahme
 
-**Aktuelle Version:** 1.8.11 · **Stand:** Juni 2026
+**Aktuelle Version:** 1.9.0 · **Stand:** Juni 2026
 **Zielgruppe:** Praxis-Inhaber:in oder IT-Betreuer:in, der/die PraxisZeit erstmalig auf einem Windows-Rechner einrichtet
 **Ergebnis:** Ein einsatzbereiter Praxis-Server, eingerichtete Mitarbeiter:innen-Konten und der erste erfolgreiche Stempelvorgang am Morgen.
 
@@ -83,7 +83,7 @@ Folgende Dateien herunterladen:
 
 > **Hinweis zur Versionslage:** Releases (inkl. Windows-ZIP) werden inzwischen
 > zentral über den Shop **praxiszeit.mr-development.de** ausgeliefert (nicht mehr
-> nur als GitHub-Release). Aktuelle Version: **1.8.11**. Ein Eigen-Build aus dem
+> nur als GitHub-Release). Aktuelle Version: **1.9.0**. Ein Eigen-Build aus dem
 > `master`-Branch ist weiterhin via `tools/build-release.sh` möglich.
 
 ### 2.2 Integrität prüfen (PowerShell)
@@ -592,4 +592,4 @@ schtasks /query /tn "PraxisZeit-Backup" /v /fo LIST > C:\PraxisZeit\logs\task-st
 
 ---
 
-*PraxisZeit · Windows-Setup · Version 1.8.11 · © 2026*
+*PraxisZeit · Windows-Setup · Version 1.9.0 · © 2026*

--- a/frontend/src/components/DocViewer.tsx
+++ b/frontend/src/components/DocViewer.tsx
@@ -480,6 +480,17 @@ export const handbuchAdminSections: AccordionItem[] = [
       </div>
     ),
   },
+  {
+    title: '11. Datensicherung (Backup & Restore)',
+    content: (
+      <div className="space-y-2">
+        <p>Unter <strong>Datensicherung</strong> erstellen Sie jederzeit eine vollständige, komprimierte Sicherung der Datenbank (<strong>Jetzt sichern</strong>) oder aktivieren eine <strong>tägliche automatische Sicherung</strong> mit Aufbewahrungsdauer und optionalem Speicherort.</p>
+        <p>Vorhandene Sicherungen lassen sich in der Liste <strong>herunterladen</strong> (für eine externe Kopie) oder löschen. Format ist Plain-SQL + gzip (<code>praxiszeit_&lt;Zeitstempel&gt;.sql.gz</code>), mit <code>--clean --if-exists</code> idempotent wiederherstellbar.</p>
+        <p><strong>§16 ArbZG:</strong> Zeitaufzeichnungen sind mind. 2 Jahre aufzubewahren — Aufbewahrungsdauer entsprechend setzen und eine Kopie <strong>außerhalb</strong> des Servers vorhalten. Vor jedem Update zusätzlich sichern.</p>
+        <p className="text-gray-500">Native installiert läuft die <em>geplante</em> Sicherung über den OS-Timer; der <em>manuelle</em> Trigger und die Liste funktionieren überall. Wiederherstellung &amp; Details: <code>docs/BACKUP.md</code>.</p>
+      </div>
+    ),
+  },
 ];
 
 // ── Schnellstart (Admin) ─────────────────────────────────────────────────────


### PR DESCRIPTION
Doku-Overhaul vor 1.9.0, Kernbefehle verifiziert (raw backup/restore + `backup.sh` laufen: 416K, restore exit 0/0 ERRORs/1382 users).

- **BACKUP.md:** neue Admin-UI „Datensicherung" (#213) dokumentiert; Docker-Zeile „KEIN Auto-Backup" korrigiert; **kaputten Docker-Restore-Befehl repariert** (`< backup.sql` → `gunzip -c … | psql`, idempotent); Scripts + `praxiszeit_backups`-Volume erklärt.
- **In-App-Handbuch** (DocViewer) + **HANDBUCH-ADMIN**: Abschnitt „Datensicherung".
- **README + INSTALL-DOCKER**: Backup auf Admin-UI + korrekte gzip-Befehle.
- **Versions-Labels** 1.8.11/1.8.15 → 1.9.0.
- **CLAUDE.md:** fastapi-Cap-Regel korrigiert (0.138, instrumentator 8.0.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)