### PR TITLE
fix(#281): Monatsübersicht Tage statt Stunden + Krank-Opt-in + Admin-Review-Härtung

### DIFF
--- a/backend/app/routers/admin_change_requests.py
+++ b/backend/app/routers/admin_change_requests.py
@@ -24,7 +24,9 @@ from app.routers.time_entries import (
 )
 from app.services.break_validation_service import validate_daily_break
 from app.services.arbzg_utils import is_night_work
-from app.services.calculation_service import get_weekly_hours_for_date, get_daily_target_for_date
+from app.services.calculation_service import (
+    get_weekly_hours_for_date, get_daily_target_for_date, get_vacation_account,
+)
 from app.services import work_window_service
 from app.models.time_entry_audit_log import TimeEntryAuditLog
 
@@ -253,6 +255,7 @@ def review_change_request(
                     end_time=_eff_end,
                     break_minutes=cr.proposed_break_minutes or 0,
                     exclude_entry_id=exclude_id,
+                    tenant_id=cr.tenant_id,
                 )
                 if daily_hours_revalidate > MAX_DAILY_HOURS_HARD:
                     raise HTTPException(
@@ -469,6 +472,34 @@ def review_change_request(
             else:
                 hours = float(cr.proposed_absence_hours) if cr.proposed_absence_hours else 0
 
+            # M-2: Urlaubsbudget-Prüfung VOR dem INSERT — wie review_vacation_request
+            # und create_absence. Ohne diese Prüfung konnte ein per CR genehmigter
+            # Urlaub das verbleibende Budget überziehen (der Direkt-Buchungs- und der
+            # Antrags-Pfad prüfen, dieser nicht). Tagesprinzip (#156/#167): 1 freier
+            # Arbeitstag = 1 Urlaubstag. Die CR bucht genau EINEN Tag (cr.proposed_date)
+            # und kennt KEIN half_day-Feld → days_needed = 1,0 für einen abrechenbaren
+            # Tag. Für use_daily_schedule+track_hours-User zählt ein 0h-Tag nicht.
+            if (
+                cr_user
+                and cr.proposed_absence_type == AbsenceType.VACATION.value
+                and cr.proposed_date
+            ):
+                _bill_day = True
+                if getattr(cr_user, "use_daily_schedule", False) and cr_user.track_hours:
+                    _bw = get_weekly_hours_for_date(db, cr_user, cr.proposed_date)
+                    _bill_day = float(get_daily_target_for_date(cr_user, cr.proposed_date, _bw)) > 0
+                if _bill_day:
+                    vacation_account = get_vacation_account(db, cr_user, cr.proposed_date.year)
+                    days_needed = 1.0
+                    if days_needed > vacation_account["remaining_days"] + 1e-9:
+                        raise HTTPException(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            detail=(
+                                f"Nicht genügend Urlaubstage für {cr.proposed_date.year} "
+                                f"({vacation_account['remaining_days']:.1f} Tage verfügbar)"
+                            ),
+                        )
+
             new_absence = Absence(
                 user_id=cr.user_id,
                 tenant_id=cr_tenant_id,
@@ -500,6 +531,33 @@ def review_change_request(
 
         elif cr.request_type == ChangeRequestType.UPDATE:
             # absence already fetched in precondition check above
+            # M-4: Bei Datumswechsel prüfen, ob am Zieltag bereits eine andere
+            # Abwesenheit liegt — sonst verletzt das UPDATE den Unique-Constraint
+            # (tenant_id, user_id, date, type) und crasht mit 500. Spiegelt die
+            # Existenz-Prüfung des CREATE-Pfads (Z.307-325); with_for_update()
+            # schließt die Race zwischen Prüfung und Schreiben. Die eigene
+            # Absence (absence.id) wird ausgeklammert.
+            if cr.proposed_date and cr.proposed_date != absence.date:
+                conflicting_absence = (
+                    db.query(Absence)
+                    .filter(
+                        Absence.user_id == cr.user_id,
+                        Absence.tenant_id == cr.tenant_id,
+                        Absence.date == cr.proposed_date,
+                        Absence.id != absence.id,
+                    )
+                    .with_for_update()
+                    .first()
+                )
+                if conflicting_absence:
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail=(
+                            f"Am {cr.proposed_date.strftime('%d.%m.%Y')} existiert bereits "
+                            f"eine Abwesenheit ({conflicting_absence.type.value})"
+                        ),
+                    )
+
             # Audit-Log für Absence-CR UPDATE (alte Werte sichern)
             audit = TimeEntryAuditLog(
                 time_entry_id=None,
@@ -593,6 +651,7 @@ def review_change_request(
                 start_time=_w_start,
                 end_time=_w_end,
                 break_minutes=cr.proposed_break_minutes or 0,
+                tenant_id=cr.tenant_id,
             )
 
             # SS6 Abs. 2: Nachtarbeitnehmer-Tageslimit
@@ -614,6 +673,7 @@ def review_change_request(
                 start_time=_w_start,
                 end_time=_w_end,
                 break_minutes=cr.proposed_break_minutes or 0,
+                tenant_id=cr.tenant_id,
             )
             if weekly > MAX_WEEKLY_HOURS_WARN:
                 cr_response.warnings.append(

--- a/backend/app/routers/admin_helpers.py
+++ b/backend/app/routers/admin_helpers.py
@@ -65,7 +65,17 @@ def _enrich_cr_responses(crs: list, db: Session) -> list[ChangeRequestResponse]:
         if cr.reviewed_by:
             user_ids.add(cr.reviewed_by)
     user_ids.discard(None)
-    users = db.query(User).filter(User.id.in_(user_ids)).all() if user_ids else []
+    # F-026: scope referenced users (incl. reviewed_by) to the tenants of the
+    # requests they belong to — sonst könnte ein reviewed_by/user_id aus einem
+    # fremden Tenant durchsickern. Mirrors _enrich_vr_responses.
+    tenant_ids = {cr.tenant_id for cr in crs}
+    users = (
+        db.query(User)
+        .filter(User.id.in_(user_ids), User.tenant_id.in_(tenant_ids))
+        .all()
+        if user_ids
+        else []
+    )
     user_map = {u.id: u for u in users}
 
     results = []
@@ -99,7 +109,17 @@ def _enrich_audit_responses(logs: list, db: Session) -> list[AuditLogResponse]:
         if log.changed_by:
             user_ids.add(log.changed_by)
     user_ids.discard(None)
-    users = db.query(User).filter(User.id.in_(user_ids)).all() if user_ids else []
+    # F-026: scope referenced users (incl. changed_by) to the tenants of the
+    # audit rows they belong to — sonst könnte ein changed_by/user_id aus einem
+    # fremden Tenant durchsickern. Mirrors _enrich_vr_responses.
+    tenant_ids = {log.tenant_id for log in logs}
+    users = (
+        db.query(User)
+        .filter(User.id.in_(user_ids), User.tenant_id.in_(tenant_ids))
+        .all()
+        if user_ids
+        else []
+    )
     user_map = {u.id: u for u in users}
 
     results = []

--- a/backend/app/routers/admin_time_entries.py
+++ b/backend/app/routers/admin_time_entries.py
@@ -73,6 +73,7 @@ def admin_create_time_entry(
             db=db, user_id=user.id, entry_date=entry_data.date,
             start_time=eff_start, end_time=eff_end,
             break_minutes=entry_data.break_minutes,
+            tenant_id=current_user.tenant_id,
         )
         if daily_hours > MAX_DAILY_HOURS_HARD:
             raise HTTPException(
@@ -89,6 +90,7 @@ def admin_create_time_entry(
             db=db, user_id=user.id, entry_date=entry_data.date,
             start_time=eff_start, end_time=eff_end,
             break_minutes=entry_data.break_minutes,
+            tenant_id=current_user.tenant_id,
         )
         if weekly_hours > MAX_WEEKLY_HOURS_WARN:
             admin_create_warnings.append(f"WEEKLY_HOURS_WARNING: Wochenarbeitszeit beträgt {weekly_hours:.1f}h (>{MAX_WEEKLY_HOURS_WARN}h, §3 ArbZG)")
@@ -156,8 +158,12 @@ def admin_update_time_entry(
     if not entry:
         raise HTTPException(status_code=404, detail="Eintrag nicht gefunden")
 
-    # Get user for SS18 exempt check and night worker warning
-    affected_user = db.query(User).filter(User.id == entry.user_id).first()
+    # Get user for SS18 exempt check and night worker warning.
+    # F-026: expliziter Tenant-Filter zusätzlich zu RLS (belt-and-suspenders).
+    affected_user = db.query(User).filter(
+        User.id == entry.user_id,
+        User.tenant_id == current_user.tenant_id,
+    ).first()
 
     # Use provided values or fall back to existing
     update_date = entry_data.date if entry_data.date is not None else entry.date
@@ -199,6 +205,7 @@ def admin_update_time_entry(
             db=db, user_id=entry.user_id, entry_date=update_date,
             start_time=eff_start, end_time=eff_end,
             break_minutes=update_break_minutes, exclude_entry_id=entry.id,
+            tenant_id=current_user.tenant_id,
         )
         if daily_hours > MAX_DAILY_HOURS_HARD:
             raise HTTPException(
@@ -215,6 +222,7 @@ def admin_update_time_entry(
             db=db, user_id=entry.user_id, entry_date=update_date,
             start_time=eff_start, end_time=eff_end,
             break_minutes=update_break_minutes, exclude_entry_id=entry.id,
+            tenant_id=current_user.tenant_id,
         )
         if weekly_hours > MAX_WEEKLY_HOURS_WARN:
             admin_update_warnings.append(f"WEEKLY_HOURS_WARNING: Wochenarbeitszeit beträgt {weekly_hours:.1f}h (>{MAX_WEEKLY_HOURS_WARN}h, §3 ArbZG)")

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -224,12 +224,8 @@ def anonymize_user(
                 status_code=400,
                 detail=f"Sperrfrist läuft noch {remaining} Tag(e). Anonymisierung frühestens am {grace_end} möglich."
             )
-    elif user.is_active:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Benutzer muss zuerst deaktiviert werden"
-        )
-    # If deactivated_at is None but user is inactive: allow anonymization (legacy user)
+    # If deactivated_at is None but user is inactive: allow anonymization (legacy user).
+    # Der is_active-Fall ist bereits oben (vor der Grace-Period-Prüfung) abgefangen.
 
     user.first_name = "Gelöschter"
     user.last_name = "Benutzer"
@@ -336,10 +332,10 @@ def purge_user(
         VacationRequest.reviewed_by == user.id,
         VacationRequest.tenant_id == current_user.tenant_id,
     ).update({"reviewed_by": None}, synchronize_session=False)
-    db.query(WorkingHoursChange).filter(WorkingHoursChange.user_id == user.id, WorkingHoursChange.tenant_id == current_user.tenant_id).delete()
-    db.query(ChangeRequest).filter(ChangeRequest.user_id == user.id, ChangeRequest.tenant_id == current_user.tenant_id).delete()
-    db.query(TimeEntry).filter(TimeEntry.user_id == user.id, TimeEntry.tenant_id == current_user.tenant_id).delete()
-    db.query(Absence).filter(Absence.user_id == user.id, Absence.tenant_id == current_user.tenant_id).delete()
+    db.query(WorkingHoursChange).filter(WorkingHoursChange.user_id == user.id, WorkingHoursChange.tenant_id == current_user.tenant_id).delete(synchronize_session=False)
+    db.query(ChangeRequest).filter(ChangeRequest.user_id == user.id, ChangeRequest.tenant_id == current_user.tenant_id).delete(synchronize_session=False)
+    db.query(TimeEntry).filter(TimeEntry.user_id == user.id, TimeEntry.tenant_id == current_user.tenant_id).delete(synchronize_session=False)
+    db.query(Absence).filter(Absence.user_id == user.id, Absence.tenant_id == current_user.tenant_id).delete(synchronize_session=False)
     db.delete(user)
     db.commit()
 
@@ -636,6 +632,7 @@ def delete_working_hours_change(
 
     most_recent = db.query(WorkingHoursChange).filter(
         WorkingHoursChange.user_id == user_id,
+        WorkingHoursChange.tenant_id == current_user.tenant_id,  # F-026
         WorkingHoursChange.effective_from <= today_local()
     ).order_by(WorkingHoursChange.effective_from.desc()).first()
 

--- a/backend/app/routers/admin_vacations.py
+++ b/backend/app/routers/admin_vacations.py
@@ -140,22 +140,26 @@ def review_vacation_request(
     if vr.status != VacationRequestStatus.PENDING.value:
         raise HTTPException(status_code=400, detail="Antrag wurde bereits bearbeitet")
 
-    vr.reviewed_by = current_user.id
-    vr.reviewed_at = datetime.now(timezone.utc)
-
     if review.action == "reject":
+        # Ablehnen ist keine Selbst-Genehmigung -> die reviewed_*-Felder dürfen
+        # hier gesetzt werden (sie belegen, wer wann abgelehnt hat).
+        vr.reviewed_by = current_user.id
+        vr.reviewed_at = datetime.now(timezone.utc)
         vr.status = VacationRequestStatus.REJECTED.value
         vr.rejection_reason = review.rejection_reason
         db.commit()
         db.refresh(vr)
         return _enrich_vr_response(vr, db)
 
+    # CLAUDE.md "Precondition-Checks VOR Status-Änderung": die reviewed_*-Felder
+    # werden auf dem Approve-Pfad erst NACH allen Vorbedingungen gesetzt (4-Augen
+    # + Budget-/Arbeitstag-Checks weiter unten), nicht vorab.
+    #
     # Audit A01: 4-eyes principle. An admin must not approve their OWN vacation
     # request — but ONLY when independent oversight is actually possible (another
     # active admin exists in the tenant). A sole-admin practice may still
     # self-approve (reviewed_by == user_id records it). Raised before any state
-    # change / absence materialisation; the get_db txn rolls back the reviewed_*
-    # assignments above so the VR stays cleanly PENDING.
+    # change / absence materialisation.
     if vr.user_id == current_user.id and _tenant_has_other_active_admin(db, current_user):
         raise HTTPException(
             status_code=403,
@@ -334,6 +338,9 @@ def review_vacation_request(
         )
         db.add(absence)
 
+    # Alle Vorbedingungen bestanden -> jetzt erst Reviewer + Genehmigung setzen.
+    vr.reviewed_by = current_user.id
+    vr.reviewed_at = datetime.now(timezone.utc)
     vr.status = VacationRequestStatus.APPROVED.value
     db.commit()
     db.refresh(vr)

--- a/backend/app/routers/change_requests.py
+++ b/backend/app/routers/change_requests.py
@@ -218,6 +218,7 @@ def create_change_request(
             end_time=data.proposed_end_time,
             break_minutes=data.proposed_break_minutes or 0,
             exclude_entry_id=entry.id if entry else None,
+            tenant_id=current_user.tenant_id,
         )
         if daily_hours > MAX_DAILY_HOURS_HARD:
             raise HTTPException(
@@ -292,6 +293,7 @@ def create_change_request(
             end_time=data.proposed_end_time,
             break_minutes=data.proposed_break_minutes or 0,
             exclude_entry_id=entry.id if entry else None,
+            tenant_id=current_user.tenant_id,
         )
         if (
             current_user.is_night_worker
@@ -315,6 +317,7 @@ def create_change_request(
             end_time=data.proposed_end_time,
             break_minutes=data.proposed_break_minutes or 0,
             exclude_entry_id=entry.id if entry else None,
+            tenant_id=current_user.tenant_id,
         )
         if weekly_hours_check > MAX_WEEKLY_HOURS_WARN:
             response.warnings.append("WEEKLY_HOURS_WARNING")

--- a/backend/app/routers/company_closures.py
+++ b/backend/app/routers/company_closures.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from typing import List
 from datetime import date, timedelta
@@ -188,12 +189,28 @@ def list_closures(
     closures = db.query(CompanyClosure).filter(
         CompanyClosure.tenant_id == current_user.tenant_id,
     ).order_by(CompanyClosure.start_date.desc()).offset(skip).limit(limit).all()
-    # Query is constant per request — compute once outside the loop (Fix B)
-    affected = db.query(User).filter(
-        User.is_active == True,
-        User.receives_company_closures == True,
-        User.tenant_id == current_user.tenant_id,
-    ).count()
+
+    # affected_employees PRO Betriebsferien: die Zahl der MA, die tatsächlich eine
+    # generierte Absence zu DIESER Schließung haben (eine MA, die an dem Tag schon
+    # eine Fremd-Absence hatte, wurde übersprungen und zählt hier nicht mit). Eine
+    # einzige GROUP-BY-Query statt einer Zählung pro Schließung (N+1).
+    closure_ids = [c.id for c in closures]
+    affected_by_closure: dict = {}
+    if closure_ids:
+        rows = (
+            db.query(
+                Absence.closure_id,
+                func.count(func.distinct(Absence.user_id)),
+            )
+            .filter(
+                Absence.closure_id.in_(closure_ids),
+                Absence.tenant_id == current_user.tenant_id,
+            )
+            .group_by(Absence.closure_id)
+            .all()
+        )
+        affected_by_closure = {cid: cnt for cid, cnt in rows}
+
     result = []
     for c in closures:
         result.append(CompanyClosureResponse(
@@ -203,7 +220,7 @@ def list_closures(
             end_date=c.end_date,
             created_by=str(c.created_by),
             counts_as_vacation=c.counts_as_vacation,
-            affected_employees=affected
+            affected_employees=affected_by_closure.get(c.id, 0),
         ))
     return result
 
@@ -348,6 +365,12 @@ def update_closure(
             absence.end_date = data.end_date
             if type_changed:
                 absence.type = new_absence_type
+
+    # L-3: die obigen Deletes/Updates in die DB schreiben, BEVOR der Create-Helper
+    # seine existing_keys-Vorabfrage stellt — sonst sähe er die behaltenen Tage
+    # nicht, würde sie erneut einfügen und am (tenant_id, user_id, date, type)-
+    # Unique-Constraint mit einem 500 scheitern.
+    db.flush()
 
     # Add absences for newly covered workdays. Reuse the create-time helper,
     # which already skips days where the employee has ANY existing absence

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -68,7 +68,10 @@ def get_monthly_report(
             tenant_id=current_user.tenant_id,
         )
         db.add(audit)
-        db.commit()
+        # L-2: nur flushen — der Audit-Eintrag wird erst committet, NACHDEM der
+        # Report fehlerfrei gebaut ist (sonst bliebe bei einem Fehler beim Bauen ein
+        # health_data_read-Audit ohne tatsächlich ausgelieferte Daten stehen).
+        db.flush()
 
     users = _get_active_visible_users(db, current_user.tenant_id)
 
@@ -97,6 +100,13 @@ def get_monthly_report(
         ).all()
         sick_hours = sum(float(a.hours) for a in sick_absences)
 
+        # Tagesprinzip (§3 BUrlG, #156/#205): Urlaub/Krank TAGEBASIERT zählen — exakt
+        # wie get_vacation_account (voller Tag 1,0; half_day 0,5; Legacy h÷Tagessoll-
+        # des-Tages; untracked rein tagebasiert). NICHT Σh ÷ Ø-Tagessoll, das driftet
+        # bei ungleichmäßigem Tagesplan oder Halbtagen.
+        vacation_days = float(calculation_service.absence_days(db, user, vacation_absences).quantize(Decimal('0.1')))
+        sick_days = float(calculation_service.absence_days(db, user, sick_absences).quantize(Decimal('0.1')))
+
         # Use weekly_hours valid at start of report month, not current value
         report_date = date(year, month_num, 1)
         hist_weekly = calculation_service.get_weekly_hours_for_date(db, user, report_date)
@@ -111,9 +121,16 @@ def get_monthly_report(
             balance=float(balance),
             overtime_cumulative=float(overtime),
             vacation_used_hours=vacation_hours,
+            vacation_used_days=vacation_days,
             sick_hours=sick_hours if include_health_data else 0.0,
+            sick_days=sick_days if include_health_data else 0.0,
             exempt_from_arbzg=bool(user.exempt_from_arbzg),
         ))
+
+    # L-2: Report erfolgreich gebaut -> jetzt erst den (ggf. oben geflushten)
+    # health_data_read-Audit-Eintrag dauerhaft festschreiben.
+    if include_health_data:
+        db.commit()
 
     return reports
 
@@ -145,7 +162,9 @@ def get_yearly_absences(
             tenant_id=current_user.tenant_id,
         )
         db.add(audit)
-        db.commit()
+        # L-2: nur flushen — Commit erst nach erfolgreichem Aufbau der Übersicht
+        # (siehe get_monthly_report).
+        db.flush()
 
     users = _get_active_visible_users(db, current_user.tenant_id)
 
@@ -220,6 +239,10 @@ def get_yearly_absences(
             overtime_year=float(overtime_year),
             total_days=total_days
         ))
+
+    # L-2: Übersicht erfolgreich gebaut -> health_data_read-Audit festschreiben.
+    if include_health_data:
+        db.commit()
 
     return results
 
@@ -657,6 +680,17 @@ def get_compensatory_rest(
     users = _get_active_visible_users(db, current_user.tenant_id)
     result = []
 
+    # L-7: Feiertage des Jahres EINMAL vorladen (tenant-scoped) statt _is_holiday
+    # pro Eintrag (DB-Query je Eintrag) — danach reine Set-Mitgliedschaft. Gleiches
+    # Muster wie der 24-Wochen-Schnitt-Endpoint; Verhalten unverändert.
+    holiday_dates = {
+        h.date
+        for h in db.query(PublicHoliday).filter(
+            PublicHoliday.year == year,
+            PublicHoliday.tenant_id == current_user.tenant_id,
+        ).all()
+    }
+
     for user in users:
         entries = (
             db.query(TimeEntry)
@@ -671,14 +705,11 @@ def get_compensatory_rest(
         worked_dates = {e.date for e in entries}
 
         # Get all dates worked on Sundays or holidays
-        from app.services.holiday_service import is_holiday as _is_holiday
-
         sunday_holidays_worked = []
         for e in entries:
             weekday = e.date.weekday()
             is_sun = weekday == 6
-            # F-026: is_holiday requires tenant_id per CLAUDE.md multi-tenant rules
-            is_hol = _is_holiday(db, e.date, tenant_id=current_user.tenant_id)
+            is_hol = e.date in holiday_dates
             if is_sun or is_hol:
                 sunday_holidays_worked.append({
                     "date": e.date,

--- a/backend/app/routers/superadmin.py
+++ b/backend/app/routers/superadmin.py
@@ -15,10 +15,11 @@ from datetime import datetime, timezone
 from io import BytesIO
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
+from app.core.limiter import limiter
 from app.database import get_db, set_superadmin_context
 from app.middleware.auth import require_superadmin
 from app.models import (
@@ -134,7 +135,9 @@ def list_all_tenants(
 
 
 @router.get("/tenants/{tenant_id}/arbzg-export")
+@limiter.limit("20/minute")
 def export_tenant_arbzg_data(
+    request: Request,
     tenant_id: uuid.UUID,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_superadmin),
@@ -201,8 +204,11 @@ def export_tenant_arbzg_data(
         # the legally-mandated §16 export itself. Roll back the failed marker
         # and still deliver the records.
         db.rollback()
-        print(f"AUDIT WARN: Superadmin-ArbZG-Export-Marker konnte nicht "
-              f"persistiert werden (tenant={tenant_id}): {exc}")
+        logger.error(
+            "AUDIT WARN: Superadmin-ArbZG-Export-Marker konnte nicht "
+            "persistiert werden (tenant=%s): %s",
+            tenant_id, exc,
+        )
 
     buffer = BytesIO(json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8"))
     filename = f"PraxisZeit_ArbZG-Export_{tenant.slug}_{datetime.now().strftime('%Y%m%d-%H%M%S')}.json"

--- a/backend/app/routers/time_entries.py
+++ b/backend/app/routers/time_entries.py
@@ -66,6 +66,7 @@ def _calculate_daily_net_hours(
     end_time: time,
     break_minutes: int,
     exclude_entry_id=None,
+    tenant_id=None,
 ) -> float:
     """Sum up all net hours for a user on a given date, including the new/updated entry."""
     query = db.query(TimeEntry).filter(
@@ -73,6 +74,9 @@ def _calculate_daily_net_hours(
         TimeEntry.date == entry_date,
         TimeEntry.end_time.isnot(None),
     )
+    # F-026: expliziter Tenant-Filter zusätzlich zu RLS (belt-and-suspenders).
+    if tenant_id is not None:
+        query = query.filter(TimeEntry.tenant_id == tenant_id)
     if exclude_entry_id:
         query = query.filter(TimeEntry.id != exclude_entry_id)
     existing = query.all()
@@ -90,6 +94,7 @@ def _calculate_weekly_net_hours(
     end_time: time,
     break_minutes: int,
     exclude_entry_id=None,
+    tenant_id=None,
 ) -> float:
     """Sum all net hours for the ISO calendar week containing entry_date, including the new/updated entry."""
     from datetime import timedelta
@@ -103,6 +108,9 @@ def _calculate_weekly_net_hours(
         TimeEntry.date <= sunday,
         TimeEntry.end_time.isnot(None),
     )
+    # F-026: expliziter Tenant-Filter zusätzlich zu RLS (belt-and-suspenders).
+    if tenant_id is not None:
+        query = query.filter(TimeEntry.tenant_id == tenant_id)
     if exclude_entry_id:
         query = query.filter(TimeEntry.id != exclude_entry_id)
     existing = query.all()
@@ -368,6 +376,7 @@ def clock_out(
         end_time=eff_end,
         break_minutes=body.break_minutes,
         exclude_entry_id=open_entry.id,
+        tenant_id=current_user.tenant_id,
     )
     # Review R2-b: §3 ArbZG (10h-Höchstgrenze) darf das Ausstempeln NICHT mit
     # 422 blockieren. Die Arbeitszeit IST zum Ausstempel-Zeitpunkt bereits
@@ -460,6 +469,7 @@ def clock_out(
             end_time=eff_end,
             break_minutes=body.break_minutes,
             exclude_entry_id=open_entry.id,
+            tenant_id=current_user.tenant_id,
         )
         if weekly_hours_out > MAX_WEEKLY_HOURS_WARN:
             clock_out_warnings.append("WEEKLY_HOURS_WARNING")
@@ -619,6 +629,7 @@ def create_time_entry(
         start_time=eff_start,
         end_time=eff_end,
         break_minutes=entry_data.break_minutes,
+        tenant_id=current_user.tenant_id,
     )
     if not exempt and daily_hours > MAX_DAILY_HOURS_HARD:
         raise HTTPException(
@@ -712,6 +723,7 @@ def create_time_entry(
             start_time=eff_start,
             end_time=eff_end,
             break_minutes=entry_data.break_minutes,
+            tenant_id=current_user.tenant_id,
         )
         if weekly_hours > MAX_WEEKLY_HOURS_WARN:
             warnings.append("WEEKLY_HOURS_WARNING")
@@ -868,6 +880,7 @@ def update_time_entry(
             end_time=entry.end_time,
             break_minutes=entry.break_minutes,
             exclude_entry_id=entry.id,
+            tenant_id=entry.tenant_id,
         )
         if daily_hours > MAX_DAILY_HOURS_HARD:
             raise HTTPException(
@@ -983,6 +996,7 @@ def update_time_entry(
             end_time=entry.end_time,
             break_minutes=entry.break_minutes,
             exclude_entry_id=entry.id,
+            tenant_id=entry.tenant_id,
         )
         if saved_hours > MAX_DAILY_HOURS_WARN:
             update_warnings.append("DAILY_HOURS_WARNING")
@@ -994,6 +1008,7 @@ def update_time_entry(
             end_time=entry.end_time,
             break_minutes=entry.break_minutes,
             exclude_entry_id=entry.id,
+            tenant_id=entry.tenant_id,
         )
         if weekly > MAX_WEEKLY_HOURS_WARN:
             update_warnings.append("WEEKLY_HOURS_WARNING")

--- a/backend/app/schemas/reports.py
+++ b/backend/app/schemas/reports.py
@@ -77,7 +77,9 @@ class EmployeeMonthlyReport(BaseModel):
     balance: float
     overtime_cumulative: float
     vacation_used_hours: float
+    vacation_used_days: float   # Tagesprinzip: Stunden ÷ Tagessoll (für die Anzeige)
     sick_hours: float
+    sick_days: float            # 0 ohne include_health_data (DSGVO Art. 9)
     exempt_from_arbzg: bool = False  # #159: leitende Angestellte (§18) — Filter im Dashboard-Schnitt
 
 

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -186,9 +186,9 @@ def resolve_backup_path(db: Session, filename: str) -> Optional[Path]:
     """Path-Traversal-sicher: nur exakte praxiszeit_<ts>.sql.gz-Namen im Backup-Dir."""
     if not _FILENAME_RE.match(filename or ""):
         return None
-    candidate = (get_backup_dir(db) / filename).resolve()
-    backup_dir = get_backup_dir(db).resolve()
-    if backup_dir not in candidate.parents:
+    backup_dir = get_backup_dir(db)
+    candidate = (backup_dir / filename).resolve()
+    if backup_dir.resolve() not in candidate.parents:
         return None
     return candidate if candidate.is_file() else None
 

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -813,6 +813,30 @@ def get_ytd_summary(db: Session, user: User, year: int = None) -> Dict:
     }
 
 
+def absence_days(db: Session, user: User, absences: list) -> Decimal:
+    """Zähle Abwesenheiten TAGEBASIERT (Tagesprinzip §3 BUrlG, #156/#205) — exakt
+    nach derselben Regel wie ``used_days`` in ``get_vacation_account``: voller Tag
+    = 1,0, ``half_day=True`` = 0,5, Legacy-Row (``half_day=None``) = Stunden ÷
+    Tagessoll DES TAGES. Ein Tag mit Tagessoll 0 (Urlaub an einem Nicht-Arbeitstag)
+    zählt 0. Untracked-MA (``get_daily_target<=0``, leitende Angestellte): rein
+    tagebasiert (Halbtag 0,5, sonst 1,0). Quelle für die Tage-Anzeige in den
+    Reports — NICHT die naive Σh ÷ Ø-Tagessoll (die für ungleichmäßige Tagespläne
+    bzw. Halbtage falsch ist)."""
+    tracked = get_daily_target(user) > 0
+    total = Decimal('0')
+    for a in absences:
+        if not tracked:
+            total += Decimal('0.5') if a.half_day else Decimal('1')
+            continue
+        dt_day = get_daily_target_for_date(user, a.date, get_weekly_hours_for_date(db, user, a.date))
+        if dt_day > 0:
+            if a.half_day is None:
+                total += Decimal(str(a.hours)) / Decimal(str(dt_day))
+            else:
+                total += Decimal('0.5') if a.half_day else Decimal('1')
+    return total
+
+
 def get_vacation_account(db: Session, user: User, year: int) -> Dict:
     """
     Calculate vacation account for a given year.
@@ -1062,9 +1086,10 @@ def create_year_closing(db: Session, year: int, users: list) -> list:
         vacation_account = get_vacation_account(db, user, year)
         remaining_vacation = Decimal(str(vacation_account['remaining_days']))
 
-        # Create or update carryover for next year
+        # Create or update carryover for next year (F-026: explicit tenant scope)
         carryover = db.query(YearCarryover).filter(
             YearCarryover.user_id == user.id,
+            YearCarryover.tenant_id == user.tenant_id,
             YearCarryover.year == next_year,
         ).first()
 

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -145,12 +145,18 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
     for entry in time_entries:
         entries_by_date.setdefault(entry.date, []).append(entry)
 
-    # Get all absences for the month
+    # Get all absences for the month.
+    # I-1: ein Tag kann MEHRERE Absences tragen (Unique-Constraint ist je
+    # (date, type) — z. B. ein halber Tag Urlaub + ein halber Tag Sonstiges).
+    # Daher pro Tag eine LISTE statt einer einzelnen Absence, sonst verschluckt
+    # die Anzeige die zweite stillschweigend.
     absences = db.query(Absence).filter(
         Absence.user_id == user.id,
         date_in_month(Absence.date, year, month)
     ).all()
-    absences_by_date = {absence.date: absence for absence in absences}
+    absences_by_date: dict = {}
+    for absence in absences:
+        absences_by_date.setdefault(absence.date, []).append(absence)
 
     # Get public holidays (tenant-scoped: each tenant may run a different
     # state-holiday set, so a global query would leak or miss holidays).
@@ -184,7 +190,7 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
         # Check if it's a weekend, holiday, or absence
         is_weekend = weekday >= 5
         is_holiday = current_date in holidays_by_date
-        absence = absences_by_date.get(current_date)
+        day_absences = absences_by_date.get(current_date, [])  # I-1: alle Absences des Tages
 
         # Date column
         sheet.cell(row=row, column=1).value = current_date
@@ -269,25 +275,32 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
             # col 10 (Bemerkung) bereits oben gesetzt – NICHT mit holiday.name überschreiben
             for col in range(1, 11):
                 sheet.cell(row=row, column=col).fill = PatternFill(start_color="FFFFCC", end_color="FFFFCC", fill_type="solid")
-        elif absence:
+        elif day_absences:
             target = Decimal('0.00')
-            # DSGVO F-003: mask sick absences when health data export not explicitly requested
-            if absence.type.value == "sick" and not include_health_data:
-                type_name = "Abwesenheit"
-                # Do not expose sick note (may contain diagnosis details)
-            else:
-                absence_type_map = {
-                    "vacation": "Urlaub",
-                    "sick": "Krank",
-                    "training": "Fortbildung",
-                    "overtime": "Überstundenausgleich",
-                    "other": "Sonstiges",
-                    "paid_leave": "Bez. Freistellung"
-                }
-                type_name = absence_type_map.get(absence.type.value, absence.type.value)
-                if absence.note:
-                    sheet.cell(row=row, column=10).value = neutralize_spreadsheet_formula(absence.note)
-            sheet.cell(row=row, column=9).value = f"{type_name} ({float(absence.hours)}h)"
+            absence_type_map = {
+                "vacation": "Urlaub",
+                "sick": "Krank",
+                "training": "Fortbildung",
+                "overtime": "Überstundenausgleich",
+                "other": "Sonstiges",
+                "paid_leave": "Bez. Freistellung"
+            }
+            # I-1: ALLE Absences des Tages anzeigen (Label in Spalte 9 verbinden,
+            # Notizen in Spalte 10). DSGVO F-003: Krank ohne Health-Flag maskieren
+            # (Label "Abwesenheit", Notiz unterdrückt — kann Diagnose enthalten).
+            abw_parts = []
+            note_parts = []
+            for absence in day_absences:
+                if absence.type.value == "sick" and not include_health_data:
+                    type_name = "Abwesenheit"
+                else:
+                    type_name = absence_type_map.get(absence.type.value, absence.type.value)
+                    if absence.note:
+                        note_parts.append(absence.note)
+                abw_parts.append(f"{type_name} ({float(absence.hours)}h)")
+            sheet.cell(row=row, column=9).value = " | ".join(abw_parts)
+            if note_parts:
+                sheet.cell(row=row, column=10).value = neutralize_spreadsheet_formula(" | ".join(note_parts))
         else:
             # Regulärer Arbeitstag
             target = daily_target
@@ -670,12 +683,15 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
     for entry in time_entries:
         entries_by_date.setdefault(entry.date, []).append(entry)
 
-    # Get all absences for the year
+    # Get all absences for the year.
+    # I-1: pro Tag eine LISTE (mehrere Absences je Tag möglich, s. _create_employee_sheet).
     absences = db.query(Absence).filter(
         Absence.user_id == user.id,
         date_in_year(Absence.date, year)
     ).all()
-    absences_by_date = {absence.date: absence for absence in absences}
+    absences_by_date: dict = {}
+    for absence in absences:
+        absences_by_date.setdefault(absence.date, []).append(absence)
 
     # Get public holidays for the year (tenant-scoped; see generate_monthly_report).
     holidays = db.query(PublicHoliday).filter(
@@ -725,7 +741,7 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
 
         is_weekend = weekday >= 5
         is_holiday = current_date in holidays_by_date
-        absence = absences_by_date.get(current_date)
+        day_absences = absences_by_date.get(current_date, [])  # I-1: alle Absences des Tages
 
         sheet.cell(row=row, column=1).value = current_date
         sheet.cell(row=row, column=1).number_format = 'DD.MM.YYYY'
@@ -802,24 +818,31 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
             sheet.cell(row=row, column=9).value = abw
             for col in range(1, 11):
                 sheet.cell(row=row, column=col).fill = PatternFill(start_color="FFFFCC", end_color="FFFFCC", fill_type="solid")
-        elif absence:
+        elif day_absences:
             target = Decimal('0.00')
-            # DSGVO F-003: mask sick absences unless health data explicitly requested
-            if absence.type.value == "sick" and not include_health_data:
-                type_name = "Abwesenheit"
-            else:
-                absence_type_map = {
-                    "vacation": "Urlaub",
-                    "sick": "Krank",
-                    "training": "Fortbildung",
-                    "overtime": "Überstundenausgleich",
-                    "other": "Sonstiges",
-                    "paid_leave": "Bez. Freistellung"
-                }
-                type_name = absence_type_map.get(absence.type.value, absence.type.value)
-                if absence.note:
-                    sheet.cell(row=row, column=10).value = neutralize_spreadsheet_formula(absence.note)
-            sheet.cell(row=row, column=9).value = f"{type_name} ({float(absence.hours)}h)"
+            absence_type_map = {
+                "vacation": "Urlaub",
+                "sick": "Krank",
+                "training": "Fortbildung",
+                "overtime": "Überstundenausgleich",
+                "other": "Sonstiges",
+                "paid_leave": "Bez. Freistellung"
+            }
+            # I-1: ALLE Absences des Tages anzeigen; DSGVO F-003: Krank ohne
+            # Health-Flag maskieren (Label "Abwesenheit", Notiz unterdrückt).
+            abw_parts = []
+            note_parts = []
+            for absence in day_absences:
+                if absence.type.value == "sick" and not include_health_data:
+                    type_name = "Abwesenheit"
+                else:
+                    type_name = absence_type_map.get(absence.type.value, absence.type.value)
+                    if absence.note:
+                        note_parts.append(absence.note)
+                abw_parts.append(f"{type_name} ({float(absence.hours)}h)")
+            sheet.cell(row=row, column=9).value = " | ".join(abw_parts)
+            if note_parts:
+                sheet.cell(row=row, column=10).value = neutralize_spreadsheet_formula(" | ".join(note_parts))
         else:
             target = daily_target
             if is_night_wrk:
@@ -1268,7 +1291,10 @@ def generate_monthly_report_pdf(db: Session, year: int, month: int, include_heal
             Absence.user_id == user.id,
             date_in_month(Absence.date, year, month),
         ).all()
-        absences_by_date = {a.date: a for a in absences}
+        # I-1: pro Tag eine LISTE (mehrere Absences je Tag möglich, s. _create_employee_sheet).
+        absences_by_date: dict = {}
+        for a in absences:
+            absences_by_date.setdefault(a.date, []).append(a)
 
         holidays = db.query(PublicHoliday).filter(
             PublicHoliday.tenant_id == user.tenant_id,
@@ -1296,7 +1322,7 @@ def generate_monthly_report_pdf(db: Session, year: int, month: int, include_heal
             is_weekend = wd >= 5
             is_sunday = wd == 6
             is_holiday = cur in holidays_by_date
-            absence = absences_by_date.get(cur)
+            day_absences = absences_by_date.get(cur, [])  # I-1: alle Absences des Tages
             day_entries = entries_by_date.get(cur, [])
 
             is_night = any(
@@ -1355,19 +1381,22 @@ def generate_monthly_report_pdf(db: Session, year: int, month: int, include_heal
                 if is_night:
                     abw += ' | Nachtarbeit'
                 bg = colors.HexColor('#FFFFCC')
-            elif absence:
+            elif day_absences:
                 target = Decimal('0.00')
-                if absence.type.value == 'sick' and not include_health_data:
-                    type_name = 'Abwesenheit'
-                    bem = ''
-                else:
-                    type_name = absence_type_map.get(absence.type.value, absence.type.value)
-                    if absence.note:
-                        if absence.type == AbsenceType.SICK and not include_health_data:
-                            pass  # Don't show sick notes without health data permission
-                        else:
-                            bem = absence.note
-                abw = f"{type_name} ({float(absence.hours):.1f}h)"
+                # I-1: ALLE Absences des Tages zeigen; DSGVO F-003: Krank ohne
+                # Health-Flag maskieren (Label 'Abwesenheit', Notiz unterdrückt).
+                abw_parts = []
+                note_parts = []
+                for absence in day_absences:
+                    if absence.type.value == 'sick' and not include_health_data:
+                        type_name = 'Abwesenheit'
+                    else:
+                        type_name = absence_type_map.get(absence.type.value, absence.type.value)
+                        if absence.note:
+                            note_parts.append(absence.note)
+                    abw_parts.append(f"{type_name} ({float(absence.hours):.1f}h)")
+                abw = " | ".join(abw_parts)
+                bem = " | ".join(note_parts)  # ersetzt evtl. Eintrags-Bemerkung wie zuvor
                 bg = None
             else:
                 target = daily_target

--- a/backend/tests/test_paid_leave_reports.py
+++ b/backend/tests/test_paid_leave_reports.py
@@ -96,6 +96,33 @@ def test_yearly_absences_endpoint_includes_paid_leave(db, test_user, test_admin)
     assert row["total_days"] == pytest.approx(5.0)
 
 
+def test_monthly_report_reports_vacation_and_sick_in_days(db, test_user, test_admin):
+    """Bug-Fix: die Monatsübersicht muss Urlaub/Krank auch in TAGEN liefern (nicht
+    nur in Stunden), damit die Anzeige Tage zeigen kann. Krank ist ohne
+    include_health_data 0 (DSGVO Art. 9), mit Flag in Tagen sichtbar."""
+    _mk_absence(db, test_user, date(YEAR, 6, 1), AbsenceType.VACATION, 8.0)  # 1 Tag Urlaub
+    _mk_absence(db, test_user, date(YEAR, 6, 2), AbsenceType.SICK, 8.0)      # 1 Tag krank
+
+    def override_db():
+        yield db
+
+    _app.dependency_overrides[get_db] = override_db
+    _app.dependency_overrides[get_current_user] = lambda: test_admin
+    _app.dependency_overrides[require_admin] = lambda: test_admin
+    try:
+        client = TestClient(_app)
+        r1 = client.get(f"/api/admin/reports/monthly?month={YEAR}-06")
+        assert r1.status_code == 200, r1.text
+        row1 = next(r for r in r1.json() if r["user_id"] == str(test_user.id))
+        assert row1["vacation_used_days"] == pytest.approx(1.0)   # 8h ÷ 8h Tagessoll
+        assert row1["sick_days"] == 0.0                            # DSGVO-maskiert ohne Flag
+        r2 = client.get(f"/api/admin/reports/monthly?month={YEAR}-06&include_health_data=true")
+        row2 = next(r for r in r2.json() if r["user_id"] == str(test_user.id))
+        assert row2["sick_days"] == pytest.approx(1.0)             # 8h ÷ 8h, jetzt sichtbar
+    finally:
+        _app.dependency_overrides.clear()
+
+
 # ---------------------------------------------------------------------------
 # XLSX yearly export — "Bez. Freistellung" column on the absences overview
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_superadmin_arbzg_export.py
+++ b/backend/tests/test_superadmin_arbzg_export.py
@@ -85,10 +85,14 @@ class TestExportSurvivesAuditFailure:
         """Schlägt der Audit-Marker-Write fehl, muss der gesetzlich
         vorgeschriebene Export trotzdem ausgeliefert werden (nicht 500)."""
         from app.routers import superadmin as sa_router
+        from app.core.limiter import limiter
         from starlette.responses import StreamingResponse
 
         # SQLite kennt kein RLS → set_superadmin_context no-oppen.
         monkeypatch.setattr(sa_router, "set_superadmin_context", lambda _db: None)
+        # L-6: der Endpoint trägt jetzt @limiter.limit (+ request-Param). Beim
+        # Direkt-Aufruf (kein App-Kontext) den Limiter durchreichen.
+        monkeypatch.setattr(limiter, "enabled", False)
 
         # commit() so patchen, dass der Audit-Marker-Write hart fehlschlägt.
         original_commit = db.commit
@@ -99,6 +103,7 @@ class TestExportSurvivesAuditFailure:
         monkeypatch.setattr(db, "commit", boom)
 
         response = sa_router.export_tenant_arbzg_data(
+            request=None,  # nur für den @limiter.limit-Decorator; der Body nutzt es nicht
             tenant_id=default_tenant.id,
             db=db,
             current_user=superadmin_user,

--- a/e2e/tests/admin/monthly-overview-days.spec.ts
+++ b/e2e/tests/admin/monthly-overview-days.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '../../fixtures/base.fixture';
+
+/**
+ * #281 — Admin-Monatsübersicht zeigt Urlaub/Krank in TAGEN (nicht Stunden),
+ * und Krank ist DSGVO-Art.-9-maskiert hinter einem ausdrücklichen Opt-in.
+ * UI-Test der in diesem Branch geänderten Bereiche.
+ */
+test.describe('Admin-Monatsübersicht: Tage statt Stunden + Krank-Opt-in (#281)', () => {
+  test.beforeEach(async ({ adminPage }) => {
+    await adminPage.goto('/admin');
+    await expect(adminPage.getByRole('heading', { name: 'Admin-Dashboard' })).toBeVisible();
+    // Auf den Monatsbericht warten (Tabelle gerendert)
+    await expect(adminPage.getByRole('heading', { name: 'Monatsübersicht' })).toBeVisible();
+  });
+
+  test('Urlaub/Krank-Spalten sind in Tagen, nicht in Stunden', async ({ adminPage }) => {
+    const main = adminPage.locator('main');
+    await expect(main.getByRole('columnheader', { name: /Urlaub \(Tage\)/ })).toBeVisible();
+    await expect(main.getByRole('columnheader', { name: /Krank \(Tage\)/ })).toBeVisible();
+    // Keine Stunden-Überschriften mehr
+    await expect(main.getByRole('columnheader', { name: /Urlaub \(h\)/ })).toHaveCount(0);
+    await expect(main.getByRole('columnheader', { name: /Krank \(h\)/ })).toHaveCount(0);
+  });
+
+  test('Krank ist standardmäßig maskiert und per DSGVO-Opt-in einblendbar', async ({ adminPage }) => {
+    const toggle = adminPage.getByRole('checkbox', { name: /Krankheitstage anzeigen/i });
+    await expect(toggle).toBeVisible();
+    await expect(toggle).not.toBeChecked();
+
+    // Default maskiert: in der Krank-Spalte steht der Platzhalter "—"
+    const desktopTable = adminPage.locator('main table').first();
+    const rowCount = await desktopTable.locator('tbody tr').count();
+
+    if (rowCount > 0) {
+      // mindestens eine Zelle zeigt den Masken-Platzhalter
+      await expect(desktopTable.getByText('—', { exact: true }).first()).toBeVisible();
+    }
+
+    // Opt-in aktivieren -> Re-Fetch mit include_health_data, Krank wird eingeblendet
+    await toggle.check();
+    await expect(toggle).toBeChecked();
+
+    if (rowCount > 0) {
+      // nach dem Opt-in keine "—"-Maske mehr in der Krank-Spalte (Tage-Wert sichtbar)
+      await expect(desktopTable.getByText('—', { exact: true })).toHaveCount(0);
+    }
+  });
+});

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -24,7 +24,9 @@ interface EmployeeReport {
   balance: number;
   overtime_cumulative: number;
   vacation_used_hours: number;
+  vacation_used_days: number;
   sick_hours: number;
+  sick_days: number;
   exempt_from_arbzg?: boolean;
 }
 
@@ -105,10 +107,15 @@ export default function AdminDashboard() {
   const [sortField, setSortField] = useState<keyof EmployeeReport | ''>('');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const [filterText, setFilterText] = useState('');
+  // DSGVO Art. 9: Krankheitstage nur auf ausdrücklichen Opt-in zeigen — das löst
+  // serverseitig ein Audit-Log aus (analog zum Reports-Export). Ohne Opt-in
+  // liefert das Backend für Krank 0 / wird hier maskiert dargestellt.
+  const [showHealthData, setShowHealthData] = useState(false);
 
   useEffect(() => {
     fetchReport();
-  }, [currentMonth]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentMonth, showHealthData]);
 
   useEffect(() => {
     // Re-fetch des offenen Mitarbeiters bei Monatswechsel. selectedEmployee ist
@@ -123,14 +130,16 @@ export default function AdminDashboard() {
 
   useEffect(() => {
     fetchYearlyAbsences();
-  }, [currentYear]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentYear, showHealthData]);
 
   // C-2: Out-of-order-Schutz bei schnellem Monatswechsel (Last-Write-Wins).
   const reportSeq = useRef(0);
   const fetchReport = async () => {
     const seq = ++reportSeq.current;
     try {
-      const response = await apiClient.get(`/admin/reports/monthly?month=${currentMonth}`);
+      const hp = showHealthData ? '&include_health_data=true' : '';
+      const response = await apiClient.get(`/admin/reports/monthly?month=${currentMonth}${hp}`);
       if (seq !== reportSeq.current) return;
       setReport(response.data);
     } catch (error) {
@@ -145,7 +154,8 @@ export default function AdminDashboard() {
   const fetchYearlyAbsences = async () => {
     const seq = ++yearlySeq.current;
     try {
-      const response = await apiClient.get(`/admin/reports/yearly-absences?year=${currentYear}`);
+      const hp = showHealthData ? '&include_health_data=true' : '';
+      const response = await apiClient.get(`/admin/reports/yearly-absences?year=${currentYear}${hp}`);
       if (seq !== yearlySeq.current) return;
       setYearlyAbsences(response.data);
     } catch (error) {
@@ -319,6 +329,10 @@ export default function AdminDashboard() {
       });
       setEmployeeAbsences(absencesResponse.data);
       fetchAuditForUser(selectedEmployee.user_id);
+      // C-2: Monatsbericht (Ist, Saldo, Urlaub/Krank) + Jahresübersicht aktualisieren,
+      // damit die Zusammenfassung sofort die Mutation widerspiegelt.
+      fetchReport();
+      fetchYearlyAbsences();
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Speichern'));
     }
@@ -341,6 +355,9 @@ export default function AdminDashboard() {
             setEmployeeTimeEntries(entriesResponse.data);
             fetchAuditForUser(selectedEmployee.user_id);
           }
+          // C-2: Monatsbericht + Jahresübersicht aktualisieren.
+          fetchReport();
+          fetchYearlyAbsences();
         } catch (error) {
           toast.error('Fehler beim Löschen');
         }
@@ -460,7 +477,7 @@ export default function AdminDashboard() {
             <Clock className="text-primary" size={24} />
           </div>
           <p className="text-xl font-bold text-gray-900">
-            {format(new Date(currentMonth + '-01'), 'MMMM yyyy')}
+            {format(new Date(currentMonth + '-01T00:00:00'), 'MMMM yyyy')}
           </p>
         </div>
       </div>
@@ -490,8 +507,19 @@ export default function AdminDashboard() {
 
       {/* Employee Table */}
       <div className="bg-white rounded-xl shadow-xs border border-gray-200 overflow-hidden">
-        <div className="px-6 py-4 border-b border-gray-200">
+        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between gap-4 flex-wrap">
           <h2 className="text-lg font-semibold">Monatsübersicht</h2>
+          {/* DSGVO Art. 9: Krankheitstage nur auf ausdrücklichen Opt-in zeigen
+              (löst serverseitig einen Audit-Log-Eintrag aus). */}
+          <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showHealthData}
+              onChange={(e) => setShowHealthData(e.target.checked)}
+              className="rounded border-gray-300"
+            />
+            Krankheitstage anzeigen <span className="text-gray-400">(Art. 9 DSGVO – wird protokolliert)</span>
+          </label>
         </div>
         
         {/* Desktop Table */}
@@ -565,8 +593,28 @@ export default function AdminDashboard() {
                     )}
                   </div>
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Urlaub (h)</th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Krank (h)</th>
+                <th
+                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase cursor-pointer hover:bg-gray-100 transition"
+                  onClick={() => handleSort('vacation_used_days')}
+                >
+                  <div className="flex items-center space-x-1">
+                    <span>Urlaub (Tage)</span>
+                    {sortField === 'vacation_used_days' && (
+                      sortDirection === 'asc' ? <ArrowUp size={14} /> : <ArrowDown size={14} />
+                    )}
+                  </div>
+                </th>
+                <th
+                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase cursor-pointer hover:bg-gray-100 transition"
+                  onClick={() => handleSort('sick_days')}
+                >
+                  <div className="flex items-center space-x-1">
+                    <span>Krank (Tage)</span>
+                    {sortField === 'sick_days' && (
+                      sortDirection === 'asc' ? <ArrowUp size={14} /> : <ArrowDown size={14} />
+                    )}
+                  </div>
+                </th>
                 <th className="px-6 py-3"></th>
               </tr>
             </thead>
@@ -612,8 +660,8 @@ export default function AdminDashboard() {
                         {formatHoursHM(emp.overtime_cumulative)}
                       </span>
                     </td>
-                    <td className="px-6 py-4 text-sm text-gray-900">{formatHoursHM(emp.vacation_used_hours)}</td>
-                    <td className="px-6 py-4 text-sm text-gray-900">{formatHoursHM(emp.sick_hours)}</td>
+                    <td className="px-6 py-4 text-sm text-gray-900">{emp.vacation_used_days.toFixed(1)}</td>
+                    <td className="px-6 py-4 text-sm text-gray-900">{showHealthData ? emp.sick_days.toFixed(1) : '—'}</td>
                     <td className="px-6 py-4 text-right">
                       <ChevronRight size={20} className="text-gray-400 inline" />
                     </td>
@@ -689,11 +737,11 @@ export default function AdminDashboard() {
                     <div className="flex items-center space-x-4">
                       <div>
                         <span className="text-gray-500">Urlaub:</span>
-                        <span className="font-medium ml-1">{formatHoursHM(emp.vacation_used_hours)}</span>
+                        <span className="font-medium ml-1">{emp.vacation_used_days.toFixed(1)} Tage</span>
                       </div>
                       <div>
                         <span className="text-gray-500">Krank:</span>
-                        <span className="font-medium ml-1">{formatHoursHM(emp.sick_hours)}</span>
+                        <span className="font-medium ml-1">{showHealthData ? `${emp.sick_days.toFixed(1)} Tage` : '—'}</span>
                       </div>
                     </div>
                   </div>
@@ -852,7 +900,7 @@ export default function AdminDashboard() {
                       </td>
                       <td className="px-6 py-4 text-right text-sm">
                         <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
-                          {emp.sick_days.toFixed(1)} Tage
+                          {showHealthData ? `${emp.sick_days.toFixed(1)} Tage` : '—'}
                         </span>
                       </td>
                       <td className="px-6 py-4 text-right text-sm">
@@ -939,7 +987,7 @@ export default function AdminDashboard() {
                           <span className="text-sm text-gray-600">Krank</span>
                         </div>
                         <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
-                          {emp.sick_days.toFixed(1)} Tage
+                          {showHealthData ? `${emp.sick_days.toFixed(1)} Tage` : '—'}
                         </span>
                       </div>
 
@@ -1012,7 +1060,7 @@ export default function AdminDashboard() {
                     {selectedEmployee.last_name}, {selectedEmployee.first_name}
                   </h2>
                   <p className="text-sm opacity-90">
-                    {format(new Date(currentMonth + '-01'), 'MMMM yyyy')} - Details
+                    {format(new Date(currentMonth + '-01T00:00:00'), 'MMMM yyyy')} - Details
                   </p>
                 </div>
                 <button

--- a/frontend/src/pages/admin/Backups.tsx
+++ b/frontend/src/pages/admin/Backups.tsx
@@ -33,6 +33,7 @@ export default function Backups() {
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
   const [savingConfig, setSavingConfig] = useState(false);
+  const [downloadingFile, setDownloadingFile] = useState<string | null>(null);
   const [backups, setBackups] = useState<BackupFile[]>([]);
   const [config, setConfig] = useState<BackupConfig>({
     enabled: false, hour: 2, retention_days: 30, location: '',
@@ -87,11 +88,14 @@ export default function Backups() {
   };
 
   const handleDownload = async (filename: string) => {
+    setDownloadingFile(filename);
     try {
       const res = await apiClient.get(`/admin/backups/${filename}/download`, { responseType: 'blob' });
       downloadBlob(res.data, filename, 'application/gzip');
     } catch (error) {
       toast.error(getErrorMessage(error, 'Download fehlgeschlagen'));
+    } finally {
+      setDownloadingFile(null);
     }
   };
 
@@ -220,7 +224,8 @@ export default function Backups() {
                   <td className="py-2 text-right space-x-2 whitespace-nowrap">
                     <button
                       onClick={() => handleDownload(b.filename)}
-                      className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800"
+                      disabled={downloadingFile === b.filename}
+                      className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800 disabled:opacity-50 disabled:cursor-not-allowed"
                       title="Herunterladen"
                     >
                       <Download className="w-4 h-4" />

--- a/frontend/src/pages/admin/Reports.tsx
+++ b/frontend/src/pages/admin/Reports.tsx
@@ -248,7 +248,8 @@ export default function Reports() {
   const handleYearlyExportOds = async () => {
     setLoading(true);
     try {
-      const response = await apiClient.get(`/admin/reports/export-yearly-ods?year=${selectedYear}`, {
+      const healthParam = includeHealthData ? '&include_health_data=true' : '';
+      const response = await apiClient.get(`/admin/reports/export-yearly-ods?year=${selectedYear}${healthParam}`, {
         responseType: 'blob',
       });
       downloadBlob(response.data, `PraxisZeit_Jahresreport_${selectedYear}.ods`);
@@ -262,7 +263,8 @@ export default function Reports() {
   const handleYearlyClassicExportOds = async () => {
     setLoading(true);
     try {
-      const response = await apiClient.get(`/admin/reports/export-yearly-classic-ods?year=${selectedYear}`, {
+      const healthParam = includeHealthData ? '&include_health_data=true' : '';
+      const response = await apiClient.get(`/admin/reports/export-yearly-classic-ods?year=${selectedYear}${healthParam}`, {
         responseType: 'blob',
       });
       downloadBlob(response.data, `PraxisZeit_Jahresreport_Classic_${selectedYear}.ods`);

--- a/frontend/src/pages/admin/Settings.tsx
+++ b/frontend/src/pages/admin/Settings.tsx
@@ -65,7 +65,10 @@ export default function Settings() {
   const toast = useToast();
   const { confirmState, confirm, handleConfirm, handleCancel } = useConfirm();
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
+  // L-4: getrennte Busy-Flags, damit das Speichern von Bundesland und
+  // Urlaubsgenehmigung sich nicht gegenseitig deaktiviert.
+  const [savingHolidayState, setSavingHolidayState] = useState(false);
+  const [savingApproval, setSavingApproval] = useState(false);
 
   // Holiday state
   const [states, setStates] = useState<string[]>([]);
@@ -195,7 +198,7 @@ export default function Settings() {
   };
 
   const saveHolidayState = async () => {
-    setSaving(true);
+    setSavingHolidayState(true);
     try {
       await apiClient.put('/admin/settings/holiday_state', { value: selectedState });
       setOriginalState(selectedState);
@@ -205,12 +208,12 @@ export default function Settings() {
     } catch (err) {
       toast.error(getErrorMessage(err));
     } finally {
-      setSaving(false);
+      setSavingHolidayState(false);
     }
   };
 
   const saveApproval = async () => {
-    setSaving(true);
+    setSavingApproval(true);
     try {
       await apiClient.put('/admin/settings/vacation_approval_required', {
         value: String(approvalRequired),
@@ -220,7 +223,7 @@ export default function Settings() {
     } catch (err) {
       toast.error(getErrorMessage(err));
     } finally {
-      setSaving(false);
+      setSavingApproval(false);
     }
   };
 
@@ -449,7 +452,7 @@ export default function Settings() {
           </div>
           <button
             onClick={saveHolidayState}
-            disabled={saving || selectedState === originalState}
+            disabled={savingHolidayState || selectedState === originalState}
             className="flex items-center gap-2 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             <Save size={16} />
@@ -757,7 +760,7 @@ export default function Settings() {
         <div className="mt-4">
           <button
             onClick={saveApproval}
-            disabled={saving || approvalRequired === originalApproval}
+            disabled={savingApproval || approvalRequired === originalApproval}
             className="flex items-center gap-2 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             <Save size={16} />

--- a/frontend/src/pages/admin/VacationApprovals.tsx
+++ b/frontend/src/pages/admin/VacationApprovals.tsx
@@ -95,12 +95,13 @@ export default function VacationApprovals() {
 
   // Review 2026-06-23: synchroner Doppelklick-Schutz — ein schneller Doppelklick
   // schickte sonst zwei Review-POSTs (der zweite wird serverseitig per Precondition
-  // abgelehnt, erzeugt aber einen verwirrenden Fehler-Toast).
-  const actionLock = useRef(false);
+  // abgelehnt, erzeugt aber einen verwirrenden Fehler-Toast). Per-Antrag gesperrt,
+  // damit eine langsame Aktion auf einer Karte nicht eine andere Karte blockiert.
+  const pendingIds = useRef(new Set<string>());
 
   const handleApprove = async (id: string) => {
-    if (actionLock.current) return;
-    actionLock.current = true;
+    if (pendingIds.current.has(id)) return;
+    pendingIds.current.add(id);
     try {
       await apiClient.post(`/admin/vacation-requests/${id}/review`, { action: 'approve' });
       toast.success('Antrag genehmigt');
@@ -108,13 +109,13 @@ export default function VacationApprovals() {
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Genehmigen'));
     } finally {
-      actionLock.current = false;
+      pendingIds.current.delete(id);
     }
   };
 
   const handleReject = async (id: string) => {
-    if (actionLock.current) return;
-    actionLock.current = true;
+    if (pendingIds.current.has(id)) return;
+    pendingIds.current.add(id);
     try {
       await apiClient.post(`/admin/vacation-requests/${id}/review`, {
         action: 'reject',
@@ -127,7 +128,7 @@ export default function VacationApprovals() {
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Ablehnen'));
     } finally {
-      actionLock.current = false;
+      pendingIds.current.delete(id);
     }
   };
 

--- a/frontend/src/pages/admin/users/CarryoverModal.tsx
+++ b/frontend/src/pages/admin/users/CarryoverModal.tsx
@@ -25,6 +25,7 @@ interface CarryoverModalProps {
 export default function CarryoverModal({ userId, userName, onClose, onSaved }: CarryoverModalProps) {
   const toast = useToast();
   const [carryovers, setCarryovers] = useState<YearCarryover[]>([]);
+  const [submitting, setSubmitting] = useState(false);
   const [formData, setFormData] = useState({
     year: new Date().getFullYear(),
     overtime_hours: 0,
@@ -65,6 +66,8 @@ export default function CarryoverModal({ userId, userName, onClose, onSaved }: C
   };
 
   const handleSubmit = async () => {
+    if (submitting) return;
+    setSubmitting(true);
     try {
       await apiClient.put(
         `/admin/users/${userId}/carryovers/${formData.year}`,
@@ -80,6 +83,8 @@ export default function CarryoverModal({ userId, userName, onClose, onSaved }: C
       onSaved();
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Speichern'));
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -152,7 +157,8 @@ export default function CarryoverModal({ userId, userName, onClose, onSaved }: C
 
           <button
             onClick={handleSubmit}
-            className="w-full bg-primary hover:bg-primary-dark text-white px-4 py-3 rounded-lg flex items-center justify-center space-x-2 transition mb-3"
+            disabled={submitting}
+            className="w-full bg-primary hover:bg-primary-dark text-white px-4 py-3 rounded-lg flex items-center justify-center space-x-2 transition mb-3 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Save size={18} />
             <span>Speichern</span>


### PR DESCRIPTION
Behebt #281 + kompletter Admin-Sektion-Review (3 Agenten, alle Findings ≤ low gefixt).

**#281:** Monatsübersicht zeigte Urlaub/Krank in Stunden + Krank immer 0 → jetzt in **Tagen** (Tagesprinzip §3 BUrlG, neuer `absence_days()`-Helper exakt wie `get_vacation_account`) + Krank über DSGVO-Art.-9-**Opt-in** sichtbar (auditiert). Jahrestabelle maskiert Krank ebenfalls.

**Review-Härtung:** F-026-Tenant-Filter (16 Call-Sites + Lookups), Absence-CR Budget-/Konflikt-Check, `synchronize_session=False`, per-Closure-Count, Audit-Commit-Reihenfolge, `absences_by_date`→Liste/Tag (§16), Superadmin-Rate-Limit + Logger, diverse Frontend-Refresh-/Guard-/TZ-Fixes.

**Verifiziert:** 980 Backend + 38 Postgres-Tenant + neuer Report-Test + 2 e2e-UI-Tests + tsc + vite build — alle grün.

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)
