### PR TITLE
chore(release): 1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## [Unreleased]
 
+## [1.10.2] - 2026-06-23
+
+Bugfix-Release: korrekte Tage-Anzeige in der Admin-Übersicht plus eine umfassende
+Härtung der gesamten Admin-Sektion (Review, alle Findings bis *low* behoben).
+
+### 🐞 Korrekturen
+- **Admin-Monatsübersicht zeigt Urlaub & Krank in *Tagen* statt Stunden (#281).**
+  Bisher wurden Urlaub/Krank in Stunden dargestellt (und Krank dauerhaft als 0).
+  Jetzt korrekt in **Tagen** nach dem Tagesprinzip (§3 BUrlG) — konsistent mit der
+  Jahresübersicht; ein halber Urlaubs-/Kranktag zählt 0,5, ein voller 1,0,
+  unabhängig vom individuellen Tagesplan.
+- **Krankheitstage sichtbar machen.** Krank ist aus Datenschutzgründen (Art. 9
+  DSGVO) standardmäßig maskiert und lässt sich über die Option **„Krankheitstage
+  anzeigen"** einblenden; der Zugriff wird protokolliert.
+
+### 🔒 Sicherheit / Robustheit (Admin-Review)
+- Durchgängige Mandanten-Filter (Mehrmandanten-Sicherheit) an allen geprüften
+  Admin-Abfragen; korrekte Bulk-Lösch-Strategie; saubere Reihenfolge der
+  Genehmigungsprüfungen.
+- **Änderungsanträge für Abwesenheiten** prüfen jetzt das Urlaubsbudget (Neuanlage)
+  bzw. Datums-Konflikte (Änderung) — keine stillen Überbuchungen oder Server-Fehler.
+- §16-Export vollständig (mehrere Abwesenheiten pro Tag werden nicht mehr verworfen);
+  Zugriffe auf Gesundheitsdaten werden erst nach erfolgreicher Auslieferung
+  protokolliert; Ratenbegrenzung auf den Mandanten-Export.
+
+### 🧹 Intern / UI
+- Monats- und Jahresübersicht aktualisieren sofort nach Korrekturen; tagbasierte
+  Spalten sind sortierbar; robustere Doppelklick- und Zeitzonen-Behandlung in
+  mehreren Admin-Dialogen; ODS-Jahresexport reicht die Gesundheitsdaten-Option durch.
+
 ## [1.10.1] - 2026-06-23
 
 Patch-Release: korrigiert die Windows-PostgreSQL-Version und härtet 1.10.0

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.10.1"
+APP_VERSION = "1.10.2"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "axios": "^1.18.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.10.1",
+  "version": "1.10.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.10.1"
+APP_VERSION="1.10.2"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
Bugfix-Release: #281 (Monatsübersicht Tage statt Stunden + Krank-Opt-in) + Admin-Review-Härtung. Version-Bump + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)