### PR TITLE
fix(1.10.1): Review-Härtung (≤medium) + docs/BUILD.md

### DIFF
--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -224,6 +224,7 @@ def get_next_vacation(
     today = today_local()
 
     next_vacation = db.query(Absence).filter(
+        Absence.tenant_id == current_user.tenant_id,  # F-026: explizit, nicht nur RLS
         Absence.user_id == current_user.id,
         Absence.type == AbsenceType.VACATION,
         Absence.date >= today

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -135,7 +135,17 @@ def update_config(
             # (nur im Log sichtbar) scheitern zu lassen.
             try:
                 probe_dir = Path(loc)
-                probe_dir.mkdir(parents=True, exist_ok=True)
+                # KEIN mkdir(parents=True): ein Admin könnte sonst per Setting
+                # beliebige Verzeichnisbäume auf dem Host anlegen lassen (Review:
+                # Privilege-Surface auf Native-Installs). Das übergeordnete
+                # Verzeichnis muss existieren; nur das letzte Segment wird angelegt.
+                if not probe_dir.exists():
+                    if not probe_dir.parent.is_dir():
+                        raise BackupError(
+                            f"Übergeordnetes Verzeichnis von '{loc}' existiert nicht — "
+                            "bitte den Pfad manuell anlegen."
+                        )
+                    probe_dir.mkdir(exist_ok=True)
                 probe = probe_dir / ".praxiszeit-write-test"
                 probe.write_text("ok")
                 probe.unlink()
@@ -289,10 +299,11 @@ def create_backup(db: Session) -> BackupFile:
 
     write_error: Optional[OSError] = None
     try:
-        with gzip.open(backup_file, "wb") as gz:
-            # DSGVO Art. 32: das Backup enthält personenbezogene Daten -> nur der
-            # Dienst-Owner darf es lesen (gzip.open legt sonst per umask 0o644 an).
-            os.chmod(backup_file, 0o600)
+        # DSGVO Art. 32: das Backup enthält personenbezogene Daten -> ATOMAR nur
+        # Owner-lesbar anlegen (os.open mit 0o600), nicht erst gzip.open(umask 0644)
+        # + nachträgliches chmod (dazwischen kurz world-readable).
+        _fd = os.open(backup_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(_fd, "wb") as _raw, gzip.GzipFile(fileobj=_raw, mode="wb") as gz:
             assert proc.stdout is not None
             while True:
                 chunk = proc.stdout.read(8192)

--- a/backend/app/services/holiday_service.py
+++ b/backend/app/services/holiday_service.py
@@ -205,7 +205,9 @@ def delete_all_holidays(db: Session, tenant_id=None, source: Optional[str] = Non
     if source is not None:
         query = query.filter(PublicHoliday.source == source)
     count = query.count()
-    query.delete()
+    # synchronize_session=False: count() hat die Rows schon in die Session geladen;
+    # die Default-"evaluate"-Strategie kann sonst bei geladenen Objekten brechen.
+    query.delete(synchronize_session=False)
     # F-034: invalidate the cache after bulk-delete
     invalidate_holiday_cache(tenant_id=tenant_id)
     # No commit – let the caller manage the transaction

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,0 +1,197 @@
+# BUILD.md — Release-Artefakte bauen (alle OS)
+
+Anleitung zum Bauen der PraxisZeit-Release-Pakete für **Linux (x64 + arm64)**,
+**Windows (x64)**, **macOS (Intel + Apple Silicon)** und **Docker**. Mit allen
+Footguns, die in der Praxis zugeschlagen haben.
+
+> **Goldene Regel:** Ein Release ist erst dann fertig, wenn `tools/validate-release.sh`
+> (Linux, 5 Distros) **grün** ist **und** mindestens ein **echter Login** auf einem
+> realen Host geprüft wurde (Unit-Tests + validate-release reichen NICHT —
+> mehrere 1.8.x-Bugs sind genau dadurch durchgerutscht).
+
+---
+
+## 1. Was gebaut wird
+
+| Artefakt | Inhalt | DB |
+|---|---|---|
+| `praxiszeit-<v>-linux-x64.tar.gz` | Nativer Installer + Python + PostgreSQL (flach entpackt) | theseus-rs PG **18.4** |
+| `praxiszeit-<v>-macos-x64/arm64.tar.gz` | Nativer Installer (Intel / Apple Silicon) | theseus-rs PG **18.4** |
+| `praxiszeit-<v>-windows-x64.zip` | `.bat`-Installer-Baum (setup.bat-Fallback) | EDB-Installer PG **18.4** |
+| `praxiszeit-<v>-setup-windows-x64.exe` | Avalonia-GUI-Single-File-Installer (#81) | (bettet das Paket ein) |
+| `praxiszeit-<v>-docker.tar.gz` | compose + Build-Kontext + backup/restore/update-pg-major | `postgres:18-alpine` |
+
+Alles entsteht aus **einem** Lauf von `tools/build-release.sh`.
+
+---
+
+## 2. Voraussetzungen
+
+| Tool | Wofür | Hinweis |
+|---|---|---|
+| **Docker** | Frontend-Build, Backend-Image, validate-release | Pflicht. |
+| **.NET 10 SDK** (`dotnet --version` → `10.x`) | Windows-`setup.exe` (Avalonia) | Fehlt es → `--skip-setup` (nur `.bat`-Fallback, kein GUI-Installer). |
+| `curl`, `sha256sum`, `tar`, `unzip`, `objdump` | Download/Verify/Pack | objdump nur für den glibc-Check. |
+| **KEIN Host-Node ≥ 26** | — | ⚠️ siehe §3. Host-Node 26 **bricht** den Frontend-Schritt. |
+
+> ⚠️ **Mehrere Build-Maschinen (Büro):** Alle relevanten Binaries werden
+> **versioniert + SHA256-verifiziert** geladen (theseus-PG, Python-Standalone,
+> NSSM, VC++-Redist, **Windows-PG seit 1.10.1**). Dadurch bauen alle Maschinen
+> **bit-identische** Bundles. Wenn eine Maschine abweicht → Cache-Datei mit
+> falscher SHA (siehe §6 Windows).
+
+---
+
+## 3. Frontend vorbauen (Host-Node-26-Footgun)
+
+`build-release.sh` ruft intern `npm run build`. **Host-Node ≥ 26 bricht das ab.**
+Darum das Frontend **mit Docker node:20 vorbauen** und dann mit `--skip-frontend`
+releasen (das `frontend/dist/` muss existieren):
+
+```bash
+docker run --rm -v "$(pwd)/frontend:/app" -w /app node:20-alpine sh -c "npm run build"
+# danach immer mit --skip-frontend bauen
+```
+
+`__APP_VERSION__` (Footer) wird aus `frontend/package.json.version` ins Bundle
+inlined — ohne korrekten Bump zeigt die UI die alte Version.
+
+---
+
+## 4. Version-Bump (3 Stellen + Lock)
+
+Vor jedem Release synchron halten — `build-release.sh` **erzwingt** die Konsistenz
+und bricht sonst ab:
+
+```bash
+# 1) backend/app/core/updater.py   -> APP_VERSION = "X.Y.Z"
+# 2) frontend/package.json         -> "version": "X.Y.Z"
+# 3) tools/build-release.sh        -> APP_VERSION="X.Y.Z"
+# 4) Lock aktualisieren:
+docker run --rm -v "$(pwd)/frontend:/app" -w /app node:20-alpine sh -c "npm install --package-lock-only"
+```
+
+`frontend/package.json.version` landet als `__APP_VERSION__` im Footer (`Layout.tsx`).
+
+---
+
+## 5. Bauen
+
+### Alles (alle OS)
+```bash
+docker run --rm -v "$(pwd)/frontend:/app" -w /app node:20-alpine sh -c "npm run build"  # Frontend vorbauen
+bash tools/build-release.sh --skip-frontend
+bash tools/validate-release.sh          # Linux-Tarball: 5-Distro-Docker-Smoke (PG18 initdb/postgres)
+```
+
+### Einzelne OS (schnellere Iteration)
+```bash
+bash tools/build-release.sh --linux-only   --skip-frontend
+bash tools/build-release.sh --windows-only --skip-frontend
+bash tools/build-release.sh --docker-only                       # nur Docker-Bundle
+bash tools/build-release.sh --windows-only --setup-only         # nur die setup.exe iterieren
+bash tools/build-release.sh --windows-only --skip-setup         # Windows ohne setup.exe (.NET fehlt)
+```
+
+**Erfolg = `dist/praxiszeit-X.Y.Z-*.{tar.gz,zip,exe}` existieren.** Der Exit-Code 1
+am Ende ist **kosmetisch** (letztes `$BUILD_LINUX && cat <<EOF` liefert 1 bei false).
+
+---
+
+## 6. Pro-OS-Details + Footguns
+
+### Linux (x64 + arm64)
+- **PostgreSQL = `theseus-rs` 18.4.0** (manylinux, glibc-2.34-portabel: Ubuntu 22.04+/
+  Debian 12+/RHEL·Rocky·Alma 9+/Fedora 35+). Download SHA256-verifiziert. Der Build
+  **bricht ab**, wenn die Binaries glibc-Symbole **> 2.34** brauchen.
+- `libxml2.so.2` wird mitgebündelt (Rolling-Distros wie Arch liefern nur `.so.16`, #177).
+- Tarball entpackt **flach** (`tar -C <ordner> .`, kein Top-Level-Ordner) — `install.sh`/
+  `validate-release.sh` setzen das voraus.
+- **`validate-release.sh` ist Pflicht** (5 Distros) — testet aber **NUR** initdb/postgres,
+  **keinen echten Login**. Nach Dep-Bumps zusätzlich realen Login prüfen.
+
+### Windows (x64) — der größte Footgun-Garten
+- **PostgreSQL = EDB-Installer (`postgresql-installer.exe`, PG 18.4)** — NICHT theseus.
+- ⚠️ **PG-Installer ist SHA256-gepinnt (`PG_WINDOWS_SHA256` in build-release.sh) +
+  wird per direktem EDB-Link auto-geladen + verifiziert.** Früher griff der Build blind
+  die erste `~/Downloads/postgresql-*-windows-x64.exe` → **jede Maschine bundelte still
+  eine andere PG-Version** (1.10.0-Windows war versehentlich PG 16.13 statt 18). Beim
+  PG-Bump `PG_WINDOWS_SHA256` an die zur `POSTGRESQL_VERSION` passende
+  `postgresql-<maj.min>-<suffix>-windows-x64.exe` mitziehen.
+- **EDB-403:** Der Auto-Download kann zeitweise mit HTTP 403 blocken. Dann bricht der
+  Build mit Manual-Hinweis + erwarteter SHA ab → Datei manuell laden, nach
+  `build/cache/postgresql-windows-x64.exe` legen, neu bauen.
+- **`setup.exe` braucht .NET 10 SDK** (`dotnet test`-Gate läuft VOR dem Build; rote
+  Tests → keine setup.exe). Cross-Build von Linux aus ist ok (echtes PE32+).
+- **ZIP-Größe:** die `setup.exe` darf **NICHT** in den `.bat`-ZIP-Baum kopiert werden
+  (sonst doppelt → ~985 MB statt ~490 MB, #231). Ein Build-Abort-Guard prüft das.
+- **Windows-Python-Deps werden beim BUILD vorinstalliert** (cp313-Wheels in
+  `bin/python/Lib/site-packages`, `PYTHONNOUSERSITE=1` beim pip), damit der Kunde
+  ohne PyPI-Download installiert.
+- **Build-Staging-Race:** Phase 2 kopiert `praxiszeit-server.py`/`app/` früh ins
+  Staging — Code-Edits NACH Build-Start landen NICHT im Artefakt. Nach Server-Änderungen
+  komplett neu bauen + im ZIP verifizieren.
+- Git Bash on Windows: `rsync`/`zip` fehlen → `tar`/PowerShell-`Compress-Archive`-Fallbacks.
+
+### macOS (Intel + Apple Silicon)
+- **PostgreSQL = theseus-rs 18.4** (EDB-DMG seit #125 raus). Downloads SHA256- **und**
+  per `file(1)` als **Mach-O** geprüft.
+- ⚠️ **`validate-macos.yml` läuft auf dem Privat-Repo NIE** (Runs bleiben `queued`, kein
+  Runner). macOS-Release stützt sich auf die lokale Mach-O-`file`-Prüfung im Build,
+  **nicht** auf den GH-Workflow; echtes `initdb`-Smoke ggf. manuell auf einem Mac.
+
+### Docker
+- `--docker-only` baut `praxiszeit-<v>-docker.tar.gz` (**Top-Level-Ordner!**) mit
+  compose-Dateien + `.env.example` + `generate-secrets.sh` + `backup.sh`/`restore.sh`/
+  **`update-pg-major.sh`** + Build-Kontext (`backend/ frontend/ ssl/ prometheus/ grafana/`).
+- DB = `postgres:18-alpine`; Backend-Image bringt `postgresql-client-18` (für #213-pg_dump).
+  ⚠️ PG18-Image legt Daten per Default in einen Major-Unterordner → in der compose
+  `PGDATA=/var/lib/postgresql/data` explizit gesetzt.
+- Der `-docker`-Name passt NICHT ins strikte pzweb-Upload-Regex → gehört an ein
+  **GitHub-Release**, nicht in den pzweb-Shop.
+
+---
+
+## 7. PostgreSQL-Major-Upgrade (16 → 18) — beim Bauen mitdenken
+
+Ab 1.10.0 ist die DB **PG 18**. Ein Major-Upgrade ist **nicht in-place**:
+- **Nativ:** `install.sh` dumpt vor dem Binary-Tausch mit den ALTEN Binaries, legt die
+  Alt-Daten als `data/db.pgXX-<ts>` zur Seite (nie gelöscht) + Marker;
+  `praxiszeit-server.py` spielt den Dump in den frischen Cluster.
+- **Docker:** `tools/docker/update-pg-major.sh` (backup → nur `*_postgres_data`-Volume
+  weg → frischer PG18 → restore).
+
+Diese Pfade sind Teil der Artefakte — bei Änderungen am PG-Start/Connect immer
+`pg_is_running()` + `_database_url()` + `pg_init`-`listen_addresses` zusammen pflegen.
+
+---
+
+## 8. Release-Ablage + Prüfsummen
+
+```bash
+# Artefakte nach pzweb/releases/version_X.Y.Z/
+# Prüfsummen PRO DATEI als checksum_<dateiname> (Inhalt: eine sha256sum-Zeile) —
+# NICHT eine gemeinsame SHA256SUMS.txt (sonst überschreibt Windows die Linux-Summe).
+for f in praxiszeit-X.Y.Z-*.{tar.gz,zip,exe}; do sha256sum "$f" > "checksum_$f"; done
+```
+
+**Dateiname-Pattern (striktes pzweb-Regex):**
+`praxiszeit-<version>-(linux-x64|macos-x64|macos-arm64|windows-x64).(tar.gz|zip)`
+— Tippfehler ⇒ 422 beim Upload.
+
+---
+
+## 9. Footgun-Schnellliste
+
+- Host-Node ≥ 26 → Frontend mit `docker node:20` vorbauen + `--skip-frontend`.
+- Windows-PG-Installer **SHA-gepinnt** — bei abweichender Maschine: falsche Cache-Datei.
+- `setup.exe` braucht .NET 10; darf nicht doppelt ins ZIP (#231-Guard).
+- theseus-PG bricht bei glibc > 2.34 ab; libxml2.so.2 wird mitgebündelt.
+- Build-Exit-Code 1 am Ende = kosmetisch; Erfolg = `dist/`-Dateien existieren.
+- Nach Server-Code-Edits **komplett** neu bauen (Staging-Race) + im ZIP verifizieren.
+- `validate-release` testet KEINEN Login → realen Host-Login nach Dep-Bumps prüfen.
+- Prüfsummen **pro Datei** (`checksum_<datei>`), nicht gemeinsam.
+- `validate-macos.yml` läuft nie (Privat-Repo) → lokale Mach-O-Prüfung ist der Gate.
+
+---
+*Stand: 1.10.1 (PostgreSQL 18.4 auf allen Plattformen).*

--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -454,9 +454,13 @@ if [ "${GEN_SSL,,}" = "j" ]; then
     # daraus ein gueltiges End-Entity-Server-Zertifikat statt eines CA-Certs
     # (ein CA-Cert wird vom Browser nicht als Server-Cert akzeptiert).
     # Fehler NICHT verschlucken: schlaegt openssl fehl, soll der Install es zeigen.
+    # PRACTICE_NAME fuer -subj entschaerfen: ein '/' (z.B. "Dr. Mueller / Partner")
+    # zerstoert sonst den RDN-String -> Cert-Erzeugung scheitert -> kein TLS ->
+    # Login mit cookie_secure=true bricht. '/' und '\' -> '_', ',' -> ' '.
+    _O_NAME=$(printf '%s' "${PRACTICE_NAME}" | tr '/\\' '__' | tr ',' ' ')
     if openssl req -x509 -newkey rsa:2048 -keyout "${INSTALL_DIR}/config/ssl/key.pem" \
         -out "${INSTALL_DIR}/config/ssl/cert.pem" -days 3650 -nodes \
-        -subj "/CN=PraxisZeit/O=${PRACTICE_NAME}" \
+        -subj "/CN=PraxisZeit/O=${_O_NAME}" \
         -addext "subjectAltName=${SAN}" \
         -addext "basicConstraints=critical,CA:FALSE" \
         -addext "keyUsage=critical,digitalSignature,keyEncipherment" \

--- a/installer/windows/uninstall.bat
+++ b/installer/windows/uninstall.bat
@@ -72,11 +72,10 @@ if %errorlevel% neq 0 (
 
 SET "BACKUP_FILE=%BACKUP_DIR%\praxiszeit-backup-%date:~6,4%%date:~3,2%%date:~0,2%.sql"
 
-REM Versuche mit User praxiszeit, dann postgres
-"%PG_DUMP%" -U praxiszeit -d praxiszeit -f "%BACKUP_FILE%" 2>nul
-if not exist "%BACKUP_FILE%" (
-    "%PG_DUMP%" -U postgres -d praxiszeit -f "%BACKUP_FILE%" 2>nul
-)
+REM -w PFLICHT: ohne haengt pg_dump headless an der Passwort-Abfrage (stderr ist
+REM unterdrueckt). Der PraxisZeit-Cluster hat KEINEN postgres-Superuser -> der
+REM frueher Fallback haette nur gehangen, daher entfernt.
+"%PG_DUMP%" -w -U praxiszeit -d praxiszeit -f "%BACKUP_FILE%" 2>nul
 
 if exist "%BACKUP_FILE%" goto :backup_ok
 

--- a/installer/windows/update-wizard.ps1
+++ b/installer/windows/update-wizard.ps1
@@ -622,7 +622,10 @@ function Step-CopyFiles {
             '/NFL', '/NDL', '/NJH', '/NJS', '/NC', '/NS',
             '/R:2', '/W:2',
             '/XD', 'data', 'logs', 'ssl',
-            '/XF', 'praxiszeit.conf', '.db-credentials', '.secret-key', 'license.key'
+            # cert.pem/key.pem zusaetzlich ausschliessen: das SSL-Cert liegt in
+            # config\ssl\ (vom /XD 'ssl' NICHT erfasst, da nur Top-Level), sonst
+            # ueberschreibt ein Paket-Platzhalter das echte Cert des Betreibers.
+            '/XF', 'praxiszeit.conf', '.db-credentials', '.secret-key', 'license.key', 'cert.pem', 'key.pem'
         )
         Write-Log "  robocopy $WizardDirResolved -> $InstallDir"
         $out = & robocopy.exe @rcArgs 2>&1

--- a/praxiszeit-server.py
+++ b/praxiszeit-server.py
@@ -1304,9 +1304,14 @@ def _restore_pending_major_upgrade():
     import tempfile
     env = {**pg_env(), "PGPASSWORD": su_password}
     tmp_path = None
+    proc = None
     try:
         with tempfile.NamedTemporaryFile(suffix=".sql", delete=False, dir=str(DATA_DIR)) as tmp:
             tmp_path = tmp.name
+            # DSGVO Art. 32: der entpackte Klartext-Dump enthält personenbezogene
+            # Daten -> explizit nur Owner-lesbar (NamedTemporaryFile ist zwar schon
+            # 0600, aber explizit = robust gegen künftige Umstellungen).
+            os.chmod(tmp_path, 0o600)
             with gzip.open(dump, "rb") as gz:
                 shutil.copyfileobj(gz, tmp)
         proc = subprocess.run(
@@ -1320,6 +1325,13 @@ def _restore_pending_major_upgrade():
                 os.unlink(tmp_path)
             except OSError:
                 pass
+    if proc is None:
+        # gzip/copy ist geflogen -> NICHT in den UnboundLocalError laufen, sondern
+        # klar melden (Alt-Daten + Dump bleiben erhalten).
+        raise RuntimeError(
+            "PG-Upgrade-Restore: Dump konnte nicht entpackt werden (I/O-Fehler oder "
+            "korrupte Datei) — alte Daten unter data/db.pg* erhalten."
+        )
     if proc.returncode != 0:
         stderr = proc.stderr.decode("utf-8", "replace") if proc.stderr else ""
         logger.error(

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -172,6 +172,22 @@ if [ "$_be_ver" != "$APP_VERSION" ]; then
     exit 1
 fi
 
+# package-lock.json mitprüfen (4. Stelle, CLAUDE.md): npm ci scheitert sonst erst
+# spät beim Frontend-Build auf einer 2. Maschine — hier früh + mit klarer Meldung.
+_lock_ver=$(sed -n 's/^  "version": *"\([^"]*\)".*/\1/p' "${REPO_DIR_PRE}/frontend/package-lock.json" | head -1)
+if [ -n "$_lock_ver" ] && [ "$_lock_ver" != "$APP_VERSION" ]; then
+    echo -e "${RED}[ERROR]${NC} Version-Drift: frontend/package-lock.json = ${_lock_ver} (erwartet ${APP_VERSION})" >&2
+    echo -e "${RED}[ERROR]${NC} Fix: cd frontend && npm install --package-lock-only" >&2
+    exit 1
+fi
+
+# POSTGRESQL_VERSION muss 3-komponentig sein (z.B. 18.4.0): die Windows-EDB-URL
+# leitet sich via ${POSTGRESQL_VERSION%.*} ab -> bei "18.4" käme die falsche URL.
+if ! [[ "$POSTGRESQL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo -e "${RED}[ERROR]${NC} POSTGRESQL_VERSION='${POSTGRESQL_VERSION}' muss drei Komponenten haben (z.B. 18.4.0)" >&2
+    exit 1
+fi
+
 # BETA_MODE-Hinweis: solange Default True, ist die Lizenzpruefung in JEDEM
 # gebauten Paket deaktiviert (keine Lizenz noetig). Das ist in der Beta gewollt,
 # aber vor dem ersten KOSTENPFLICHTIGEN Release MUSS BETA_MODE auf False —
@@ -293,7 +309,13 @@ download_with_sha() {
             fi
             info "SHA256 verifiziert: ${name}"
         else
-            warn "Keine .sha256-Datei fuer ${name} (Quelle: ${sha_url})"
+            # Hart abbrechen statt warn(): ohne .sha256 lässt sich die Integrität
+            # nicht garantieren -> ein gecachter partieller/fremder Tarball würde
+            # sonst ungeprüft ins Release wandern (genau der Fehlermodus, den der
+            # Pin verhindern soll).
+            error "Keine .sha256-Datei fuer ${name} (Quelle: ${sha_url}) — Integrität nicht prüfbar, Abbruch."
+            rm -f "$target"
+            return 1
         fi
     fi
 }

--- a/tools/docker/backup.sh
+++ b/tools/docker/backup.sh
@@ -31,9 +31,11 @@ OUT="${BACKUP_DIR}/praxiszeit_$(date +%Y%m%d_%H%M%S).sql.gz"
 
 echo "Sichere Datenbank '${PG_DB}' (User '${PG_USER}') ..."
 if docker compose exec -T db pg_dump -U "$PG_USER" --clean --if-exists "$PG_DB" | gzip > "$OUT"; then
-    # Leeren/abgebrochenen Dump erkennen (1.8.12-Lehre): gzip muss intakt sein und
-    # entpackt mindestens ein Byte liefern, sonst war der Dump nicht erfolgreich.
-    if ! gzip -t "$OUT" 2>/dev/null || [ -z "$(gzip -dc "$OUT" 2>/dev/null | head -c 1)" ]; then
+    # Leeren/abgebrochenen Dump erkennen (1.8.12-Lehre): gzip muss intakt sein
+    # (-t fängt Trunkierung) UND mehr als ein leeres gzip-Gerüst (~20 Byte) sein.
+    # Kein `gzip -dc | head` unter pipefail (SIGPIPE-Footgun, CLAUDE.md) — die
+    # komprimierte Größe genügt: ein leeres gzip ist ~20 Byte, ein echter Dump KB+.
+    if ! gzip -t "$OUT" 2>/dev/null || [ "$(stat -c%s "$OUT" 2>/dev/null || echo 0)" -le 30 ]; then
         echo "FEHLER: Backup ist leer/ungueltig — wird geloescht." >&2
         rm -f "$OUT"
         exit 1

--- a/tools/docker/update-pg-major.sh
+++ b/tools/docker/update-pg-major.sh
@@ -22,7 +22,11 @@ BK="$(ls -1t backups/praxiszeit_*.sql.gz 2>/dev/null | head -1)"
 # Vollständigkeit prüfen, BEVOR gleich das Volume zerstört wird: ein vollständiger
 # Plain-SQL-Dump endet immer mit dem pg_dump-Trailer. Fehlt er, war der Dump
 # abgebrochen (partiell-aber-valides gzip) -> NICHT weitermachen.
-if ! gzip -dc "$BK" | tail -5 | grep -q "PostgreSQL database dump complete"; then
+# Kein `... | grep -q` unter `set -o pipefail`: grep beendet bei Treffer früh ->
+# tail/gzip bekommen SIGPIPE (141) -> pipefail macht die Pipe non-zero -> `if !`
+# kippt um (CLAUDE.md). Erst in eine Variable, dann per Here-String prüfen.
+_dump_tail="$(gzip -dc "$BK" | tail -5)"
+if ! grep -q "PostgreSQL database dump complete" <<<"$_dump_tail"; then
     echo "FEHLER: Dump-Trailer fehlt — Backup unvollständig. Abbruch (Daten unangetastet)." >&2; exit 1
 fi
 echo "    Backup: $BK (vollständig)"


### PR DESCRIPTION
3-Agenten-Review (Build-Pipeline · Backend-Security · Installer/Lifecycle), alle Findings bis medium gefixt: Backup atomar 0600, F-026-Lücke, holiday delete synchronize_session, uninstall pg_dump -w, update-wizard cert-Schutz, openssl-subj-Sanitize, build-SHA-hard-fail + lock-check + PG-Assertion, SIGPIPE-Fixes. + docs/BUILD.md (alle OS + Footguns). 979 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)