### PR TITLE
chore(e2e): lokale screenshots-*/ ignorieren

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 playwright-report/
 test-results/
-screenshots-release/
+screenshots-*/


### PR DESCRIPTION
Verallgemeinert das bestehende `screenshots-release/`-Ignore auf `screenshots-*/` (deckt die lokalen .131-Screenshot-Läufe ab). Reine Aufräum-Änderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)