### PR TITLE
PostgreSQL 16→18 + python-holidays (1.10.0)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,8 +40,8 @@ FROM python:3.12.13-slim-bookworm AS runtime
 WORKDIR /app
 
 # Runtime system dependencies: libpq5 (psycopg2) + postgresql-client-18 for the
-# #213 DB-Backup-Feature (pg_dump). Der Client MUSS zur Server-Major (postgres:16)
-# passen — bookworm liefert nur Client 15 (verweigert den Dump eines 16er-Servers),
+# #213 DB-Backup-Feature (pg_dump). Der Client MUSS zur Server-Major (postgres:18)
+# passen — bookworm liefert nur Client 15 (verweigert den Dump eines 18er-Servers),
 # daher das PGDG-Repo. curl/gnupg werden nur fuer den Repo-Key gebraucht und danach
 # wieder entfernt.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -39,7 +39,7 @@ FROM python:3.12.13-slim-bookworm AS runtime
 
 WORKDIR /app
 
-# Runtime system dependencies: libpq5 (psycopg2) + postgresql-client-16 for the
+# Runtime system dependencies: libpq5 (psycopg2) + postgresql-client-18 for the
 # #213 DB-Backup-Feature (pg_dump). Der Client MUSS zur Server-Major (postgres:16)
 # passen — bookworm liefert nur Client 15 (verweigert den Dump eines 16er-Servers),
 # daher das PGDG-Repo. curl/gnupg werden nur fuer den Repo-Key gebraucht und danach
@@ -50,7 +50,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         | gpg --dearmor -o /usr/share/keyrings/pgdg.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
         > /etc/apt/sources.list.d/pgdg.list \
-    && apt-get update && apt-get install -y --no-install-recommends postgresql-client-16 \
+    && apt-get update && apt-get install -y --no-install-recommends postgresql-client-18 \
     && apt-get purge -y curl gnupg && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.9.0"
+APP_VERSION = "1.10.0"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/services/holiday_service.py
+++ b/backend/app/services/holiday_service.py
@@ -7,63 +7,41 @@ from app.config import settings
 from app.services.timezone_service import today_local
 
 
-# German translations for holiday names returned by workalendar
-HOLIDAY_NAME_DE = {
-    # Fixed holidays
-    "New year": "Neujahr",
-    "New Year's Day": "Neujahr",
-    "Epiphany": "Heilige Drei Könige",
-    "Labour Day": "Tag der Arbeit",
-    "German Unity Day": "Tag der Deutschen Einheit",
-    "All Saints Day": "Allerheiligen",
-    "Christmas Day": "1. Weihnachtstag",
-    "Second Day of Christmas": "2. Weihnachtstag",
-    "Christmas": "1. Weihnachtstag",
-    "Second Christmas Day": "2. Weihnachtstag",
-    # Easter-based
-    "Good Friday": "Karfreitag",
-    "Easter Sunday": "Ostersonntag",
-    "Easter Monday": "Ostermontag",
-    "Ascension Thursday": "Christi Himmelfahrt",
-    "Ascension Day": "Christi Himmelfahrt",
-    "Whit Sunday": "Pfingstsonntag",
-    "Whit Monday": "Pfingstmontag",
-    "Corpus Christi": "Fronleichnam",
-    # Regional
-    "Assumption of Mary to Heaven": "Mariä Himmelfahrt",
-    "Assumption of Mary": "Mariä Himmelfahrt",
-    "Day of Repentance and Prayer": "Buß- und Bettag",
-    "Reformation Day": "Reformationstag",
-    "Peace Festival": "Augsburger Hohes Friedensfest",
-    "St. Stephen's Day": "2. Weihnachtstag",
-    "International Women's Day": "Internationaler Frauentag",
-    "World Children's Day": "Weltkindertag",
+# python-holidays (Sprache "de") liefert bereits deutsche Namen; nur wenige
+# weichen von den im Projekt/Handbuch etablierten Schreibweisen ab. Hier auf die
+# Projekt-Schreibweise normalisiert, damit Resyncs keine Bestands-Namen umbenennen
+# und UI/Handbuch konsistent bleiben.
+_NAME_NORMALIZE = {
+    "Erster Mai": "Tag der Arbeit",
+    "Erster Weihnachtstag": "1. Weihnachtstag",
+    "Zweiter Weihnachtstag": "2. Weihnachtstag",
+    "Frauentag": "Internationaler Frauentag",
 }
 
-# Supported German states mapping (class names from workalendar.europe)
+# Bundesland-Name -> ISO-3166-2-Subdivisions-Code für python-holidays.
 SUPPORTED_STATES = {
-    "Baden-Württemberg": "workalendar.europe.BadenWurttemberg",
-    "Bayern": "workalendar.europe.Bavaria",
-    "Berlin": "workalendar.europe.Berlin",
-    "Brandenburg": "workalendar.europe.Brandenburg",
-    "Bremen": "workalendar.europe.Bremen",
-    "Hamburg": "workalendar.europe.Hamburg",
-    "Hessen": "workalendar.europe.Hesse",
-    "Mecklenburg-Vorpommern": "workalendar.europe.MecklenburgVorpommern",
-    "Niedersachsen": "workalendar.europe.LowerSaxony",
-    "Nordrhein-Westfalen": "workalendar.europe.NorthRhineWestphalia",
-    "Rheinland-Pfalz": "workalendar.europe.RhinelandPalatinate",
-    "Saarland": "workalendar.europe.Saarland",
-    "Sachsen": "workalendar.europe.Saxony",
-    "Sachsen-Anhalt": "workalendar.europe.SaxonyAnhalt",
-    "Schleswig-Holstein": "workalendar.europe.SchleswigHolstein",
-    "Thüringen": "workalendar.europe.Thuringia",
+    "Baden-Württemberg": "BW",
+    "Bayern": "BY",
+    "Berlin": "BE",
+    "Brandenburg": "BB",
+    "Bremen": "HB",
+    "Hamburg": "HH",
+    "Hessen": "HE",
+    "Mecklenburg-Vorpommern": "MV",
+    "Niedersachsen": "NI",
+    "Nordrhein-Westfalen": "NW",
+    "Rheinland-Pfalz": "RP",
+    "Saarland": "SL",
+    "Sachsen": "SN",
+    "Sachsen-Anhalt": "ST",
+    "Schleswig-Holstein": "SH",
+    "Thüringen": "TH",
 }
 
 
 def _translate_name(name: str) -> str:
-    """Translate English holiday name to German."""
-    return HOLIDAY_NAME_DE.get(name, name)
+    """Normalisiere python-holidays-Namen auf die Projekt-Schreibweise."""
+    return _NAME_NORMALIZE.get(name, name)
 
 
 def get_holiday_state(db: Session, tenant_id=None) -> str:
@@ -77,15 +55,23 @@ def get_holiday_state(db: Session, tenant_id=None) -> str:
     return settings.HOLIDAY_STATE
 
 
-def _get_calendar(state: Optional[str] = None):
-    """Return the workalendar calendar for the given or configured state."""
+def _german_holidays(state: Optional[str], year: int):
+    """python-holidays-Feiertage (deutsch) für das Bundesland + Jahr.
+
+    Bayern bekommt zusätzlich die katholische Kategorie, damit Mariä Himmelfahrt
+    (in den kath.-geprägten Gemeinden gesetzlich, ~75 % Bayerns) wie zuvor unter
+    workalendar als Feiertag gilt; Praxen in den wenigen nicht-kath. Gemeinden
+    können den Tag als Custom-Holiday entfernen. python-holidays ist gepflegt und
+    bildet u. a. den Frauentag (MV, seit 2023), Weltkindertag (TH) und Oster-/
+    Pfingstsonntag (BB) korrekt ab — workalendar (seit 2023 unmaintained) nicht.
+    """
+    import holidays
     state = state or settings.HOLIDAY_STATE
-    module_path = SUPPORTED_STATES.get(state, "workalendar.europe.Bavaria")
-    module_name, class_name = module_path.rsplit(".", 1)
-    import importlib
-    module = importlib.import_module(module_name)
-    cal_class = getattr(module, class_name)
-    return cal_class()
+    code = SUPPORTED_STATES.get(state, "BY")
+    kwargs = {"years": year, "subdiv": code, "language": "de"}
+    if code == "BY":
+        kwargs["categories"] = ("public", "catholic")
+    return holidays.Germany(**kwargs)
 
 
 def sync_holidays(db: Session, year: int, state: Optional[str] = None, tenant_id=None) -> int:
@@ -94,11 +80,10 @@ def sync_holidays(db: Session, year: int, state: Optional[str] = None, tenant_id
     Caller is responsible for committing.
     Returns number of holidays added.
     """
-    cal = _get_calendar(state)
-    holidays = cal.holidays(year)
+    cal = _german_holidays(state, year)
 
     count = 0
-    for holiday_date, holiday_name in holidays:
+    for holiday_date, holiday_name in sorted(cal.items()):
         german_name = _translate_name(holiday_name)
 
         query = db.query(PublicHoliday).filter(PublicHoliday.date == holiday_date)

--- a/backend/app/services/holiday_service.py
+++ b/backend/app/services/holiday_service.py
@@ -67,7 +67,13 @@ def _german_holidays(state: Optional[str], year: int):
     """
     import holidays
     state = state or settings.HOLIDAY_STATE
-    code = SUPPORTED_STATES.get(state, "BY")
+    code = SUPPORTED_STATES.get(state)
+    if code is None:
+        # Kein stilles Zurückfallen auf Bayern: ein vertipptes/altes HOLIDAY_STATE
+        # würde sonst fremde Feiertage seeden (z. B. NRW bekäme Fronleichnam).
+        raise ValueError(
+            f"Unbekanntes Bundesland {state!r} — erlaubt: {', '.join(sorted(SUPPORTED_STATES))}"
+        )
     kwargs = {"years": year, "subdiv": code, "language": "de"}
     if code == "BY":
         kwargs["categories"] = ("public", "catholic")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,9 +17,10 @@ PyJWT[crypto]==2.13.*
 # continue to verify without migration.
 bcrypt==5.*
 python-multipart>=0.0.18,<0.1  # Floor >=0.0.18 (DoS-Fix, security-Audit M-02), bleibt 0.0.x
-# VULN-014: workalendar is unmaintained (last release 2023); consider replacing with
-# python-holidays (actively maintained) in a future migration.
-workalendar==17.*
+# Feiertage: python-holidays (aktiv gepflegt) — ersetzt das seit 2023 unmaintained
+# workalendar (#175). Bildet aktuelle Bundesland-Feiertage korrekt ab (z. B. MV
+# Frauentag seit 2023). Nur zur Sync-Zeit genutzt (seedet PublicHoliday-Rows).
+holidays==0.99
 openpyxl==3.1.*
 odfpy==1.4.*
 reportlab==4.*

--- a/backend/tests/test_holiday_service.py
+++ b/backend/tests/test_holiday_service.py
@@ -114,3 +114,30 @@ def test_sync_current_and_next_year_returns_dict(db, default_tenant):
     assert result["next_count"] > 0
     total = db.query(PublicHoliday).count()
     assert total > 0
+
+
+# --- python-holidays-Migration (#175): korrekte + aktuelle Bundesland-Feiertage ---
+
+def test_bavaria_keeps_assumption_day(db, default_tenant):
+    """Bayern behält Mariä Himmelfahrt (15.8., kath. Kategorie) wie zuvor unter workalendar."""
+    holiday_service.sync_holidays(db, 2026, state="Bayern", tenant_id=DEFAULT_TENANT_ID)
+    db.commit()
+    h = db.query(PublicHoliday).filter(PublicHoliday.date == date(2026, 8, 15)).first()
+    assert h is not None and h.name == "Mariä Himmelfahrt"
+
+
+def test_mv_has_womens_day(db, default_tenant):
+    """MV: Internationaler Frauentag (8.3., gesetzlich seit 2023) — das unmaintained workalendar kannte ihn nicht."""
+    holiday_service.sync_holidays(db, 2026, state="Mecklenburg-Vorpommern", tenant_id=DEFAULT_TENANT_ID)
+    db.commit()
+    assert db.query(PublicHoliday).filter(PublicHoliday.date == date(2026, 3, 8)).first() is not None
+
+
+def test_holiday_names_normalized_to_project_spelling(db, default_tenant):
+    """python-holidays-Namen auf Projekt-Schreibweise normalisiert (z. B. 'Erster Mai' -> 'Tag der Arbeit')."""
+    holiday_service.sync_holidays(db, 2026, state="Bayern", tenant_id=DEFAULT_TENANT_ID)
+    db.commit()
+    mayday = db.query(PublicHoliday).filter(PublicHoliday.date == date(2026, 5, 1)).first()
+    assert mayday is not None and mayday.name == "Tag der Arbeit"
+    xmas = db.query(PublicHoliday).filter(PublicHoliday.date == date(2026, 12, 25)).first()
+    assert xmas is not None and xmas.name == "1. Weihnachtstag"

--- a/backend/tests/test_holiday_service.py
+++ b/backend/tests/test_holiday_service.py
@@ -141,3 +141,18 @@ def test_holiday_names_normalized_to_project_spelling(db, default_tenant):
     assert mayday is not None and mayday.name == "Tag der Arbeit"
     xmas = db.query(PublicHoliday).filter(PublicHoliday.date == date(2026, 12, 25)).first()
     assert xmas is not None and xmas.name == "1. Weihnachtstag"
+
+
+def test_sync_holidays_idempotent(db, default_tenant):
+    """Zweiter Sync desselben Jahres fügt nichts hinzu — keine Duplikate."""
+    holiday_service.sync_holidays(db, 2026, state="Bayern", tenant_id=DEFAULT_TENANT_ID)
+    db.commit()
+    second = holiday_service.sync_holidays(db, 2026, state="Bayern", tenant_id=DEFAULT_TENANT_ID)
+    db.commit()
+    assert second == 0
+
+
+def test_german_holidays_rejects_unknown_state():
+    """Unbekanntes Bundesland -> ValueError statt stillem Fallback auf Bayern."""
+    with pytest.raises(ValueError):
+        holiday_service._german_holidays("Tirol", 2026)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,18 @@
 
 services:
   db:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
       # F-025: passed to init-db-user.sh so it can ALTER ROLE praxiszeit_app
       APP_DB_PASSWORD: ${APP_DB_PASSWORD:?Set APP_DB_PASSWORD in .env}
+      # PG18: das offizielle Image legt die Daten ab 18 standardmäßig in einem
+      # Major-Version-Unterordner (/var/lib/postgresql/18/docker) ab. Wir setzen
+      # PGDATA explizit auf den historischen Pfad, damit das bestehende Volume-
+      # Layout (Mount auf .../data) unverändert bleibt.
+      PGDATA: /var/lib/postgresql/data
     volumes:
       - postgres_data:/var/lib/postgresql/data
       # 01_ prefix ensures the SQL runs before the shell script

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -19,6 +19,26 @@ Die Daten liegen im Docker-Volume `postgres_data` und bleiben über Updates
 hinweg erhalten — der `docker compose down`/`up`-Zyklus löscht sie **nicht**
 (nur `down -v` würde das Volume entfernen — niemals ungesichert tun).
 
+> ### ⚠️ Update auf 1.10.0 = PostgreSQL-Major-Upgrade (16 → 18)
+>
+> Ab **1.10.0** bündelt PraxisZeit **PostgreSQL 18** (vorher 16). Ein PG-Major-
+> Upgrade ist **nicht in-place**: `postgres:18` kann ein von `postgres:16`
+> angelegtes `postgres_data`-Volume nicht starten (es bricht mit einer
+> „incompatible"-Meldung ab). Kommst du von **1.9.x oder älter**, nutze den
+> **geführten Helfer im Docker-Bundle** statt eines einfachen `up`:
+>
+> ```bash
+> bash update-pg-major.sh   # alter Stack muss noch laufen
+> ```
+>
+> Er sichert die laufende DB, entfernt **nur** das `*_postgres_data`-Volume (die
+> #213-Backups im `praxiszeit_backups`-Volume bleiben), startet den frischen
+> PG18-Stack und spielt den Dump wieder ein. Manuell:
+> `bash backup.sh` → `docker compose down` → `docker volume rm <projekt>_postgres_data`
+> → neuen Stack `up -d --build` → `bash restore.sh backups/praxiszeit_<ts>.sql.gz`.
+> Verifiziert (PG16→18, Daten byte-genau identisch + Login). Spätere 1.10.x-Updates
+> bleiben wieder normale In-Place-Updates.
+
 ### 1. Backup
 
 ```bash

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "axios": "^1.18.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -281,7 +281,9 @@ OLD_PGDATA="${INSTALL_DIR}/data/db"
 NEW_POSTGRES="${SCRIPT_DIR}/bin/postgresql/bin/postgres"
 if [ -f "${OLD_PGDATA}/PG_VERSION" ] && [ -x "${NEW_POSTGRES}" ] && [ -f "${INSTALL_DIR}/config/.db-credentials" ]; then
     OLD_MAJOR=$(cut -d. -f1 "${OLD_PGDATA}/PG_VERSION" 2>/dev/null)
-    NEW_MAJOR=$(LD_LIBRARY_PATH="${SCRIPT_DIR}/bin/postgresql/lib" "${NEW_POSTGRES}" --version 2>/dev/null | grep -oE '[0-9]+' | head -1)
+    # awk 'NR==1' statt 'head -1': head schliesst die Pipe frueh -> SIGPIPE +
+    # pipefail (CLAUDE.md 1.8.8). Hier zwar kleine Ausgabe, aber konsistent robust.
+    NEW_MAJOR=$(LD_LIBRARY_PATH="${SCRIPT_DIR}/bin/postgresql/lib" "${NEW_POSTGRES}" --version 2>/dev/null | grep -oE '[0-9]+' | awk 'NR==1')
     if [ -n "${OLD_MAJOR}" ] && [ -n "${NEW_MAJOR}" ] && [ "${OLD_MAJOR}" -lt "${NEW_MAJOR}" ] 2>/dev/null; then
         info "PostgreSQL-Major-Upgrade ${OLD_MAJOR} -> ${NEW_MAJOR} erkannt — sichere Daten mit den alten Binaries..."
         OLD_PGBIN="${INSTALL_DIR}/bin/postgresql/bin"
@@ -300,10 +302,21 @@ if [ -f "${OLD_PGDATA}/PG_VERSION" ] && [ -x "${NEW_POSTGRES}" ] && [ -f "${INST
         if ! sudo -u "${SERVICE_USER}" env LD_LIBRARY_PATH="${OLD_PGLIB}" "${OLD_PGBIN}/pg_ctl" -D "${OLD_PGDATA}" -w -t 60 start; then
             error "PG-Upgrade: alter Cluster ließ sich nicht starten — Abbruch (Daten unangetastet)."; exit 1
         fi
+        # set -o pipefail im sh -c: sonst maskiert ein erfolgreiches gzip einen
+        # mittendrin abgebrochenen pg_dump (partieller, aber valider .gz = Daten-
+        # verlust). Bricht jetzt hart ab, wenn pg_dump scheitert.
         if ! sudo -u "${SERVICE_USER}" env LD_LIBRARY_PATH="${OLD_PGLIB}" PGPASSWORD="${SU_PW}" \
-                sh -c "'${OLD_PGBIN}/pg_dump' -w --clean --if-exists -h '${RUN_DIR}' -U praxiszeit -d praxiszeit | gzip > '${DUMP_FILE}'"; then
+                sh -c "set -o pipefail; '${OLD_PGBIN}/pg_dump' -w --clean --if-exists -h '${RUN_DIR}' -U praxiszeit -d praxiszeit | gzip > '${DUMP_FILE}'"; then
             sudo -u "${SERVICE_USER}" env LD_LIBRARY_PATH="${OLD_PGLIB}" "${OLD_PGBIN}/pg_ctl" -D "${OLD_PGDATA}" -w stop 2>/dev/null || true
+            rm -f "${DUMP_FILE}"
             error "PG-Upgrade: pg_dump fehlgeschlagen — Abbruch (Daten unangetastet)."; exit 1
+        fi
+        # Plausibilitaet: ein echter Dump ist nie winzig (selbst leere DB > 1 KB).
+        DUMP_SIZE=$(stat -c%s "${DUMP_FILE}" 2>/dev/null || echo 0)
+        if [ "${DUMP_SIZE}" -lt 1024 ]; then
+            sudo -u "${SERVICE_USER}" env LD_LIBRARY_PATH="${OLD_PGLIB}" "${OLD_PGBIN}/pg_ctl" -D "${OLD_PGDATA}" -w stop 2>/dev/null || true
+            rm -f "${DUMP_FILE}"
+            error "PG-Upgrade: Dump verdaechtig klein (${DUMP_SIZE} Bytes) — Abbruch (Daten unangetastet)."; exit 1
         fi
         sudo -u "${SERVICE_USER}" env LD_LIBRARY_PATH="${OLD_PGLIB}" "${OLD_PGBIN}/pg_ctl" -D "${OLD_PGDATA}" -w stop 2>/dev/null || true
         # Alte Daten zur Seite legen (NIE löschen) + Marker für praxiszeit-server.py.

--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -272,6 +272,49 @@ if systemctl is-active --quiet "${SERVICE_NAME}" 2>/dev/null; then
     sleep 2
 fi
 
+# --- PostgreSQL Major-Upgrade (z. B. 16 -> 18) ---
+# PG18-Binaries können ein PG16-Datenverzeichnis NICHT starten (Major-Upgrade ist
+# nicht in-place). Daher VOR dem Binary-Tausch mit den ALTEN Binaries dumpen, das
+# alte Datenverzeichnis zur Seite legen (NIE löschen) + einen Marker schreiben;
+# praxiszeit-server.py spielt den Dump beim ersten Start in den frischen Cluster.
+OLD_PGDATA="${INSTALL_DIR}/data/db"
+NEW_POSTGRES="${SCRIPT_DIR}/bin/postgresql/bin/postgres"
+if [ -f "${OLD_PGDATA}/PG_VERSION" ] && [ -x "${NEW_POSTGRES}" ] && [ -f "${INSTALL_DIR}/config/.db-credentials" ]; then
+    OLD_MAJOR=$(cut -d. -f1 "${OLD_PGDATA}/PG_VERSION" 2>/dev/null)
+    NEW_MAJOR=$(LD_LIBRARY_PATH="${SCRIPT_DIR}/bin/postgresql/lib" "${NEW_POSTGRES}" --version 2>/dev/null | grep -oE '[0-9]+' | head -1)
+    if [ -n "${OLD_MAJOR}" ] && [ -n "${NEW_MAJOR}" ] && [ "${OLD_MAJOR}" -lt "${NEW_MAJOR}" ] 2>/dev/null; then
+        info "PostgreSQL-Major-Upgrade ${OLD_MAJOR} -> ${NEW_MAJOR} erkannt — sichere Daten mit den alten Binaries..."
+        OLD_PGBIN="${INSTALL_DIR}/bin/postgresql/bin"
+        OLD_PGLIB="${INSTALL_DIR}/bin/postgresql/lib"
+        RUN_DIR="${INSTALL_DIR}/data/run"
+        SU_PW=$(grep -E '^SUPERUSER_PASSWORD=' "${INSTALL_DIR}/config/.db-credentials" | cut -d= -f2-)
+        TS=$(date +%Y%m%d_%H%M%S)
+        DUMP_FILE="${INSTALL_DIR}/data/backups/pre-upgrade-pg${OLD_MAJOR}-${TS}.sql.gz"
+        mkdir -p "${INSTALL_DIR}/data/backups" "${RUN_DIR}"
+        chown "${SERVICE_USER}:${SERVICE_USER}" "${INSTALL_DIR}/data/backups" "${RUN_DIR}" 2>/dev/null || true
+        if [ -z "${SU_PW}" ]; then
+            error "PG-Upgrade: .db-credentials ohne SUPERUSER_PASSWORD — Migration nicht möglich. Abbruch (Daten unangetastet)."; exit 1
+        fi
+        # Alten Cluster starten (alte postgresql.conf hat listen_addresses='' +
+        # unix_socket_directories bereits gesetzt), dumpen, stoppen — als Dienst-User.
+        if ! sudo -u "${SERVICE_USER}" env LD_LIBRARY_PATH="${OLD_PGLIB}" "${OLD_PGBIN}/pg_ctl" -D "${OLD_PGDATA}" -w -t 60 start; then
+            error "PG-Upgrade: alter Cluster ließ sich nicht starten — Abbruch (Daten unangetastet)."; exit 1
+        fi
+        if ! sudo -u "${SERVICE_USER}" env LD_LIBRARY_PATH="${OLD_PGLIB}" PGPASSWORD="${SU_PW}" \
+                sh -c "'${OLD_PGBIN}/pg_dump' -w --clean --if-exists -h '${RUN_DIR}' -U praxiszeit -d praxiszeit | gzip > '${DUMP_FILE}'"; then
+            sudo -u "${SERVICE_USER}" env LD_LIBRARY_PATH="${OLD_PGLIB}" "${OLD_PGBIN}/pg_ctl" -D "${OLD_PGDATA}" -w stop 2>/dev/null || true
+            error "PG-Upgrade: pg_dump fehlgeschlagen — Abbruch (Daten unangetastet)."; exit 1
+        fi
+        sudo -u "${SERVICE_USER}" env LD_LIBRARY_PATH="${OLD_PGLIB}" "${OLD_PGBIN}/pg_ctl" -D "${OLD_PGDATA}" -w stop 2>/dev/null || true
+        # Alte Daten zur Seite legen (NIE löschen) + Marker für praxiszeit-server.py.
+        mv "${OLD_PGDATA}" "${INSTALL_DIR}/data/db.pg${OLD_MAJOR}-${TS}"
+        echo "${DUMP_FILE}" > "${INSTALL_DIR}/data/.pg-upgrade-restore"
+        chown "${SERVICE_USER}:${SERVICE_USER}" "${INSTALL_DIR}/data/.pg-upgrade-restore" 2>/dev/null || true
+        info "Daten gesichert: ${DUMP_FILE}"
+        info "Frischer PG${NEW_MAJOR}-Cluster wird beim Start angelegt + Dump eingespielt; alter Cluster bleibt als data/db.pg${OLD_MAJOR}-${TS} erhalten."
+    fi
+fi
+
 info "Kopiere Anwendungsdateien..."
 # The installer package should contain these directories at the same level
 if [ -d "${SCRIPT_DIR}/bin" ]; then

--- a/praxiszeit-server.py
+++ b/praxiszeit-server.py
@@ -1282,30 +1282,51 @@ def _restore_pending_major_upgrade():
         return
     dump = Path(PG_UPGRADE_RESTORE_MARKER.read_text().strip())
     if not dump.is_file():
-        logger.error("PG-Upgrade-Marker vorhanden, aber Dump fehlt: %s — übersprungen.", dump)
-        PG_UPGRADE_RESTORE_MARKER.unlink()
-        return
+        # Marker da, Dump weg: NICHT stillschweigend mit leerer DB weiterlaufen —
+        # die Alt-Daten liegen noch unter data/db.pg*. Abbrechen; der Operator
+        # spielt den Dump zurück ODER entfernt den Marker bewusst.
+        raise RuntimeError(
+            f"PG-Upgrade-Marker vorhanden, aber Dump-Datei fehlt: {dump}. "
+            "Bitte den Dump wiederherstellen oder data/.pg-upgrade-restore manuell entfernen, "
+            "um einen Start ohne Restore zu erzwingen (Alt-Daten unter data/db.pg* erhalten)."
+        )
     su_password, _ = pg_load_credentials()
     if not su_password:
         raise RuntimeError("PG-Upgrade-Restore: keine Superuser-Credentials gefunden.")
     logger.info("PostgreSQL-Major-Upgrade: spiele gesicherten Daten-Dump ein (%s)...", dump.name)
+    # Streamend in eine temporäre .sql-Datei entpacken (NICHT den ganzen Dump in
+    # den RAM laden -> kein OOM auf kleinen VPS) und per `psql -f` einspielen.
+    # ON_ERROR_STOP=1: jeder echte Fehler -> Exit != 0 (die DROP … IF EXISTS aus
+    # --clean --if-exists erzeugen in der frischen DB keine Fehler) — zuverlässiger
+    # als das vorherige stderr-"ERROR"-Zeilenzählen.
     import gzip
-    with gzip.open(dump, "rb") as gz:
-        sql = gz.read()
+    import shutil
+    import tempfile
     env = {**pg_env(), "PGPASSWORD": su_password}
-    # Dump ist Plain-SQL mit --clean --if-exists -> idempotent in die frische DB.
-    proc = subprocess.run(
-        [str(pg_cmd("psql")), "-w", "-U", "praxiszeit", "-d", "praxiszeit", "-v", "ON_ERROR_STOP=0"],
-        input=sql, env=env, capture_output=True,
-    )
-    stderr = proc.stderr.decode("utf-8", "replace") if proc.stderr else ""
-    errors = sum(1 for ln in stderr.splitlines() if ln.strip().startswith("ERROR"))
-    if proc.returncode != 0 or errors:
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".sql", delete=False, dir=str(DATA_DIR)) as tmp:
+            tmp_path = tmp.name
+            with gzip.open(dump, "rb") as gz:
+                shutil.copyfileobj(gz, tmp)
+        proc = subprocess.run(
+            [str(pg_cmd("psql")), "-w", "-U", "praxiszeit", "-d", "praxiszeit",
+             "-v", "ON_ERROR_STOP=1", "-f", tmp_path],
+            env=env, capture_output=True,
+        )
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+    if proc.returncode != 0:
+        stderr = proc.stderr.decode("utf-8", "replace") if proc.stderr else ""
         logger.error(
-            "PG-Upgrade-Restore fehlgeschlagen (Exit %s, %d ERROR-Zeilen). Das alte "
-            "Datenverzeichnis (data/db.pg*) + der Dump bleiben erhalten — bitte manuell "
-            "wiederherstellen. Letzte Fehler:\n%s",
-            proc.returncode, errors, "\n".join(stderr.splitlines()[-8:]),
+            "PG-Upgrade-Restore fehlgeschlagen (Exit %s). Das alte Datenverzeichnis "
+            "(data/db.pg*) + der Dump bleiben erhalten — bitte manuell wiederherstellen. "
+            "Letzte Fehler:\n%s",
+            proc.returncode, "\n".join(stderr.splitlines()[-8:]),
         )
         raise RuntimeError("PG-Upgrade-Restore fehlgeschlagen — alte Daten unter data/db.pg* erhalten.")
     logger.info("PostgreSQL-Major-Upgrade: Daten erfolgreich eingespielt.")

--- a/praxiszeit-server.py
+++ b/praxiszeit-server.py
@@ -1266,6 +1266,52 @@ def _signal_handler(signum, frame):
     _shutdown_requested = True
 
 
+PG_UPGRADE_RESTORE_MARKER = DATA_DIR / ".pg-upgrade-restore"
+
+
+def _restore_pending_major_upgrade():
+    """PG-Major-Upgrade (z. B. 16 -> 18): install.sh hat mit den ALTEN Binaries
+    gedumpt, das alte Datenverzeichnis zur Seite gelegt (``data/db.pgXX-<ts>``,
+    NIE gelöscht) und den Dump-Pfad in den Marker geschrieben. Hier — nachdem
+    cmd_start den frischen PGNN-Cluster initialisiert + die DB/Rollen angelegt hat
+    — spielen wir den Dump in die leere ``praxiszeit``-DB ein. Idempotent: ohne
+    Marker passiert nichts; bei Restore-Fehler bleibt der Marker + das alte
+    Datenverzeichnis erhalten (recoverable), und wir brechen ab statt mit
+    Teildaten weiterzulaufen."""
+    if not PG_UPGRADE_RESTORE_MARKER.exists():
+        return
+    dump = Path(PG_UPGRADE_RESTORE_MARKER.read_text().strip())
+    if not dump.is_file():
+        logger.error("PG-Upgrade-Marker vorhanden, aber Dump fehlt: %s — übersprungen.", dump)
+        PG_UPGRADE_RESTORE_MARKER.unlink()
+        return
+    su_password, _ = pg_load_credentials()
+    if not su_password:
+        raise RuntimeError("PG-Upgrade-Restore: keine Superuser-Credentials gefunden.")
+    logger.info("PostgreSQL-Major-Upgrade: spiele gesicherten Daten-Dump ein (%s)...", dump.name)
+    import gzip
+    with gzip.open(dump, "rb") as gz:
+        sql = gz.read()
+    env = {**pg_env(), "PGPASSWORD": su_password}
+    # Dump ist Plain-SQL mit --clean --if-exists -> idempotent in die frische DB.
+    proc = subprocess.run(
+        [str(pg_cmd("psql")), "-w", "-U", "praxiszeit", "-d", "praxiszeit", "-v", "ON_ERROR_STOP=0"],
+        input=sql, env=env, capture_output=True,
+    )
+    stderr = proc.stderr.decode("utf-8", "replace") if proc.stderr else ""
+    errors = sum(1 for ln in stderr.splitlines() if ln.strip().startswith("ERROR"))
+    if proc.returncode != 0 or errors:
+        logger.error(
+            "PG-Upgrade-Restore fehlgeschlagen (Exit %s, %d ERROR-Zeilen). Das alte "
+            "Datenverzeichnis (data/db.pg*) + der Dump bleiben erhalten — bitte manuell "
+            "wiederherstellen. Letzte Fehler:\n%s",
+            proc.returncode, errors, "\n".join(stderr.splitlines()[-8:]),
+        )
+        raise RuntimeError("PG-Upgrade-Restore fehlgeschlagen — alte Daten unter data/db.pg* erhalten.")
+    logger.info("PostgreSQL-Major-Upgrade: Daten erfolgreich eingespielt.")
+    PG_UPGRADE_RESTORE_MARKER.unlink()
+
+
 # --- Main Commands ---
 
 def cmd_start(args):
@@ -1366,6 +1412,11 @@ def cmd_start(args):
             logger.error("Database credentials not found. Run 'praxiszeit-server init' first.")
             pg_stop()
             sys.exit(1)
+
+    # 3a1. PG-Major-Upgrade: falls install.sh die Alt-Daten gedumpt + zur Seite
+    # gelegt hat (Marker), den Dump jetzt in den frischen Cluster einspielen.
+    # Idempotent (no-op ohne Marker); läuft NACH pg_setup_database (DB + Rollen da).
+    _restore_pending_major_upgrade()
 
     # 3a2. #213: Der Backup-Service im Backend braucht das Ziel-Verzeichnis UND
     # den gebuendelten pg_dump-Pfad — anders als im Docker-Image liegt pg_dump

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.9.0"
+APP_VERSION="1.10.0"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -913,7 +913,8 @@ if [ "$BUILD_DOCKER" = true ]; then
     cp "${REPO_DIR}/tools/docker/generate-secrets.sh" "${DOCKER_STAGE}/generate-secrets.sh"
     cp "${REPO_DIR}/tools/docker/backup.sh"           "${DOCKER_STAGE}/backup.sh"
     cp "${REPO_DIR}/tools/docker/restore.sh"          "${DOCKER_STAGE}/restore.sh"
-    chmod +x "${DOCKER_STAGE}/generate-secrets.sh" "${DOCKER_STAGE}/backup.sh" "${DOCKER_STAGE}/restore.sh"
+    cp "${REPO_DIR}/tools/docker/update-pg-major.sh"  "${DOCKER_STAGE}/update-pg-major.sh"
+    chmod +x "${DOCKER_STAGE}/generate-secrets.sh" "${DOCKER_STAGE}/backup.sh" "${DOCKER_STAGE}/restore.sh" "${DOCKER_STAGE}/update-pg-major.sh"
 
     # Build-Kontext kopieren (ohne Ballast / ohne evtl. lokale Secrets+Certs).
     # cd ins REPO_DIR -> Pfade in den tar-Excludes sind relativ ("backend/...").
@@ -954,6 +955,20 @@ dem Hochziehen der neuen Version wieder einspielen:
     # ... neue Version entpacken, .env + backups/ uebernehmen, Stack starten ...
     bash restore.sh backups/praxiszeit_<ts>.sql.gz  # DB einspielen
     docker compose up -d backend                    # Alembic-Migrationen -> Schema auf head
+
+## ⚠️ PostgreSQL-Major-Upgrade (ab dieser Version PostgreSQL 18)
+
+Ein PostgreSQL-Major-Upgrade (z. B. 16 -> 18) ist NICHT in-place: postgres:18 kann
+ein von postgres:16 angelegtes Daten-Volume nicht starten. Kommst du von einer
+Version mit PostgreSQL 16 (PraxisZeit <= 1.9.x), nutze den gefuehrten Helfer
+STATT eines einfachen \`up\` — er sichert, ersetzt nur das DB-Volume (deine
+#213-Backups bleiben) und spielt die Daten in den frischen PG18-Cluster ein:
+
+    bash update-pg-major.sh
+
+(Der ALTE Stack muss beim Aufruf noch laufen.) Manuell entspricht das: backup.sh
+-> docker compose down -> Volume \`*_postgres_data\` entfernen -> neuen Stack
+hochziehen -> restore.sh.
 
 Die Backups sind gzip-komprimierte Plain-SQL-Dumps und lassen sich auch per
 \`gunzip -c <datei>.sql.gz | docker compose exec -T db psql -U praxiszeit praxiszeit\` einspielen.

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -24,7 +24,7 @@ PYTHON_STANDALONE_TAG="20260510"
 # theseus-rs/postgresql-binaries — manylinux-Build, portable bis glibc 2.34
 # (Ubuntu 22.04, Debian 12, RHEL 9 und neuer). Releases:
 #   https://github.com/theseus-rs/postgresql-binaries/releases
-POSTGRESQL_VERSION="16.13.0"
+POSTGRESQL_VERSION="18.4.0"
 # EDB-Format (für Legacy-Fallback, falls jemals wieder verfügbar)
 POSTGRESQL_EDB_SUFFIX="1"
 NSSM_VERSION="2.24"

--- a/tools/docker/restore.sh
+++ b/tools/docker/restore.sh
@@ -38,6 +38,9 @@ PG_USER="${PG_USER:-praxiszeit}"
 PG_DB="${PG_DB:-praxiszeit}"
 
 echo "Spiele '${FILE}' in Datenbank '${PG_DB}' (User '${PG_USER}') ein ..."
-gunzip -c "$FILE" | docker compose exec -T db psql -U "$PG_USER" -d "$PG_DB"
+# ON_ERROR_STOP=1: psql bricht beim ersten echten SQL-Fehler ab + Exit != 0 (sonst
+# meldet psql trotz Fehlern Exit 0 -> ein kaputter Restore sähe erfolgreich aus).
+# Die DROP … IF EXISTS aus --clean --if-exists erzeugen keine Fehler.
+gunzip -c "$FILE" | docker compose exec -T db psql -v ON_ERROR_STOP=1 -U "$PG_USER" -d "$PG_DB"
 echo "Restore abgeschlossen."
 echo "Backend neu starten, damit Migrationen laufen: docker compose up -d backend"

--- a/tools/docker/update-pg-major.sh
+++ b/tools/docker/update-pg-major.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# PraxisZeit — Docker-Update MIT PostgreSQL-Major-Upgrade (z. B. PG16 -> PG18).
+#
+# Hintergrund: Ein PostgreSQL-Major-Upgrade ist NICHT in-place — postgres:18 kann
+# ein von postgres:16 angelegtes Daten-Volume nicht starten (es bricht mit einer
+# ausfuehrlichen "incompatible"-Meldung ab). Dieser Helfer macht den Umstieg
+# sicher: er sichert die laufende DB, entfernt NUR das DB-Volume (die #213-Backups
+# im praxiszeit_backups-Volume bleiben erhalten), startet einen frischen
+# PG18-Stack und spielt den Dump wieder ein.
+#
+# Aufruf NEBEN der docker-compose.yml (im Docker-Bundle):  bash update-pg-major.sh
+# (Der ALTE Stack muss noch laufen, damit gesichert werden kann.)
+set -euo pipefail
+cd "$(dirname "$0")"   # Bundle-Root (hier liegen docker-compose.yml + backup.sh/restore.sh)
+
+[ -f docker-compose.yml ] || { echo "FEHLER: keine docker-compose.yml neben diesem Skript (bitte im Docker-Bundle ausfuehren)." >&2; exit 1; }
+
+echo "==> 1/5  Backup der laufenden Datenbank (alte PostgreSQL-Version)..."
+bash backup.sh
+BK="$(ls -1t backups/praxiszeit_*.sql.gz 2>/dev/null | head -1)"
+[ -n "$BK" ] && [ -f "$BK" ] || { echo "FEHLER: kein Backup erzeugt — Abbruch (Daten unangetastet)." >&2; exit 1; }
+echo "    Backup: $BK"
+
+echo "==> 2/5  Exaktes DB-Volume ermitteln (vor dem Stop)..."
+VOL="$(docker compose ps -q db | xargs -r docker inspect -f '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}')"
+[ -n "$VOL" ] || { echo "FEHLER: DB-Volume nicht gefunden — laeuft der alte Stack noch?" >&2; exit 1; }
+echo "    Volume: $VOL"
+
+echo "==> 3/5  Stack stoppen + altes DB-Volume entfernen (Backups bleiben erhalten)..."
+docker compose down
+docker volume rm "$VOL"
+
+echo "==> 4/5  Frischen PG18-Stack bauen + starten..."
+docker compose up -d --build
+for _ in $(seq 1 40); do
+    [ "$(docker compose ps db --format '{{.Health}}' 2>/dev/null)" = "healthy" ] && break
+    sleep 3
+done
+[ "$(docker compose ps db --format '{{.Health}}' 2>/dev/null)" = "healthy" ] \
+    || { echo "FEHLER: neue Datenbank wurde nicht 'healthy'. Backup liegt unter ${BK}." >&2; exit 1; }
+
+echo "==> 5/5  Restore in den frischen Cluster..."
+bash restore.sh "$BK"
+docker compose up -d backend
+
+echo ""
+echo "Fertig. Das alte DB-Volume wurde durch einen frischen PG18-Cluster ersetzt."
+echo "Das Backup bleibt erhalten: ${BK} — erst loeschen, wenn alles geprueft ist."

--- a/tools/docker/update-pg-major.sh
+++ b/tools/docker/update-pg-major.sh
@@ -19,21 +19,39 @@ echo "==> 1/5  Backup der laufenden Datenbank (alte PostgreSQL-Version)..."
 bash backup.sh
 BK="$(ls -1t backups/praxiszeit_*.sql.gz 2>/dev/null | head -1)"
 [ -n "$BK" ] && [ -f "$BK" ] || { echo "FEHLER: kein Backup erzeugt — Abbruch (Daten unangetastet)." >&2; exit 1; }
-echo "    Backup: $BK"
+# Vollständigkeit prüfen, BEVOR gleich das Volume zerstört wird: ein vollständiger
+# Plain-SQL-Dump endet immer mit dem pg_dump-Trailer. Fehlt er, war der Dump
+# abgebrochen (partiell-aber-valides gzip) -> NICHT weitermachen.
+if ! gzip -dc "$BK" | tail -5 | grep -q "PostgreSQL database dump complete"; then
+    echo "FEHLER: Dump-Trailer fehlt — Backup unvollständig. Abbruch (Daten unangetastet)." >&2; exit 1
+fi
+echo "    Backup: $BK (vollständig)"
 
 echo "==> 2/5  Exaktes DB-Volume ermitteln (vor dem Stop)..."
-VOL="$(docker compose ps -q db | xargs -r docker inspect -f '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}')"
-[ -n "$VOL" ] || { echo "FEHLER: DB-Volume nicht gefunden — laeuft der alte Stack noch?" >&2; exit 1; }
+VOL="$(docker compose ps -q db | xargs -r docker inspect \
+    --format '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{"\n"}}{{end}}{{end}}' | grep -v '^$')"
+VOL_COUNT="$(printf '%s\n' "$VOL" | grep -c . || true)"
+[ "$VOL_COUNT" = "1" ] || { echo "FEHLER: ${VOL_COUNT} Volumes auf /var/lib/postgresql/data (erwartet: 1) — bitte manuell prüfen." >&2; exit 1; }
 echo "    Volume: $VOL"
 
 echo "==> 3/5  Stack stoppen + altes DB-Volume entfernen (Backups bleiben erhalten)..."
 docker compose down
+# Sicherstellen, dass kein Container das Volume noch hält (sonst rm-Race).
+if docker ps -a --filter "volume=${VOL}" -q | grep -q .; then
+    echo "FEHLER: Volume ${VOL} wird noch von einem Container gehalten — bitte manuell prüfen." >&2; exit 1
+fi
 docker volume rm "$VOL"
 
 echo "==> 4/5  Frischen PG18-Stack bauen + starten..."
 docker compose up -d --build
 for _ in $(seq 1 40); do
     [ "$(docker compose ps db --format '{{.Health}}' 2>/dev/null)" = "healthy" ] && break
+    STATE="$(docker compose ps db --format '{{.State}}' 2>/dev/null)"
+    if [ "$STATE" = "exited" ] || [ "$STATE" = "dead" ]; then
+        echo "FEHLER: db-Container unerwartet beendet:" >&2
+        docker compose logs --tail=30 db >&2
+        echo "Backup liegt unter ${BK}." >&2; exit 1
+    fi
     sleep 3
 done
 [ "$(docker compose ps db --format '{{.Health}}' 2>/dev/null)" = "healthy" ] \


### PR DESCRIPTION
## 1.10.0 — PostgreSQL 18 + python-holidays

Minor-Bump wegen neuer Major-DB (PostgreSQL 16 → 18).

### PostgreSQL 16.13 → 18.4
- **Fresh**: theseus-rs 18.4 (glibc-2.34-portabel ✓), docker `postgres:18-alpine` + `postgresql-client-18`; `PGDATA` explizit gesetzt (PG18-Image legt Daten sonst in einen Major-Unterordner). validate-release **5 Distros grün**.
- **Native Major-Upgrade** (nicht in-place): `install.sh` dumpt vor dem Binary-Tausch mit den ALTEN Binaries, legt die Alt-Daten zur Seite (NIE gelöscht) + Marker; `praxiszeit-server.py` initialisiert PG18 frisch + spielt den Dump ein. **Auf .131 verifiziert** (PG16.13→18.4, alle Daten-Tabellen byte-genau, Login OK).
- **Docker Major-Upgrade**: `tools/docker/update-pg-major.sh` (backup → nur DB-Volume entfernen → frischer PG18 → restore). **Lokal verifiziert** (Daten byte-genau, Login 200).

### workalendar → python-holidays (#175)
workalendar seit 2023 unmaintained; python-holidays bildet aktuelle Bundesland-Feiertage korrekt ab (MV Frauentag seit 2023, TH Weltkindertag, BB Oster/Pfingstsonntag). Bayern behält Mariä Himmelfahrt (catholic-Kategorie). Äquivalenz aller 16 Länder × 2 Jahre geprüft, keine Regression.

### Review-Härtung (3-Agenten-Review, alle Findings ≤low gefixt)
pg_dump-pipefail + Dump-Größencheck; Restore via `psql -f -v ON_ERROR_STOP=1` (streamend, kein OOM); fehlender Dump → harter Abbruch statt leerer DB; docker restore.sh ON_ERROR_STOP=1; update-pg-major.sh Dump-Trailer-/Volume-/Health-Guards; unbekanntes Bundesland → ValueError.

**Tests**: 979 Backend (SQLite) + 31 Feiertags-Tests grün; validate-release 5 Distros; native .131 + docker lokal byte-genau.

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
