### PR TITLE
refactor(#219): system_settings-Lese-Helfer in settings_service bündeln

### DIFF
--- a/backend/app/routers/admin_settings.py
+++ b/backend/app/routers/admin_settings.py
@@ -13,15 +13,6 @@ from typing import Dict
 router = APIRouter(prefix="/api/admin", tags=["admin"], dependencies=[Depends(require_admin)])
 
 
-def _get_setting(db: Session, key: str, default: str = "", tenant_id=None) -> str:
-    """Retrieve a value from system_settings."""
-    q = db.query(SystemSetting).filter(SystemSetting.key == key)
-    if tenant_id is not None:
-        q = q.filter(SystemSetting.tenant_id == tenant_id)
-    s = q.first()
-    return s.value if s else default
-
-
 # #146: the four special-day keys (24./31.12. mode + counts_as_vacation) are
 # managed through this router too. They are added to the whitelist so the
 # generic PUT accepts them; mode keys are validated against the allowed modes.

--- a/backend/app/routers/vacation_requests.py
+++ b/backend/app/routers/vacation_requests.py
@@ -8,22 +8,13 @@ from datetime import datetime, timezone, timedelta, date
 from app.database import get_db
 from app.models import User, UserRole, PublicHoliday, Absence, AbsenceType, TimeEntryAuditLog
 from app.models.vacation_request import VacationRequest, VacationRequestStatus
-from app.models.system_setting import SystemSetting
 from app.middleware.auth import get_current_user
 from app.schemas.vacation_request import VacationRequestCreate, VacationRequestResponse, VacationRequestUpdate
 from app.services.calculation_service import count_workdays
 from app.services.timezone_service import today_local
+from app.services import settings_service
 
 router = APIRouter(prefix="/api/vacation-requests", tags=["vacation-requests"])
-
-
-def get_setting(db: Session, key: str, tenant_id, default: str = "") -> str:
-    """Retrieve a tenant-scoped value from system_settings."""
-    s = db.query(SystemSetting).filter(
-        SystemSetting.key == key,
-        SystemSetting.tenant_id == tenant_id,
-    ).first()
-    return s.value if s else default
 
 
 def _enrich(vr: VacationRequest, db: Session) -> VacationRequestResponse:
@@ -237,7 +228,7 @@ def create_vacation_request(
     requests up front so they don't reach the admin review queue as
     garbage.
     """
-    if get_setting(db, "vacation_approval_required", current_user.tenant_id, "false").lower() != "true":
+    if not settings_service.get_bool_setting(db, "vacation_approval_required", tenant_id=current_user.tenant_id):
         raise HTTPException(
             status_code=400,
             detail="Urlaubsanträge sind nicht aktiviert. Urlaub direkt über Abwesenheiten buchen.",

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -32,6 +32,7 @@ import uuid
 from sqlalchemy.orm import Session
 
 from app.models import SystemSetting
+from app.services import settings_service
 
 logger = logging.getLogger(__name__)
 
@@ -71,15 +72,6 @@ class BackupConfig:
 # Konfiguration (SystemSetting, global unter Default-Tenant)
 # ---------------------------------------------------------------------------
 
-def _get_setting(db: Session, key: str) -> Optional[str]:
-    row = (
-        db.query(SystemSetting)
-        .filter(SystemSetting.key == key, SystemSetting.tenant_id == DEFAULT_TENANT_ID)
-        .first()
-    )
-    return row.value if row else None
-
-
 def _set_setting(db: Session, key: str, value: str) -> None:
     row = (
         db.query(SystemSetting)
@@ -94,7 +86,7 @@ def _set_setting(db: Session, key: str, value: str) -> None:
 
 def get_backup_dir(db: Session) -> Path:
     """Effektives Backup-Verzeichnis: Setting-Override > Env > Docker-Default."""
-    override = (_get_setting(db, SETTING_LOCATION) or "").strip()
+    override = (settings_service.get_setting(db, SETTING_LOCATION, tenant_id=DEFAULT_TENANT_ID) or "").strip()
     if override:
         return Path(override)
     env_dir = os.environ.get("PRAXISZEIT_BACKUP_DIR", "").strip()
@@ -104,14 +96,14 @@ def get_backup_dir(db: Session) -> Path:
 
 
 def get_config(db: Session) -> BackupConfig:
-    enabled = (_get_setting(db, SETTING_ENABLED) or "false").lower() == "true"
+    enabled = settings_service.get_bool_setting(db, SETTING_ENABLED, tenant_id=DEFAULT_TENANT_ID)
     try:
-        hour = int(_get_setting(db, SETTING_HOUR) or DEFAULT_HOUR)
+        hour = int(settings_service.get_setting(db, SETTING_HOUR, tenant_id=DEFAULT_TENANT_ID) or DEFAULT_HOUR)
     except ValueError:
         hour = DEFAULT_HOUR
     hour = min(23, max(0, hour))
     try:
-        retention = int(_get_setting(db, SETTING_RETENTION_DAYS) or DEFAULT_RETENTION_DAYS)
+        retention = int(settings_service.get_setting(db, SETTING_RETENTION_DAYS, tenant_id=DEFAULT_TENANT_ID) or DEFAULT_RETENTION_DAYS)
     except ValueError:
         retention = DEFAULT_RETENTION_DAYS
     retention = max(1, retention)

--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -1,0 +1,35 @@
+"""Zentrale Lese-Helfer für ``system_settings`` (#219 Dedup).
+
+Vorher lag dieselbe Query 3× vor (``vacation_requests.get_setting``,
+``admin_settings._get_setting`` [tot], ``backup_service._get_setting``) plus
+diverse Inline-Reads. Diese Helfer bündeln die Lese-Logik; Schreiber bleiben
+bei den jeweiligen Routern/Services.
+"""
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.system_setting import SystemSetting
+
+
+def get_setting(db: Session, key: str, tenant_id=None, default: Optional[str] = None) -> Optional[str]:
+    """Lies den Roh-Wert eines ``system_settings``-Eintrags.
+
+    ``tenant_id=None`` filtert NICHT nach Tenant (RLS scoped ohnehin); ein
+    übergebenes ``tenant_id`` filtert zusätzlich explizit (F-026 belt-and-
+    suspenders). Fehlt der Schlüssel, wird ``default`` zurückgegeben.
+    """
+    q = db.query(SystemSetting).filter(SystemSetting.key == key)
+    if tenant_id is not None:
+        q = q.filter(SystemSetting.tenant_id == tenant_id)
+    s = q.first()
+    return s.value if s else default
+
+
+def get_bool_setting(db: Session, key: str, tenant_id=None, default: bool = False) -> bool:
+    """Boolean-Setting (``'true'``/``'false'``, case-insensitive). Fehlt der
+    Schlüssel, wird ``default`` zurückgegeben."""
+    raw = get_setting(db, key, tenant_id=tenant_id, default=None)
+    if raw is None:
+        return default
+    return raw.strip().lower() == "true"

--- a/backend/app/services/special_days_service.py
+++ b/backend/app/services/special_days_service.py
@@ -68,7 +68,7 @@ VACATION_FLAG_KEYS = {
 def _get_raw_setting(db: Session, key: str, tenant_id, default: str) -> str:
     """Read a single tenant-scoped value from ``system_settings``.
 
-    Mirrors ``holiday_service.get_holiday_state`` / ``admin_settings._get_setting``.
+    Mirrors ``holiday_service.get_holiday_state`` / ``settings_service.get_setting``.
     """
     # SEC-F: always scope by tenant_id. All callers pass a real tenant_id, and
     # leaving the filter conditional risked leaking another tenant's setting if


### PR DESCRIPTION
Bündelt die 3× duplizierte SystemSetting-Read-Query in `settings_service` (get_setting/get_bool_setting). `admin_settings._get_setting` war toter Code → gelöscht. Verhalten unverändert, 98 betroffene Tests grün. Enrichment-/Hook-Dedup bewusst zurückgestellt (Risiko).

Teil von #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)