### PR TITLE
fix(build): .gitattributes erzwingt LF für Shell-/SQL-Skripte (CRLF-Shebang-Bug)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,42 @@
+# Line-Ending-Normalisierung.
+#
+# Hintergrund: Ohne diese Datei werden auf Windows (core.autocrlf=true) ALLE
+# Textdateien — auch Shell-Skripte — als CRLF ausgecheckt. Ein in einem Linux-
+# Container ausgefuehrtes Skript mit CRLF-Shebang bricht dann mit
+#   "/bin/bash^M: bad interpreter: No such file or directory"
+# ab. Real aufgetreten beim PG16->18-Docker-Reinit: die
+# docker-entrypoint-initdb.d-Skripte (init-db-user.sh) liefen nicht ->
+# praxiszeit_app ohne Passwort -> Backend-Login "password authentication failed".
+#
+# Git speichert Text im Repo als LF; eol=lf/eol=crlf steuert den Checkout.
+
+* text=auto
+
+# In Linux-Containern/Hosts ausgefuehrte Skripte MUESSEN LF sein.
+*.sh    text eol=lf
+*.bash  text eol=lf
+*.sql   text eol=lf
+
+# Windows-Skripte bleiben CRLF.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Binaerdateien nie normalisieren.
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.webp  binary
+*.pdf   binary
+*.ttf   binary
+*.otf   binary
+*.woff  binary
+*.woff2 binary
+*.zip   binary
+*.gz    binary
+*.exe   binary
+*.xls   binary
+*.xlsx  binary
+*.ods   binary


### PR DESCRIPTION
## Problem
Ohne `.gitattributes` checkt Windows (`core.autocrlf=true`) **alle** Textdateien als CRLF aus — auch `*.sh`. Ein im Linux-Container ausgeführtes Skript mit CRLF-Shebang bricht mit:
```
/docker-entrypoint-initdb.d/02_init-db-user.sh: /bin/bash^M: bad interpreter: No such file or directory
```

**Real aufgetreten beim PG16→18-Docker-Reinit (1.10.0):** die `docker-entrypoint-initdb.d`-Skripte liefen nicht → `praxiszeit_app` ohne Passwort → Backend `password authentication failed for user "praxiszeit_app"` → Stack nicht lauffähig. `git ls-files --eol` zeigte `i/lf w/crlf` (Repo LF, Windows-Checkout CRLF).

Betrifft auch das **Docker-Bundle** (`build-release.sh --docker-only` auf Windows würde CRLF-`.sh` ausliefern → Kunden-Fresh-Install bzw. `tools/docker/update-pg-major.sh` kaputt).

## Fix
`.gitattributes`:
- `*.sh` / `*.bash` / `*.sql` → **`eol=lf`** (Linux-Container/Hosts)
- `*.bat` / `*.cmd` / `*.ps1` → `eol=crlf` (Windows)
- binary-Markierungen (png/jpg/pdf/ttf/woff/zip/gz/exe/xls/…)

Repo-Blobs sind bereits LF → `git add --renormalize .` ändert **keine** Datei-Inhalte (rein additiv, nur die neue `.gitattributes`).

## Kein Release/Version-Bump
Reiner Build-/Repo-Hygiene-Fix: **kein App-Code geändert**, `APP_VERSION` bleibt 1.10.0 (updater.py/package.json/build-release.sh unverändert). Das bereits ausgelieferte native Windows-Artefakt (setup.exe/zip, nutzt `.bat`) ist **nicht** betroffen und muss nicht neu gebaut werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
