### PR TITLE
fix(#287): Arbeitsbereich nutzt volle Breite (kein max-w-7xl-Cap)

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -410,7 +410,11 @@ export default function Layout() {
       {/* Main Content */}
       <main id="main-content" className="flex-1 overflow-y-auto overflow-x-hidden lg:pt-0 pt-16 pb-20 lg:pb-0 bg-background" tabIndex={-1}>
         <TrialBanner />
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 lg:py-8">
+        {/* #287: Arbeitsbereich nutzt die volle Breite neben dem Menü (kein
+            max-w-7xl-Cap mehr, das auf breiten Screens ~die Hälfte leer ließ).
+            Die responsive px-Polsterung lässt einen schmalen Rand ⇒ ~95 % Füllung.
+            Schmale Form-Seiten (Billing/Backups) behalten ihre eigenen max-w. */}
+        <div className="w-full px-4 sm:px-6 lg:px-8 py-6 lg:py-8">
           {/* #147: Lazy-geladene Routen (admin/* + Help) -> Suspense nur um den
               Content, damit die Sidebar beim Chunk-Laden stehen bleibt. */}
           <Suspense


### PR DESCRIPTION
## #287 — „ganze Breite nutzen"

Der Hauptinhalt war auf `max-w-7xl` (1280px) + `mx-auto` begrenzt → auf breiten Screens blieb rechts/links viel leerer Raum (Screenshot im Issue: ~die Hälfte leer).

**Fix:** `Layout.tsx` Haupt-Wrapper `max-w-7xl mx-auto` → `w-full`. Der Inhalt füllt jetzt die volle Breite des Arbeitsbereichs neben dem Menü; die responsive `px`-Polsterung lässt einen schmalen Rand (~95%). Schmale Form-Seiten (Billing/Backups) und Modals behalten ihre eigenen `max-w` bewusst.

### Verifiziert (Playwright @1920×1080, 7 Seiten)
Dashboard, Admin-Dashboard, Benutzer, Änderungsprotokoll, Berichte, Abwesenheiten, Einstellungen:
- **KEIN horizontaler Seiten-Scroll** (explizite Nutzer-Anforderung für Full-HD) ✓
- **KEIN Clipping** im `overflow-x-hidden`-`<main>` ✓
- Inhalt füllt **100% des Arbeitsbereichs (1664px)** statt vorher 1280px ✓
- tsc + vite build grün.

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)