### PR TITLE
fix(#286): Windows-Installer-Härtung (CRLF) + Docker-Upgrade-Skripte + Upgrade-Doku

### DIFF
--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -86,7 +86,7 @@ Oder direkt aus dem `db`-Container (Dienst läuft weiter) — **mit gzip**, dami
 Restore mit `gunzip -c | psql` zusammenpasst:
 
 ```bash
-docker compose exec -T db pg_dump -U "$POSTGRES_USER" --clean --if-exists "$POSTGRES_DB" \
+docker compose exec -T db pg_dump -U praxiszeit --clean --if-exists praxiszeit \
     | gzip > backup-$(date +%F).sql.gz
 ```
 

--- a/docs/INSTALL-DOCKER.md
+++ b/docs/INSTALL-DOCKER.md
@@ -25,9 +25,9 @@ Dateien (inkl. `docker-compose.yml`) zu kommen:
 ## Weg A — Docker-Bundle
 
 ```bash
-# 1. Bundle entpacken (enthält einen Top-Level-Ordner praxiszeit-X.Y.Z/)
-tar xzf praxiszeit-1.9.0-docker.tar.gz
-cd praxiszeit-1.9.0
+# 1. Bundle entpacken (enthält einen Top-Level-Ordner praxiszeit-<version>/)
+tar xzf praxiszeit-<version>-docker.tar.gz
+cd praxiszeit-<version>      # z. B. praxiszeit-1.10.3
 
 # 2. Secrets erzeugen (.env mit Zufallswerten + komplexem Admin-Passwort)
 bash generate-secrets.sh
@@ -133,7 +133,7 @@ im Volume `praxiszeit_backups` und lassen sich dort herunterladen.
 **Kommandozeile** (gzip, damit der Restore mit `gunzip -c | psql` zusammenpasst):
 
 ```bash
-docker compose exec -T db pg_dump -U "$POSTGRES_USER" --clean --if-exists "$POSTGRES_DB" \
+docker compose exec -T db pg_dump -U praxiszeit --clean --if-exists praxiszeit \
     | gzip > backup-$(date +%F).sql.gz
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -111,7 +111,8 @@ Pruefen ob alles laeuft:
 docker compose ps
 ```
 
-Alle 3 Dienste sollten "Up" zeigen. Health-Check:
+Alle Dienste sollten "Up" zeigen (`db`, `backend`, `frontend` und das Monitoring
+`prometheus`/`grafana`). Health-Check:
 ```bash
 curl http://localhost/api/health
 # Erwartet: {"status":"healthy","database":"connected"}
@@ -222,6 +223,12 @@ docker compose up -d
 
 ## Updates einspielen
 
+> **⚠️ Von 1.9.x oder älter auf 1.10.x?** Das ist ein PostgreSQL-Major-Upgrade
+> (16 → 18, **nicht in-place**) — ein einfaches `up --build` scheitert am
+> inkompatiblen PG16-Volume. Vorher den geführten Helfer fahren (läuft auch aus
+> dem git-Checkout): `bash tools/docker/update-pg-major.sh`. Vollständige
+> Anleitung inkl. Backup/Restore: **[UPDATE.md](UPDATE.md)**.
+
 ```bash
 cd ~/praxiszeit
 docker compose down
@@ -233,6 +240,7 @@ docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d --build
 ```
 
 Datenbank-Migrationen werden automatisch beim Start ausgefuehrt.
+Details & alle Pfade (Docker, Native, Windows): **[UPDATE.md](UPDATE.md)**.
 
 ---
 
@@ -241,7 +249,8 @@ Datenbank-Migrationen werden automatisch beim Start ausgefuehrt.
 ### Manuelles Backup
 ```bash
 cd ~/praxiszeit
-docker compose exec db pg_dump -U praxiszeit praxiszeit > backup_$(date +%Y%m%d).sql
+# --clean --if-exists + gzip → sauber zurückspielbar (s. „Backup wiederherstellen").
+docker compose exec -T db pg_dump -U praxiszeit --clean --if-exists praxiszeit | gzip > backup_$(date +%Y%m%d).sql.gz
 ```
 
 ### Automatisches taegliches Backup (Cron)
@@ -261,7 +270,8 @@ mkdir -p ~/backups
 ### Backup wiederherstellen
 ```bash
 cd ~/praxiszeit
-docker compose exec -T db psql -U praxiszeit praxiszeit < backup_20260214.sql
+gunzip -c backup_20260214.sql.gz | docker compose exec -T db psql -v ON_ERROR_STOP=1 -U praxiszeit -d praxiszeit
+docker compose up -d backend   # Migrationen heben das Schema auf head
 ```
 
 ---

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -42,8 +42,13 @@ hinweg erhalten — der `docker compose down`/`up`-Zyklus löscht sie **nicht**
 ### 1. Backup
 
 ```bash
-docker compose exec -T db pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" > backup-$(date +%F).sql
+# Default-User/-DB = praxiszeit (eigene Werte ggf. aus der .env ablesen).
+# --clean --if-exists + gzip → exakt so zurückspielbar wie unter „Rollback".
+docker compose exec -T db pg_dump -U praxiszeit --clean --if-exists praxiszeit | gzip > backup-$(date +%F).sql.gz
 ```
+
+> Die `$POSTGRES_USER`/`$POSTGRES_DB` aus der `.env` sind **nur im Container** gesetzt,
+> nicht in deiner Host-Shell — deshalb oben die festen Default-Namen `praxiszeit`.
 
 ### 2a. Mit Docker-Paket (Tarball/ZIP, ohne git)
 
@@ -55,8 +60,8 @@ lassen — das überschriebe Secrets und das Admin-Passwort):
 # im neuen, entpackten Paket-Ordner:
 cp /pfad/zur/alten/installation/.env ./.env
 # Falls SSL genutzt wird, auch das Zertifikat übernehmen:
-cp -r /pfad/zur/alten/installation/ssl/cert.pem ssl/cert.pem 2>/dev/null || true
-cp -r /pfad/zur/alten/installation/ssl/key.pem  ssl/key.pem  2>/dev/null || true
+cp /pfad/zur/alten/installation/ssl/cert.pem ssl/cert.pem 2>/dev/null || true
+cp /pfad/zur/alten/installation/ssl/key.pem  ssl/key.pem  2>/dev/null || true
 
 # HTTP:
 docker compose up -d --build
@@ -70,6 +75,16 @@ docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d --build
 > Wechsel das SQL-Backup ziehen und nach dem Start prüfen, ob die Daten da sind.
 
 ### 2b. Aus dem Quellcode (nur mit git-Zugriff)
+
+> **Von 1.9.x oder älter? Erst das PostgreSQL-Major-Upgrade fahren** — sonst
+> scheitert `up --build` am inkompatiblen PG16-Volume (siehe Box oben). Der Helfer
+> funktioniert auch aus dem git-Checkout (er findet die `docker-compose.yml` im
+> Repo-Root und nutzt `backup.sh`/`restore.sh` daneben):
+> ```bash
+> cd praxiszeit && git pull                 # holt PG18-Compose + den Helfer
+> bash tools/docker/update-pg-major.sh      # Backup → frischer PG18 → Restore
+> ```
+> Bereits auf 1.10.x? Dann ist es ein normales In-Place-Update:
 
 ```bash
 cd praxiszeit
@@ -155,7 +170,14 @@ beschriebenen Schritte.
 ## Rollback
 
 Es gibt keinen automatischen Rollback. Im Problemfall: die alte Paket-/Code-Version
-erneut einspielen und das **vor** dem Update gezogene DB-Backup zurückspielen
-(Docker: `psql … < backup.sql`; nativ: `pg_dump`/`psql` aus `bin/postgresql/bin`,
-siehe INSTALL-Dokumente). Migrationen sind in der Regel vorwärtskompatibel; ein
-Downgrade des Schemas wird **nicht** unterstützt — daher das Backup.
+erneut einspielen und das **vor** dem Update gezogene DB-Backup zurückspielen.
+Docker (zum `--clean`-gzip-Backup aus Schritt 1):
+
+```bash
+gunzip -c backup-JJJJ-MM-TT.sql.gz | docker compose exec -T db psql -v ON_ERROR_STOP=1 -U praxiszeit -d praxiszeit
+docker compose up -d backend
+```
+
+Nativ: `pg_dump`/`psql` aus `bin/postgresql/bin` (siehe INSTALL-Dokumente).
+Migrationen sind in der Regel vorwärtskompatibel; ein Downgrade des Schemas wird
+**nicht** unterstützt — daher das Backup.

--- a/installer/windows/setup.bat
+++ b/installer/windows/setup.bat
@@ -107,28 +107,33 @@ if exist "%PG_INSTALL_DIR%\bin\pg_ctl.exe" (
             --disable-components stackbuilder,pgAdmin ^
             --servicename "PraxisZeit-PostgreSQL" ^
             --install_runtimes 1
-        if not errorlevel 1 set "PG_INSTALL_RESULT=0"
     )
+    REM #286: Der EDB-Unattended-Installer kehrt teils mit Nicht-0-Exitcode zurueck
+    REM bzw. legt die Binaries ASYNCHRON ab - sie erscheinen erst Minuten spaeter.
+    REM Erfolg daher an der Existenz von pg_ctl.exe festmachen, nicht am Exitcode,
+    REM und bis zu 6 Minuten darauf warten. CRLF-Zeilenenden noetig: mit LF brechen
+    REM cmd.exe-Label-Spruenge call/goto :label und mehrzeilige Klammer-Bloecke.
+    REM Hinweis: keine Klammern in diesen REM-Zeilen - dies ist noch ein ()-Block.
+    echo Warte auf PostgreSQL-Binaries ^(kann einige Minuten dauern^)...
+    for /l %%w in (1,1,72) do if not exist "%PG_INSTALL_DIR%\bin\pg_ctl.exe" timeout /t 5 /nobreak >nul
 
-    if not "%PG_INSTALL_RESULT%"=="0" (
-        echo.
-        echo FEHLER: PostgreSQL-Installation fehlgeschlagen!
-        echo Bitte installieren Sie PostgreSQL manuell von:
-        echo   https://www.enterprisedb.com/downloads/postgres-postgresql-downloads
-        if not defined PRAXISZEIT_NONINTERACTIVE pause
-        exit /b 1
+    if exist "%PG_INSTALL_DIR%\bin\pg_ctl.exe" (
+        REM Binaries vorhanden = EDB-Installer fertig -> dessen eigenen Dienst und
+        REM Datenverzeichnis entfernen. PraxisZeit verwaltet PG mit eigenem Cluster.
+        REM Kein Race mit dem Installer, weil die Binaries bereits geschrieben sind.
+        echo Raeume EDB-Installer auf...
+        net stop PraxisZeit-PostgreSQL 2>nul
+        sc delete PraxisZeit-PostgreSQL 2>nul
+        if exist "%PG_DATA_DIR%\PG_VERSION" rd /s /q "%PG_DATA_DIR%"
+        if not exist "%PG_DATA_DIR%" mkdir "%PG_DATA_DIR%"
+        echo PostgreSQL installiert.
+    ) else (
+        REM Binaries noch nicht da ist KEIN harter Fehler: der Dienst initialisiert
+        REM PostgreSQL beim ersten Start selbst und legt ein fremdes EDB-Datadir
+        REM dabei sauber zur Seite. Kein exit/b - sonst bricht das Setup grundlos ab.
+        echo HINWEIS: PostgreSQL-Binaries noch nicht sichtbar. Der Dienst
+        echo initialisiert die Datenbank beim ersten Start. Setup faehrt fort.
     )
-
-    REM EDB erstellt einen eigenen Service und Datenverzeichnis mit User "postgres".
-    REM PraxisZeit verwaltet PostgreSQL selbst mit eigenem Superuser "praxiszeit".
-    REM Daher: EDB-Service und Datenverzeichnis entfernen.
-    echo Raeume EDB-Installer auf...
-    net stop PraxisZeit-PostgreSQL 2>nul
-    sc delete PraxisZeit-PostgreSQL 2>nul
-    if exist "%PG_DATA_DIR%\PG_VERSION" rd /s /q "%PG_DATA_DIR%"
-    if not exist "%PG_DATA_DIR%" mkdir "%PG_DATA_DIR%"
-
-    echo PostgreSQL installiert.
 ) else (
     echo.
     echo WARNUNG: PostgreSQL-Installer nicht gefunden.

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -668,6 +668,9 @@ if [ "$BUILD_WINDOWS" = true ]; then
     cp "${REPO_DIR}/installer/windows/backup.bat" "${WIN_DIR}/"
     cp "${REPO_DIR}/installer/windows/update-wizard.bat" "${WIN_DIR}/"
     cp "${REPO_DIR}/installer/windows/update-wizard.ps1" "${WIN_DIR}/"
+    # restore-backup.bat aus dem Template ausliefern (BACKUP.md/UPDATE.md verweisen
+    # darauf). Das Template defaultet INSTALL_DIR auf C:\praxiszeit -> direkt nutzbar.
+    cp "${REPO_DIR}/installer/windows/restore-backup.template.bat" "${WIN_DIR}/restore-backup.bat"
 
     info "Entpacke Python ${PYTHON_VERSION} (Windows x64)..."
     mkdir -p "${WIN_DIR}/bin/python"
@@ -740,6 +743,19 @@ PTHEOF
 
     # Setup + Service Scripts aus dem Repo kopieren
     cp "${REPO_DIR}/installer/windows/setup.bat" "${WIN_DIR}/"
+
+    # #286: Windows-Skripte ZWINGEND mit CRLF ausliefern. Bei LF-Zeilenenden findet
+    # cmd.exe keine Labels (call/goto :label -> "cannot find batch label specified")
+    # und mehrzeilige ()-Bloecke brechen -> setup.bat meldete faelschlich
+    # "PostgreSQL-Installation fehlgeschlagen!" obwohl PG 18.4 korrekt installierte.
+    # .gitattributes (*.bat eol=crlf) griff nicht auf jeder Build-Maschine (stale
+    # working tree) -> hier hart erzwingen, damit jede Build-Maschine identisch liefert.
+    find "${WIN_DIR}" -type f \( -name '*.bat' -o -name '*.cmd' -o -name '*.ps1' \) \
+        -exec perl -0777 -i -pe 's/\r?\n/\r\n/g' {} +
+    if ! grep -q $'\r' "${WIN_DIR}/setup.bat"; then
+        echo -e "${RED}[ERROR]${NC} setup.bat ohne CRLF — Windows-cmd bricht an Labels ab (#286)." >&2
+        exit 1
+    fi
 
     # ========================================================================
     # Phase 5b: Avalonia GUI-Installer (setup.exe) mit eingebettetem Payload

--- a/tools/docker/backup.sh
+++ b/tools/docker/backup.sh
@@ -11,7 +11,10 @@
 # komprimiert und liesse sich nicht wie dokumentiert per gunzip|psql einspielen).
 set -euo pipefail
 
+# Bundle: docker-compose.yml + .env liegen NEBEN diesem Skript. Git-Checkout:
+# das Skript liegt in tools/docker/, docker-compose.yml + .env im Repo-Root.
 cd "$(dirname "$0")"
+if [ ! -f docker-compose.yml ] && [ -f ../../docker-compose.yml ]; then cd ../../; fi
 
 if [ ! -f .env ]; then
     echo "FEHLER: .env nicht gefunden — zuerst 'bash generate-secrets.sh' ausfuehren." >&2

--- a/tools/docker/restore.sh
+++ b/tools/docker/restore.sh
@@ -16,9 +16,15 @@
 # also die vorhandenen Tabellen.
 set -euo pipefail
 
-cd "$(dirname "$0")"
-
+# $FILE relativ zum AUFRUF-Verzeichnis absolut machen, BEVOR das cwd wechselt.
 FILE="${1:-}"
+case "$FILE" in /*|"") ;; *) FILE="$(pwd)/$FILE" ;; esac
+
+# Bundle: docker-compose.yml + .env liegen NEBEN diesem Skript. Git-Checkout:
+# das Skript liegt in tools/docker/, docker-compose.yml + .env im Repo-Root.
+cd "$(dirname "$0")"
+if [ ! -f docker-compose.yml ] && [ -f ../../docker-compose.yml ]; then cd ../../; fi
+
 if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
     echo "Aufruf: bash restore.sh <pfad/zu/praxiszeit_*.sql.gz>" >&2
     exit 1

--- a/tools/docker/update-pg-major.sh
+++ b/tools/docker/update-pg-major.sh
@@ -11,12 +11,23 @@
 # Aufruf NEBEN der docker-compose.yml (im Docker-Bundle):  bash update-pg-major.sh
 # (Der ALTE Stack muss noch laufen, damit gesichert werden kann.)
 set -euo pipefail
-cd "$(dirname "$0")"   # Bundle-Root (hier liegen docker-compose.yml + backup.sh/restore.sh)
-
-[ -f docker-compose.yml ] || { echo "FEHLER: keine docker-compose.yml neben diesem Skript (bitte im Docker-Bundle ausfuehren)." >&2; exit 1; }
+# Bundle: docker-compose.yml + backup.sh/restore.sh liegen NEBEN diesem Skript.
+# Git-Checkout: dieses Skript liegt in tools/docker/, die docker-compose.yml im
+# Repo-Root. SCRIPT_DIR behaelt den Ort der Helfer-Skripte, in COMPOSE_DIR (wo die
+# docker-compose.yml liegt = Compose-Projekt + Volume) wird gearbeitet.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "$SCRIPT_DIR/docker-compose.yml" ]; then
+    COMPOSE_DIR="$SCRIPT_DIR"
+elif [ -f "$SCRIPT_DIR/../../docker-compose.yml" ]; then
+    COMPOSE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+else
+    echo "FEHLER: keine docker-compose.yml gefunden (weder neben dem Skript noch im Repo-Root)." >&2
+    exit 1
+fi
+cd "$COMPOSE_DIR"
 
 echo "==> 1/5  Backup der laufenden Datenbank (alte PostgreSQL-Version)..."
-bash backup.sh
+bash "$SCRIPT_DIR/backup.sh"
 BK="$(ls -1t backups/praxiszeit_*.sql.gz 2>/dev/null | head -1)"
 [ -n "$BK" ] && [ -f "$BK" ] || { echo "FEHLER: kein Backup erzeugt — Abbruch (Daten unangetastet)." >&2; exit 1; }
 # Vollständigkeit prüfen, BEVOR gleich das Volume zerstört wird: ein vollständiger
@@ -33,6 +44,11 @@ if ! grep -q "PostgreSQL database dump complete" <<<"$_dump_tail"; then
     echo "FEHLER: Dump-Trailer fehlt — Backup unvollständig. Abbruch (Daten unangetastet)." >&2; exit 1
 fi
 echo "    Backup: $BK (vollständig)"
+
+# Ab hier wird gleich das alte Volume entfernt. Schlägt danach IRGENDETWAS fehl
+# (z. B. ein Port-Konflikt beim `up`, ein Build-Fehler), sind die Daten NICHT
+# verloren — sie liegen im verifizierten Backup. Diese Falle weist den Weg.
+trap '_rc=$?; if [ "$_rc" != 0 ]; then echo "" >&2; echo "ABBRUCH (Exit $_rc). Deine Daten sind sicher im Backup: ${BK}" >&2; echo "Nach Behebung der Ursache manuell wiederherstellen:" >&2; echo "  cd \"$COMPOSE_DIR\" && docker compose up -d db && bash \"$SCRIPT_DIR/restore.sh\" \"${BK}\" && docker compose up -d" >&2; fi' EXIT
 
 echo "==> 2/5  Exaktes DB-Volume ermitteln (vor dem Stop)..."
 VOL="$(docker compose ps -q db | xargs -r docker inspect \
@@ -65,8 +81,9 @@ done
     || { echo "FEHLER: neue Datenbank wurde nicht 'healthy'. Backup liegt unter ${BK}." >&2; exit 1; }
 
 echo "==> 5/5  Restore in den frischen Cluster..."
-bash restore.sh "$BK"
+bash "$SCRIPT_DIR/restore.sh" "$BK"
 docker compose up -d backend
+trap - EXIT   # Erfolg — Abbruch-Falle entschaerfen
 
 echo ""
 echo "Fertig. Das alte DB-Volume wurde durch einen frischen PG18-Cluster ersetzt."


### PR DESCRIPTION
## #286 — Windows-`setup.bat` meldet fälschlich „PostgreSQL-Installation fehlgeschlagen!"

### Root cause (tiefer als der Issue vermutete)
Nicht der EDB-Exitcode, sondern **LF-Zeilenenden**: `setup.bat` & weitere `.bat` wurden mit LF ausgeliefert. cmd.exe findet damit keine Labels (`cannot find batch label specified - detect_system_pg`) und mehrzeilige `()`-Blöcke brechen → die PG-Erfolgsprüfung lief nie → falsche FEHLER-Meldung + `exit /b 1`. Die `.gitattributes`-Regel `*.bat eol=crlf` existierte, griff aber auf dem stale Working-Tree nicht (nur `uninstall.bat` war zufällig CRLF).

### Fix
- **CRLF für alle Windows-Skripte** + **Build-Guard** in `build-release.sh` (erzwingt CRLF im Paket, bricht ab wenn `setup.bat` kein CRLF hat → reproduzierbar auf jeder Build-Maschine).
- `setup.bat` PG-Erkennung robust: der EDB-Installer legt die Binaries **asynchron** ab → bis zu 6 min auf `pg_ctl.exe` warten statt Exitcode; fehlende Binaries sind **kein** harter Fehler mehr (der Dienst initialisiert PG beim ersten Start selbst). EDB-Aufräumung nur wenn Binaries da (kein Race).

### Verifiziert (dockur/windows, echtes Win11)
4 Emulator-Läufe. Ergebnis mit Fix: **kein** Label-Fehler, **kein** FEHLER, `PostgreSQL installiert.` + `Setup abgeschlossen!`, `HEALTH_HTTP=200`, `LOGIN_HTTP=200`, `psql 18.4`.

---

## Mitgenommen: Docker-Upgrade-Härtung (beim Migrationstest 1.8.x→1.10.x gefunden)

- `update-pg-major.sh`/`backup.sh`/`restore.sh` waren **bundle-only** → aus git-Checkout abgebrochen. Jetzt **dual-layout** (finden die `docker-compose.yml` neben dem Skript ODER im Repo-Root). Verifiziert: `backup.sh`+`restore.sh` aus Repo-Root (Backup erzeugt, Restore + Login 200).
- `update-pg-major.sh`: **Backup-Sicherheits-Trap** — bei Fehler nach dem Volume-Entfernen (z. B. Port-Konflikt) wird auf das intakte Backup + den Restore-Befehl hingewiesen.

## Mitgenommen: Upgrade-/Install-Doku (Doc-Review, gegen Code verifiziert)
- **PG16→18-Hinweis für git-Quellinstall** (UPDATE.md §2b + INSTALLATION.md) — stiller Upgrade-Breaker 1.9.x→1.10.x.
- Backup-Befehle nutzten unset `$POSTGRES_USER`/`$POSTGRES_DB` → feste `praxiszeit`-Defaults; durchgängig `--clean --if-exists` + gzip + `ON_ERROR_STOP=1`.
- **`restore-backup.bat`** (von Docs referenziert, nie ausgeliefert) → wird jetzt gebaut.
- `cp -r`→`cp`; „3 Dienste"→5; Version `1.9.0`→Platzhalter.

---

### Migrationstest-Nebenbefund (zum Bug-Report „alle MA → 1.6.2026")
1.8.15(PG16)→1.10.3(PG18) erhält die Daten **byte-genau** (inkl. `first_work_day=2026-06-15`, checksum identisch, Login 200). Der Report ist **nicht** durch die Migration oder den Code reproduzierbar — definitiver Check ist das Pre-Update-Backup des Kunden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
