### PR TITLE
test(e2e): Release-Smoke (Login + #213-Backup + Feedback, Screenshots)

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 playwright-report/
 test-results/
+screenshots-release/

--- a/e2e/tests/release-smoke.spec.ts
+++ b/e2e/tests/release-smoke.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+// 1.9.0 Release-Smoke: Login + Dashboard + #213-Datensicherung (inkl. echtem
+// Backup-Trigger) + Feedback-Dialog — mit Screenshots als Beleg.
+const SHOT = (n: string) => ({ path: `screenshots-release/${n}.png`, fullPage: true });
+
+test('release-smoke: login, dashboard, backup, feedback', async ({ page }) => {
+  // --- Login-Seite -----------------------------------------------------------
+  await page.goto('/login');
+  await expect(page.locator('#username')).toBeVisible();
+  await page.screenshot(SHOT('01-login'));
+
+  // --- Login als Admin -------------------------------------------------------
+  await page.fill('#username', 'admin');
+  await page.fill('#password', 'Admin2025!');
+  await page.click('button[type="submit"]');
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 15000 });
+  await expect(page.locator('main')).toBeVisible();
+  await page.screenshot(SHOT('02-dashboard'));
+
+  // --- #213 Datensicherung ---------------------------------------------------
+  await page.goto('/admin/backups');
+  await expect(page.getByRole('heading', { name: 'Datensicherung' })).toBeVisible();
+  await page.screenshot(SHOT('03-backups-page'));
+
+  // echten Backup-Trigger ausführen (pg_dump im Container)
+  await page.getByRole('button', { name: /Jetzt sichern/ }).click();
+  await expect(page.getByText(/Backup erstellt/)).toBeVisible({ timeout: 30000 });
+  // die neue Datei muss in der Liste auftauchen
+  await expect(page.locator('table').getByText(/praxiszeit_\d{8}_\d{6}\.sql\.gz/).first()).toBeVisible();
+  await page.screenshot(SHOT('04-backup-created'));
+
+  // --- Feedback / Rückmeldung ------------------------------------------------
+  await page.getByRole('button', { name: 'Hilfe öffnen' }).click();
+  await page.getByRole('button', { name: /Fehler melden \/ Feedback/ }).click();
+  await expect(page.getByText(/Feedback|Fehler melden/).first()).toBeVisible();
+  await page.screenshot(SHOT('05-feedback-dialog'));
+});


### PR DESCRIPTION
Playwright-Smoke gegen den vollen Docker-Stack: Login → Dashboard → Datensicherung (echter Backup-Trigger, Datei erscheint) → Feedback-Dialog, mit Screenshot-Belegen. Lokal **1 passed**, Backup erzeugt + gelistet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)