### PR TITLE
fix(#284): keine Phantom-„Gelöscht"-Einträge im Änderungsprotokoll (1.10.3)

### DIFF
--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.10.2"
+APP_VERSION = "1.10.3"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/routers/admin_time_entries.py
+++ b/backend/app/routers/admin_time_entries.py
@@ -22,6 +22,15 @@ from app.services import work_window_service
 
 router = APIRouter(prefix="/api/admin", tags=["admin"], dependencies=[Depends(require_admin)])
 
+# #284: The audit table stores BOTH real changes to time entries/absences
+# (create/update/delete) AND access/system events (e.g. DSGVO read-access markers
+# 'absence_list_read'/'health_data_read' written on every admin open of an
+# employee, #208). The operational per-employee "Änderungsprotokoll" must show
+# only the former; otherwise every open spawns a fresh access-log row that the
+# UI rendered as a phantom "Gelöscht". The dedicated compliance audit page keeps
+# full visibility (changes_only=False).
+_CHANGE_ACTIONS = ("create", "update", "delete")
+
 
 # ── Admin Time Entry Management ─────────────────────────────────────────
 
@@ -326,6 +335,11 @@ def list_audit_log(
         None,
         description="Keyset cursor — ISO-8601 timestamp; return entries strictly older than this",
     ),
+    changes_only: bool = Query(
+        False,
+        description="Return only real change actions (create/update/delete), "
+        "excluding access/system events such as DSGVO read-access markers (#284).",
+    ),
     skip: int = 0,
     limit: int = Query(default=100, le=500),
     db: Session = Depends(get_db),
@@ -349,6 +363,10 @@ def list_audit_log(
 
     if user_id:
         query = query.filter(TimeEntryAuditLog.user_id == user_id)
+
+    if changes_only:
+        # #284: keep the per-employee change log free of access/system events.
+        query = query.filter(TimeEntryAuditLog.action.in_(_CHANGE_ACTIONS))
 
     if month:
         try:

--- a/backend/tests/test_audit_log_changes_filter.py
+++ b/backend/tests/test_audit_log_changes_filter.py
@@ -1,0 +1,108 @@
+"""Regression tests for #284 — phantom 'Gelöscht' entries in the per-employee
+Änderungsprotokoll.
+
+Opening an employee in the admin dashboard issues GET /api/absences?user_id=X,
+which writes a DSGVO access-log row (action 'absence_list_read' / 'health_data_read',
+#208). The per-employee change-log view then fetched ALL audit rows for that user
+and the frontend rendered every non-create/update action as 'Gelöscht' — so each
+open produced a fresh phantom deletion.
+
+The operational change-log view must request only real change actions
+(create/update/delete). The dedicated compliance audit page keeps full visibility.
+"""
+import uuid
+from datetime import date
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.middleware.auth import get_current_user, require_admin
+from app.models import Absence, AbsenceType, User, UserRole
+from app.services import auth_service
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _app() -> FastAPI:
+    from app.routers import absences, admin_time_entries
+    from app.core.limiter import limiter
+    from slowapi import _rate_limit_exceeded_handler
+    from slowapi.errors import RateLimitExceeded
+
+    app = FastAPI()
+    limiter.enabled = False
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.include_router(absences.router)
+    app.include_router(admin_time_entries.router)
+    return app
+
+
+_APP = _app()
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    yield
+    _APP.dependency_overrides.clear()
+
+
+def _client(db, current):
+    def odb():
+        yield db
+    _APP.dependency_overrides[get_db] = odb
+    _APP.dependency_overrides[get_current_user] = lambda: current
+    _APP.dependency_overrides[require_admin] = lambda: current
+    return TestClient(_APP)
+
+
+def _mk_employee(db) -> User:
+    u = User(
+        id=uuid.uuid4(), username=f"u_{uuid.uuid4().hex[:6]}",
+        email=f"{uuid.uuid4().hex[:6]}@t.local",
+        password_hash=auth_service.hash_password("Test2025!Password"),
+        first_name="Erika", last_name="Muster", role=UserRole.EMPLOYEE,
+        weekly_hours=40.0, vacation_days=30, work_days_per_week=5,
+        is_active=True, tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _open_employee_absences(db, admin, employee):
+    """Simulate the dashboard opening an employee → writes the DSGVO read-log row."""
+    resp = _client(db, admin).get(f"/api/absences?user_id={employee.id}")
+    assert resp.status_code == 200, resp.text
+
+
+def test_changes_only_excludes_dsgvo_read_access_rows(db, test_admin):
+    employee = _mk_employee(db)
+    # Admin opens the employee twice → two DSGVO access-log rows are written.
+    _open_employee_absences(db, test_admin, employee)
+    _open_employee_absences(db, test_admin, employee)
+
+    resp = _client(db, test_admin).get(
+        f"/api/admin/audit-log?user_id={employee.id}&changes_only=true"
+    )
+    assert resp.status_code == 200, resp.text
+    actions = [row["action"] for row in resp.json()]
+    # The reported bug: read-access rows leaked into the change log and were
+    # rendered as 'Gelöscht'. They must NOT appear in the changes-only view.
+    assert "absence_list_read" not in actions
+    assert "health_data_read" not in actions
+    assert all(a in ("create", "update", "delete") for a in actions), actions
+
+
+def test_full_audit_log_still_includes_access_rows_for_compliance(db, test_admin):
+    employee = _mk_employee(db)
+    _open_employee_absences(db, test_admin, employee)
+
+    # The dedicated compliance page (no changes_only filter) keeps full visibility
+    # of access events — DSGVO Art. 5(2) accountability must not be hidden.
+    resp = _client(db, test_admin).get(f"/api/admin/audit-log?user_id={employee.id}")
+    assert resp.status_code == 200, resp.text
+    actions = [row["action"] for row in resp.json()]
+    assert "absence_list_read" in actions

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.10.2",
+      "version": "1.10.3",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "axios": "^1.18.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.10.2",
+  "version": "1.10.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -262,7 +262,10 @@ export default function AdminDashboard() {
   const fetchAuditForUser = async (userId: string) => {
     setAuditLoading(true);
     try {
-      const response = await apiClient.get(`/admin/audit-log?user_id=${userId}&month=${currentMonth}`);
+      // #284: only real changes (create/update/delete) belong in the per-employee
+      // change log — access/system events (e.g. DSGVO read-access markers written
+      // on every open) otherwise piled up here, rendered as phantom "Gelöscht".
+      const response = await apiClient.get(`/admin/audit-log?user_id=${userId}&month=${currentMonth}&changes_only=true`);
       setAuditLog(response.data);
     } catch (error) {
       toast.error('Fehler beim Laden des Audit-Logs');
@@ -1407,9 +1410,10 @@ export default function AdminDashboard() {
                                 <span className={`px-2 py-0.5 rounded font-medium ${
                                   log.action === 'create' ? 'bg-green-100 text-green-800' :
                                   log.action === 'update' ? 'bg-blue-100 text-blue-800' :
-                                  'bg-red-100 text-red-800'
+                                  log.action === 'delete' ? 'bg-red-100 text-red-800' :
+                                  'bg-gray-100 text-gray-700'
                                 }`}>
-                                  {log.action === 'create' ? 'Erstellt' : log.action === 'update' ? 'Geändert' : 'Gelöscht'}
+                                  {log.action === 'create' ? 'Erstellt' : log.action === 'update' ? 'Geändert' : log.action === 'delete' ? 'Gelöscht' : log.action}
                                 </span>
                                 <span className="text-gray-500">
                                   {format(new Date(log.created_at), 'dd.MM. HH:mm')} | {log.changed_by_first_name} {log.changed_by_last_name}

--- a/frontend/src/pages/admin/AuditLog.tsx
+++ b/frontend/src/pages/admin/AuditLog.tsx
@@ -37,20 +37,48 @@ interface UserOption {
 }
 
 const actionLabels: Record<string, string> = {
+  // Änderungen an Zeiteinträgen/Abwesenheiten
   create: 'Erstellt',
   update: 'Geändert',
   delete: 'Gelöscht',
+  import: 'Importiert',
+  profile_update: 'Profil geändert',
+  // Zugriffs-/Systemereignisse (keine Änderung — #284: NICHT als „Gelöscht" rendern)
+  absence_list_read: 'Abwesenheiten gelesen',
+  health_data_read: 'Gesundheitsdaten gelesen',
+  health_export: 'Gesundheitsdaten exportiert',
+  self_data_export: 'Eigene Daten exportiert',
+  arbzg_superadmin_export: 'Notfall-Export (§16)',
+  dsgvo_anonymize: 'Anonymisiert (Art. 17)',
+  dsgvo_purge: 'Endgültig gelöscht (Art. 17)',
+  license_readonly_mode_entered: 'Lizenz: Read-Only aktiviert',
 };
 
 const actionColors: Record<string, string> = {
   create: 'bg-green-100 text-green-800',
   update: 'bg-blue-100 text-blue-800',
   delete: 'bg-red-100 text-red-800',
+  import: 'bg-blue-100 text-blue-800',
+  profile_update: 'bg-blue-100 text-blue-800',
+  // destruktive DSGVO-Aktionen rot, Zugriffe/Exporte/Systemereignisse neutral
+  dsgvo_anonymize: 'bg-red-100 text-red-800',
+  dsgvo_purge: 'bg-red-100 text-red-800',
+  absence_list_read: 'bg-gray-100 text-gray-700',
+  health_data_read: 'bg-amber-100 text-amber-800',
+  health_export: 'bg-amber-100 text-amber-800',
+  self_data_export: 'bg-gray-100 text-gray-700',
+  arbzg_superadmin_export: 'bg-amber-100 text-amber-800',
+  license_readonly_mode_entered: 'bg-amber-100 text-amber-800',
 };
 
 const sourceLabels: Record<string, string> = {
   manual: 'Admin',
   change_request: 'Antrag',
+  import: 'Import',
+  dsgvo: 'DSGVO',
+  break_waiver: 'Pausen-Verzicht',
+  vacation_request_cancel: 'Urlaub storniert',
+  license_startup: 'Lizenz',
 };
 
 export default function AuditLog() {
@@ -214,7 +242,7 @@ export default function AuditLog() {
                     </span>
                   </div>
                   <div className="text-xs text-gray-500">
-                    {format(new Date(entry.created_at), 'dd.MM.yyyy HH:mm')} | von {entry.changed_by_first_name} {entry.changed_by_last_name} | {sourceLabels[entry.source]}
+                    {format(new Date(entry.created_at), 'dd.MM.yyyy HH:mm')} | von {entry.changed_by_first_name} {entry.changed_by_last_name} | {sourceLabels[entry.source] || entry.source}
                   </div>
                   <div className="flex items-center space-x-2 text-xs">
                     {entry.old_date && (

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.10.2"
+APP_VERSION="1.10.3"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
## #284 — Phantom „Gelöscht"-Einträge im Änderungsprotokoll

### Problem
Beim Öffnen eines Mitarbeiters im Admin-Dashboard erschien bei **jedem** Aufruf ein „Gelöscht"-Eintrag im Änderungsprotokoll (gemeldet von @philvdb).

### Ursache (root cause)
Das Öffnen löst `GET /absences?user_id=X` aus, das — gewollt, Feature #208 / DSGVO Art. 5(2) — bei jedem gezielten Admin-Lesezugriff eine Audit-Zeile `absence_list_read` bzw. `health_data_read` schreibt. Die Per-Mitarbeiter-Änderungsansicht (`AdminDashboard.tsx`) holte **alle** Audit-Zeilen des Nutzers, und das Frontend rendert jede Aktion ≠ `create`/`update` per `else → 'Gelöscht'`. Ergebnis: pro Öffnen ein neuer Phantom-„Gelöscht"-Eintrag.

### Fix (root cause, data-minimizing, defense-in-depth)
- **Backend** `list_audit_log`: neuer Parameter `changes_only` (Default `False`). `True` → nur echte Änderungsaktionen (`create`/`update`/`delete`). Die dedizierte Compliance-Audit-Seite bleibt unverändert (volle Sicht).
- **Frontend `AdminDashboard`**: Per-MA-Log fragt `changes_only=true` an; Label-Fallback nicht mehr „Gelöscht", sondern neutral.
- **Frontend `AuditLog`** (Compliance-Seite): saubere Labels/Farben für Zugriffs-/System-Ereignisse statt rohem snake_case bzw. Fehlfarbe; Mobile-Quelle-Fallback ergänzt.

Die DSGVO-Lesezugriffs-Protokollierung selbst bleibt unberührt — die Zeilen werden weiter geschrieben und sind auf der Audit-Protokoll-Seite vollständig sichtbar.

### Reviews (3 Agenten)
- **Security/DSGVO:** sound — Accountability intakt, kein Leak, Tamper-Evidence (HMAC) unberührt, kein XSS.
- **ArbZG §16:** konform — `_CHANGE_ACTIONS` vollständig; der `import`-Summary-Satz (`time_entry_id=None`) wird korrekt ausgeschlossen, da Einzeleinträge als `create`/`update` protokolliert sind.
- **Correctness:** Mobile-Quelle-Fallback ergänzt; Vorschlag `import`/`profile_update` aufzunehmen nach Verifikation abgelehnt (würde payloadlose Summary-Zeilen zurückholen).

### Tests
- Neuer Regressionstest `backend/tests/test_audit_log_changes_filter.py` (RED→GREEN).
- Backend-Suite: **982 passed / 49 skipped**. Frontend Vitest: **116 passed**. `tsc` grün.
- **Live-Build-Gegentest** (Docker, echter Login → Mitarbeiter zweimal geöffnet → `changes_only` schließt Read-Zeilen aus, Compliance-Sicht behält sie): **PASS**.
- `validate-release.sh`: 5/5 Distros (postgres+initdb 18.4).

### Release
Version-Bump 1.10.2 → **1.10.3** (`updater.py`, `build-release.sh`, `package.json` + Lock). Alle 6 Artefakte gebaut, Windows-ZIP-Integrität geprüft (PG-18.4-SHA-Pin, keine `setup.exe`-Dopplung, Bundle-Version 1.10.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
