### PR TITLE
chore(release): 1.9.0 — Version-Bump

### DIFF
--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.8.15"
+APP_VERSION = "1.9.0"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.8.15",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.8.15",
+      "version": "1.9.0",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "axios": "^1.18.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.8.15",
+  "version": "1.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.8.15"
+APP_VERSION="1.9.0"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
Version-Bump auf **1.9.0** (updater.py + package.json + build-release.sh + lock — Consistency-Check enforced).

**1.9.0 vereint:** #213 Admin-DB-Backup (manuell + geplant, nativ & Docker, e2e-verifiziert inkl. Restore) · fastapi 0.136→0.138 · Produktions-Härtung aus dem vollen Code-/Security-/ArbZG-Review · Doku-Overhaul · neue #213-Router-/TOTP-Tests (Suite 991). **BETA_MODE bleibt True** (Beta, keine Lizenzpflicht).

🤖 Generated with [Claude Code](https://claude.com/claude-code)