### PR TITLE
fix(#252): fälschliche §3-Tagesstunden-Warnung beim Bearbeiten eines <8h-Eintrags

### DIFF
--- a/backend/app/routers/time_entries.py
+++ b/backend/app/routers/time_entries.py
@@ -972,6 +972,11 @@ def update_time_entry(
         update_warnings.append(f"BREAK_WAIVER: {waiver_detail}")
     saved_hours = 0.0  # defined here so the night-worker check below can always reference it
     if not exempt and entry.end_time is not None:
+        # #252: Diese Warn-Berechnung läuft NACH db.commit() — der bearbeitete
+        # Eintrag steckt also schon (mit dem NEUEN Wert) in der DB. _calculate_*_
+        # net_hours addiert die übergebenen Zeiten ZUSÄTZLICH zur Tabellen-Summe,
+        # daher MUSS der Eintrag per exclude_entry_id ausgeschlossen werden, sonst
+        # wird er doppelt gezählt (6h-Eintrag -> 12h -> fälschliche >8h-Warnung).
         saved_hours = _calculate_daily_net_hours(
             db=db,
             user_id=entry.user_id,
@@ -979,7 +984,7 @@ def update_time_entry(
             start_time=entry.start_time,
             end_time=entry.end_time,
             break_minutes=entry.break_minutes,
-            exclude_entry_id=None,
+            exclude_entry_id=entry.id,
         )
         if saved_hours > MAX_DAILY_HOURS_WARN:
             update_warnings.append("DAILY_HOURS_WARNING")
@@ -990,7 +995,7 @@ def update_time_entry(
             start_time=entry.start_time,
             end_time=entry.end_time,
             break_minutes=entry.break_minutes,
-            exclude_entry_id=None,
+            exclude_entry_id=entry.id,
         )
         if weekly > MAX_WEEKLY_HOURS_WARN:
             update_warnings.append("WEEKLY_HOURS_WARNING")

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -515,6 +515,31 @@ class TestTimeEntryCreate:
         assert resp.status_code == 422
 
 
+class TestTimeEntryUpdateWarning:
+    """PUT /api/time-entries/{id} — §3-Warnung darf NICHT fälschlich feuern (#252)."""
+
+    def test_update_under_8h_no_daily_warning(self, employee_client):
+        """#252: Ein Eintrag <8h, der bearbeitet wird (weiter <8h), darf KEINE
+        DAILY_HOURS_WARNING auslösen. Bug: die Warn-Berechnung lief NACH dem commit
+        mit exclude_entry_id=None -> der bereits gespeicherte Eintrag wurde doppelt
+        gezählt (6h -> 12h -> >8h-Warnung), obwohl der Tag <8h hat."""
+        today = date.today().isoformat()
+        # 08:00–14:00, 0 Pause = 6h (<8h)
+        r = employee_client.post("/api/time-entries/", json={
+            "date": today, "start_time": "08:00", "end_time": "14:00", "break_minutes": 0,
+        })
+        assert r.status_code in (200, 201), r.text
+        eid = r.json()["id"]
+        # Bearbeiten auf 08:00–13:00 = 5h (immer noch <8h)
+        r2 = employee_client.put(f"/api/time-entries/{eid}", json={
+            "date": today, "start_time": "08:00", "end_time": "13:00", "break_minutes": 0,
+        })
+        assert r2.status_code == 200, r2.text
+        warnings = r2.json().get("warnings", [])
+        assert "DAILY_HOURS_WARNING" not in warnings, f"Fälschliche §3-Warnung bei <8h: {warnings}"
+        assert "WEEKLY_HOURS_WARNING" not in warnings, f"Fälschliche §3-Wochen-Warnung: {warnings}"
+
+
 class TestTimeEntryDelete:
     """DELETE /api/time-entries/{entry_id}"""
 


### PR DESCRIPTION
**Root cause:** `update_time_entry` berechnet die §3-Warnung (`DAILY_HOURS_WARNING`) **nach** `db.commit()` mit `exclude_entry_id=None`. Der bereits gespeicherte Eintrag wird von `_calculate_daily_net_hours` doppelt gezählt (übergebene Zeiten werden ZUSÄTZLICH zur Tabellensumme addiert) → 6h-Eintrag liest als 12h → falsche „über 8 Stunden"-Warnung. Gespeichert wird er trotzdem, weil der harte 10h-Check VOR dem commit korrekt rechnet — exakt das Report-Verhalten.

**Fix:** Nach-Commit-Berechnungen (Tag + Woche) nutzen `exclude_entry_id=entry.id`. `create_time_entry` nicht betroffen (Berechnung vor dem Add). Failing-Test ergänzt; 139 passed.

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)