### PR TITLE
refactor(#219): Code-Duplikation entfernen (Audit + vorsichtige Konsolidierung)

### DIFF
--- a/backend/app/routers/admin_helpers.py
+++ b/backend/app/routers/admin_helpers.py
@@ -3,8 +3,11 @@
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from app.models import User, ChangeRequest, TimeEntryAuditLog
+from app.models.vacation_request import VacationRequest
 from app.schemas.change_request import ChangeRequestResponse
 from app.schemas.time_entry_audit_log import AuditLogResponse
+from app.schemas.vacation_request import VacationRequestResponse
+from app.services.calculation_service import count_workdays
 
 
 def _get_field(entry, field: str):
@@ -91,6 +94,59 @@ def _enrich_cr_responses(crs: list, db: Session) -> list[ChangeRequestResponse]:
                 response.reviewer_first_name = reviewer.first_name
                 response.reviewer_last_name = reviewer.last_name
         results.append(response)
+    return results
+
+
+def _enrich_vr_response(vr: VacationRequest, db: Session) -> VacationRequestResponse:
+    """Add user names + workdays to a vacation request response (single item)."""
+    return _enrich_vr_responses([vr], db)[0]
+
+
+def _enrich_vr_responses(vrs: list, db: Session) -> list[VacationRequestResponse]:
+    """#219: single shared enricher for vacation requests (was duplicated in
+    admin_vacations._enrich_vr_responses + vacation_requests._enrich, the latter
+    doing 3 DB queries PER item). Batch: one user query for the whole list."""
+    if not vrs:
+        return []
+    user_ids = set()
+    for vr in vrs:
+        user_ids.add(vr.user_id)
+        if vr.reviewed_by:
+            user_ids.add(vr.reviewed_by)
+        if vr.last_modified_by:
+            user_ids.add(vr.last_modified_by)
+    user_ids.discard(None)
+    # F-026: scope referenced users to the tenants of the requests they belong to.
+    tenant_ids = {vr.tenant_id for vr in vrs}
+    users = (
+        db.query(User)
+        .filter(User.id.in_(user_ids), User.tenant_id.in_(tenant_ids))
+        .all()
+        if user_ids
+        else []
+    )
+    user_map = {u.id: u for u in users}
+
+    results = []
+    for vr in vrs:
+        resp = VacationRequestResponse.model_validate(vr)
+        user = user_map.get(vr.user_id)
+        if user:
+            resp.user_first_name = user.first_name
+            resp.user_last_name = user.last_name
+        if vr.reviewed_by:
+            reviewer = user_map.get(vr.reviewed_by)
+            if reviewer:
+                resp.reviewer_first_name = reviewer.first_name
+                resp.reviewer_last_name = reviewer.last_name
+        if vr.last_modified_by:
+            modifier = user_map.get(vr.last_modified_by)
+            if modifier:
+                resp.last_modifier_first_name = modifier.first_name
+                resp.last_modifier_last_name = modifier.last_name
+        end = vr.end_date if vr.end_date else vr.date
+        resp.days = count_workdays(db, vr.date, end, tenant_id=vr.tenant_id)
+        results.append(resp)
     return results
 
 

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -39,6 +39,18 @@ def _get_user_in_tenant(db: Session, user_id: str, current_user: User) -> User:
     return user
 
 
+def _filtered_user_list_query(db: Session, current_user: User, include_inactive: bool, include_hidden: bool):
+    """#219: shared user-list query for list_users + users_overview (#194 keeps them
+    in sync). Returns the UNEXECUTED query so callers add their own .offset/.limit/.all.
+    F-026: explicit tenant filter on top of RLS; active+visible by default."""
+    query = db.query(User).filter(User.tenant_id == current_user.tenant_id)
+    if not include_inactive:
+        query = query.filter(User.is_active == True)  # noqa: E712
+    if not include_hidden:
+        query = query.filter(User.is_hidden == False)  # noqa: E712
+    return query.order_by(User.last_name, User.first_name)
+
+
 def _tenant_has_other_active_admin(db: Session, current_user: User) -> bool:
     """Audit A01 (4-Augen-Prinzip): does the caller's tenant have ANOTHER
     active admin besides ``current_user``?
@@ -76,13 +88,10 @@ def list_users(
     """List users (admin only). By default only active, visible users."""
     # F-026: belt-and-suspenders — RLS already scopes by tenant, but every
     # list endpoint must add the explicit filter so a missing GUC cannot
-    # leak cross-tenant rows.
-    query = db.query(User).filter(User.tenant_id == current_user.tenant_id)
-    if not include_inactive:
-        query = query.filter(User.is_active == True)
-    if not include_hidden:
-        query = query.filter(User.is_hidden == False)
-    users = query.order_by(User.last_name, User.first_name).offset(skip).limit(limit).all()
+    # leak cross-tenant rows. (#219: shared with users_overview.)
+    users = _filtered_user_list_query(
+        db, current_user, include_inactive, include_hidden
+    ).offset(skip).limit(limit).all()
     return users
 
 
@@ -101,12 +110,9 @@ def users_overview(
     F-026: explicit tenant filter on top of RLS.
     """
     year = year or today_local().year
-    query = db.query(User).filter(User.tenant_id == current_user.tenant_id)
-    if not include_inactive:
-        query = query.filter(User.is_active == True)
-    if not include_hidden:
-        query = query.filter(User.is_hidden == False)
-    users = query.order_by(User.last_name, User.first_name).all()
+    users = _filtered_user_list_query(
+        db, current_user, include_inactive, include_hidden
+    ).all()
 
     result = []
     for u in users:

--- a/backend/app/routers/admin_vacations.py
+++ b/backend/app/routers/admin_vacations.py
@@ -11,9 +11,12 @@ from app.models.vacation_request import VacationRequest, VacationRequestStatus
 from app.middleware.auth import require_admin
 from app.schemas.vacation_request import VacationRequestResponse, VacationRequestReview, VacationRequestUpdate
 from app.services import calculation_service
-from app.services.calculation_service import count_workdays
 from app.services.timezone_service import today_local
-from app.routers.admin_helpers import _create_audit_log
+from app.routers.admin_helpers import (
+    _create_audit_log,
+    _enrich_vr_response,
+    _enrich_vr_responses,
+)
 from app.routers.admin_users import _tenant_has_other_active_admin
 from app.routers.vacation_requests import (
     cancel_approved_vacation_request,
@@ -37,56 +40,7 @@ def get_pending_vacation_request_count(
     return {"count": count}
 
 
-def _enrich_vr_response(vr: VacationRequest, db: Session) -> VacationRequestResponse:
-    """Add user names to the vacation request response (single item)."""
-    return _enrich_vr_responses([vr], db)[0]
-
-
-def _enrich_vr_responses(vrs: list, db: Session) -> list[VacationRequestResponse]:
-    """Add user names to vacation request responses (batch, single query)."""
-    if not vrs:
-        return []
-    user_ids = set()
-    for vr in vrs:
-        user_ids.add(vr.user_id)
-        if vr.reviewed_by:
-            user_ids.add(vr.reviewed_by)
-        if vr.last_modified_by:
-            user_ids.add(vr.last_modified_by)
-    user_ids.discard(None)
-    # F-026: scope referenced users to the tenants of the requests they belong to.
-    tenant_ids = {vr.tenant_id for vr in vrs}
-    users = (
-        db.query(User)
-        .filter(User.id.in_(user_ids), User.tenant_id.in_(tenant_ids))
-        .all()
-        if user_ids
-        else []
-    )
-    user_map = {u.id: u for u in users}
-
-    results = []
-    for vr in vrs:
-        resp = VacationRequestResponse.model_validate(vr)
-        user = user_map.get(vr.user_id)
-        if user:
-            resp.user_first_name = user.first_name
-            resp.user_last_name = user.last_name
-        if vr.reviewed_by:
-            reviewer = user_map.get(vr.reviewed_by)
-            if reviewer:
-                resp.reviewer_first_name = reviewer.first_name
-                resp.reviewer_last_name = reviewer.last_name
-        if vr.last_modified_by:
-            modifier = user_map.get(vr.last_modified_by)
-            if modifier:
-                resp.last_modifier_first_name = modifier.first_name
-                resp.last_modifier_last_name = modifier.last_name
-        # Compute workdays
-        end = vr.end_date if vr.end_date else vr.date
-        resp.days = count_workdays(db, vr.date, end, tenant_id=vr.tenant_id)
-        results.append(resp)
-    return results
+# _enrich_vr_response / _enrich_vr_responses live in admin_helpers now (#219).
 
 
 @router.get("/vacation-requests", response_model=List[VacationRequestResponse])

--- a/backend/app/routers/change_requests.py
+++ b/backend/app/routers/change_requests.py
@@ -13,26 +13,11 @@ from app.routers.time_entries import (
     MAX_DAILY_HOURS_HARD, MAX_NIGHT_WORKER_DAILY_WARN, MAX_WEEKLY_HOURS_WARN,
 )
 from app.services.arbzg_utils import is_night_work
+# #219: single shared CR-enricher (was duplicated per-item here vs the batch in
+# admin_helpers). _enrich_cr_response wraps the batch _enrich_cr_responses([cr]).
+from app.routers.admin_helpers import _enrich_cr_response as _enrich_response
 
 router = APIRouter(prefix="/api/change-requests", tags=["change-requests"])
-
-
-def _enrich_response(cr: ChangeRequest, db: Session) -> ChangeRequestResponse:
-    """Add user names to the change request response."""
-    response = ChangeRequestResponse.model_validate(cr)
-
-    user = db.query(User).filter(User.id == cr.user_id, User.tenant_id == cr.tenant_id).first()
-    if user:
-        response.user_first_name = user.first_name
-        response.user_last_name = user.last_name
-
-    if cr.reviewed_by:
-        reviewer = db.query(User).filter(User.id == cr.reviewed_by, User.tenant_id == cr.tenant_id).first()
-        if reviewer:
-            response.reviewer_first_name = reviewer.first_name
-            response.reviewer_last_name = reviewer.last_name
-
-    return response
 
 
 @router.post("/", response_model=ChangeRequestResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/app/routers/vacation_requests.py
+++ b/backend/app/routers/vacation_requests.py
@@ -10,33 +10,13 @@ from app.models import User, UserRole, PublicHoliday, Absence, AbsenceType, Time
 from app.models.vacation_request import VacationRequest, VacationRequestStatus
 from app.middleware.auth import get_current_user
 from app.schemas.vacation_request import VacationRequestCreate, VacationRequestResponse, VacationRequestUpdate
-from app.services.calculation_service import count_workdays
 from app.services.timezone_service import today_local
 from app.services import settings_service
+# #219: single shared VR-enricher (was duplicated here as a per-item N+1 copy of
+# admin_vacations._enrich_vr_responses). _enrich = thin single-item alias.
+from app.routers.admin_helpers import _enrich_vr_response as _enrich, _enrich_vr_responses
 
 router = APIRouter(prefix="/api/vacation-requests", tags=["vacation-requests"])
-
-
-def _enrich(vr: VacationRequest, db: Session) -> VacationRequestResponse:
-    resp = VacationRequestResponse.model_validate(vr)
-    user = db.query(User).filter(User.id == vr.user_id, User.tenant_id == vr.tenant_id).first()
-    if user:
-        resp.user_first_name = user.first_name
-        resp.user_last_name = user.last_name
-    if vr.reviewed_by:
-        reviewer = db.query(User).filter(User.id == vr.reviewed_by, User.tenant_id == vr.tenant_id).first()
-        if reviewer:
-            resp.reviewer_first_name = reviewer.first_name
-            resp.reviewer_last_name = reviewer.last_name
-    if vr.last_modified_by:
-        modifier = db.query(User).filter(User.id == vr.last_modified_by, User.tenant_id == vr.tenant_id).first()
-        if modifier:
-            resp.last_modifier_first_name = modifier.first_name
-            resp.last_modifier_last_name = modifier.last_name
-    # Compute workdays
-    end = vr.end_date if vr.end_date else vr.date
-    resp.days = count_workdays(db, vr.date, end, tenant_id=vr.tenant_id)
-    return resp
 
 
 def format_vacation_request_audit_text(vr: VacationRequest) -> str:
@@ -366,7 +346,7 @@ def list_my_vacation_requests(
     if status:
         query = query.filter(VacationRequest.status == status)
     requests = query.order_by(VacationRequest.created_at.desc()).offset(skip).limit(limit).all()
-    return [_enrich(vr, db) for vr in requests]
+    return _enrich_vr_responses(requests, db)  # #219: batch (was per-item N+1)
 
 
 def cancel_approved_vacation_request(

--- a/backend/app/schemas/absence.py
+++ b/backend/app/schemas/absence.py
@@ -4,6 +4,7 @@ from datetime import date, datetime, time
 from decimal import Decimal
 from uuid import UUID
 from app.models.absence import AbsenceType
+from app.schemas.validators import validate_half_day_single_day
 
 
 class AbsenceBase(BaseModel):
@@ -25,13 +26,7 @@ class AbsenceCreate(AbsenceBase):
     @field_validator('half_day')
     @classmethod
     def half_day_single_day(cls, v, info):
-        # Halbe Tage nur für Einzeltage — ein Zeitraum würde jeden Tag halbieren.
-        if v:
-            start = info.data.get('date')
-            end = info.data.get('end_date')
-            if end is not None and start is not None and end != start:
-                raise ValueError('Halbe Tage sind nur für Einzeltage möglich')
-        return v
+        return validate_half_day_single_day(v, info)  # #219: shared
 
 
 class AbsenceResponse(AbsenceBase):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -5,6 +5,7 @@ from datetime import datetime, date, time
 from decimal import Decimal
 from uuid import UUID
 from app.models.user import UserRole
+from app.schemas.validators import validate_employment_and_window_order
 
 
 def _validate_password_complexity(password: str) -> str:
@@ -62,27 +63,9 @@ class UserBase(BaseModel):
     scheduled_start_friday: Optional[time] = None
     scheduled_end_friday: Optional[time] = None
 
-    _SCHEDULED_WINDOW_PAIRS = [
-        ("scheduled_start_monday", "scheduled_end_monday", "Montag"),
-        ("scheduled_start_tuesday", "scheduled_end_tuesday", "Dienstag"),
-        ("scheduled_start_wednesday", "scheduled_end_wednesday", "Mittwoch"),
-        ("scheduled_start_thursday", "scheduled_end_thursday", "Donnerstag"),
-        ("scheduled_start_friday", "scheduled_end_friday", "Freitag"),
-    ]
-
     @model_validator(mode='after')
     def check_work_day_order(self):
-        if self.first_work_day and self.last_work_day:
-            if self.first_work_day >= self.last_work_day:
-                raise ValueError("Erster Arbeitstag muss vor dem letzten Arbeitstag liegen")
-        for start_field, end_field, label in self._SCHEDULED_WINDOW_PAIRS:
-            s = getattr(self, start_field, None)
-            e = getattr(self, end_field, None)
-            if s is not None and e is not None and s >= e:
-                raise ValueError(
-                    f"Soll-Beginn muss vor Soll-Ende liegen ({label})"
-                )
-        return self
+        return validate_employment_and_window_order(self)  # #219: shared
 
 
 class UserCreate(UserBase):
@@ -133,27 +116,9 @@ class UserUpdate(BaseModel):
     scheduled_start_friday: Optional[time] = None
     scheduled_end_friday: Optional[time] = None
 
-    _SCHEDULED_WINDOW_PAIRS = [
-        ("scheduled_start_monday", "scheduled_end_monday", "Montag"),
-        ("scheduled_start_tuesday", "scheduled_end_tuesday", "Dienstag"),
-        ("scheduled_start_wednesday", "scheduled_end_wednesday", "Mittwoch"),
-        ("scheduled_start_thursday", "scheduled_end_thursday", "Donnerstag"),
-        ("scheduled_start_friday", "scheduled_end_friday", "Freitag"),
-    ]
-
     @model_validator(mode='after')
     def check_work_day_order(self):
-        if self.first_work_day and self.last_work_day:
-            if self.first_work_day >= self.last_work_day:
-                raise ValueError("Erster Arbeitstag muss vor dem letzten Arbeitstag liegen")
-        for start_field, end_field, label in self._SCHEDULED_WINDOW_PAIRS:
-            s = getattr(self, start_field, None)
-            e = getattr(self, end_field, None)
-            if s is not None and e is not None and s >= e:
-                raise ValueError(
-                    f"Soll-Beginn muss vor Soll-Ende liegen ({label})"
-                )
-        return self
+        return validate_employment_and_window_order(self)  # #219: shared
 
 
 class UserResponse(UserBase):

--- a/backend/app/schemas/vacation_request.py
+++ b/backend/app/schemas/vacation_request.py
@@ -4,6 +4,11 @@ from datetime import date as _date_type
 from typing import Optional, Literal
 import uuid
 
+from app.schemas.validators import (
+    validate_half_day_single_day,
+    validate_vr_absence_type,
+)
+
 
 class VacationRequestCreate(BaseModel):
     date: date
@@ -16,10 +21,7 @@ class VacationRequestCreate(BaseModel):
     @field_validator('absence_type')
     @classmethod
     def validate_absence_type(cls, v):
-        allowed = {"vacation", "training", "overtime", "other"}
-        if v not in allowed:
-            raise ValueError(f'absence_type muss einer von {allowed} sein')
-        return v
+        return validate_vr_absence_type(v, allow_none=False)  # #219: shared
 
     @field_validator('end_date')
     @classmethod
@@ -31,14 +33,7 @@ class VacationRequestCreate(BaseModel):
     @field_validator('half_day')
     @classmethod
     def half_day_single_day(cls, v, info):
-        # Halbe Tage sind ein Einzeltag-Konzept — ein Zeitraum mit half_day=True
-        # würde jeden Tag des Bereichs halbieren (überraschend, inkonsistent zur UI).
-        if v:
-            start = info.data.get('date')
-            end = info.data.get('end_date')
-            if end is not None and start is not None and end != start:
-                raise ValueError('Halbe Tage sind nur für Einzeltage möglich')
-        return v
+        return validate_half_day_single_day(v, info)  # #219: shared
 
 
 class VacationRequestUpdate(BaseModel):
@@ -64,12 +59,7 @@ class VacationRequestUpdate(BaseModel):
     @field_validator('absence_type')
     @classmethod
     def validate_absence_type(cls, v):
-        if v is None:
-            return v
-        allowed = {"vacation", "training", "overtime", "other"}
-        if v not in allowed:
-            raise ValueError(f'absence_type muss einer von {allowed} sein')
-        return v
+        return validate_vr_absence_type(v, allow_none=True)  # #219: shared
 
 
 class VacationRequestReview(BaseModel):

--- a/backend/app/schemas/validators.py
+++ b/backend/app/schemas/validators.py
@@ -1,0 +1,58 @@
+"""#219: Shared Pydantic-Validator-Logik.
+
+Diese Helfer bündeln Validierungs-Logik, die zuvor mehrfach byte-identisch in
+verschiedenen Schemas dupliziert war (half_day-Einzeltag, Soll-Fenster-Reihenfolge,
+absence_type-Set). Die Schemas behalten ihre dünnen ``@field_validator``/
+``@model_validator``-Wrapper und rufen nur noch die gemeinsame Logik auf — so bleibt
+das Verhalten exakt gleich, aber es gibt nur noch EINE Quelle der Wahrheit.
+"""
+from typing import Any
+
+# Erlaubte absence_type-Werte für Urlaubs-/Abwesenheitsanträge.
+VACATION_REQUEST_ABSENCE_TYPES = {"vacation", "training", "overtime", "other"}
+
+# (start_field, end_field, Label) je Wochentag für die Soll-Arbeitszeit-Fenster (#201).
+SCHEDULED_WINDOW_PAIRS = [
+    ("scheduled_start_monday", "scheduled_end_monday", "Montag"),
+    ("scheduled_start_tuesday", "scheduled_end_tuesday", "Dienstag"),
+    ("scheduled_start_wednesday", "scheduled_end_wednesday", "Mittwoch"),
+    ("scheduled_start_thursday", "scheduled_end_thursday", "Donnerstag"),
+    ("scheduled_start_friday", "scheduled_end_friday", "Freitag"),
+]
+
+
+def validate_half_day_single_day(v: bool, info: Any) -> bool:
+    """half_day ist ein Einzeltag-Konzept — ein Zeitraum mit half_day=True würde
+    jeden Tag des Bereichs halbieren (überraschend, inkonsistent zur UI)."""
+    if v:
+        start = info.data.get("date")
+        end = info.data.get("end_date")
+        if end is not None and start is not None and end != start:
+            raise ValueError("Halbe Tage sind nur für Einzeltage möglich")
+    return v
+
+
+def validate_vr_absence_type(v, *, allow_none: bool):
+    """absence_type gegen die erlaubte Menge prüfen.
+
+    ``allow_none=True`` (Update-Pfad) lässt ``None`` durch (Feld nicht gesetzt);
+    ``allow_none=False`` (Create-Pfad) lehnt ``None`` ab wie zuvor.
+    """
+    if v is None and allow_none:
+        return v
+    if v not in VACATION_REQUEST_ABSENCE_TYPES:
+        raise ValueError(f"absence_type muss einer von {VACATION_REQUEST_ABSENCE_TYPES} sein")
+    return v
+
+
+def validate_employment_and_window_order(model: Any) -> Any:
+    """Erster < letzter Arbeitstag, und je Wochentag Soll-Beginn < Soll-Ende (#193/#201)."""
+    if model.first_work_day and model.last_work_day:
+        if model.first_work_day >= model.last_work_day:
+            raise ValueError("Erster Arbeitstag muss vor dem letzten Arbeitstag liegen")
+    for start_field, end_field, label in SCHEDULED_WINDOW_PAIRS:
+        s = getattr(model, start_field, None)
+        e = getattr(model, end_field, None)
+        if s is not None and e is not None and s >= e:
+            raise ValueError(f"Soll-Beginn muss vor Soll-Ende liegen ({label})")
+    return model

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -24,6 +24,16 @@ from sqlalchemy import extract
 _FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
 
 
+def _group_by_date(rows) -> dict:
+    """#219: group TimeEntry/Absence rows into {date: [rows…]} (Reihenfolge erhalten).
+    Pro Tag eine LISTE — ein Tag kann mehrere Einträge/Abwesenheiten tragen
+    (I-1: z. B. halber Tag Urlaub + halber Tag Sonstiges)."""
+    by_date: dict = {}
+    for r in rows:
+        by_date.setdefault(r.date, []).append(r)
+    return by_date
+
+
 def neutralize_spreadsheet_formula(value):
     """Return ``value`` with a leading apostrophe if it could be parsed as a
     spreadsheet formula. Non-strings and safe strings are returned unchanged."""
@@ -141,9 +151,7 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
         TimeEntry.user_id == user.id,
         date_in_month(TimeEntry.date, year, month)
     ).order_by(TimeEntry.start_time).all()
-    entries_by_date: dict = {}
-    for entry in time_entries:
-        entries_by_date.setdefault(entry.date, []).append(entry)
+    entries_by_date = _group_by_date(time_entries)  # #219: shared
 
     # Get all absences for the month.
     # I-1: ein Tag kann MEHRERE Absences tragen (Unique-Constraint ist je
@@ -154,9 +162,7 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
         Absence.user_id == user.id,
         date_in_month(Absence.date, year, month)
     ).all()
-    absences_by_date: dict = {}
-    for absence in absences:
-        absences_by_date.setdefault(absence.date, []).append(absence)
+    absences_by_date = _group_by_date(absences)  # #219: shared
 
     # Get public holidays (tenant-scoped: each tenant may run a different
     # state-holiday set, so a global query would leak or miss holidays).
@@ -679,9 +685,7 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
         TimeEntry.user_id == user.id,
         date_in_year(TimeEntry.date, year)
     ).order_by(TimeEntry.start_time).all()
-    entries_by_date: dict = {}
-    for entry in time_entries:
-        entries_by_date.setdefault(entry.date, []).append(entry)
+    entries_by_date = _group_by_date(time_entries)  # #219: shared
 
     # Get all absences for the year.
     # I-1: pro Tag eine LISTE (mehrere Absences je Tag möglich, s. _create_employee_sheet).
@@ -689,9 +693,7 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
         Absence.user_id == user.id,
         date_in_year(Absence.date, year)
     ).all()
-    absences_by_date: dict = {}
-    for absence in absences:
-        absences_by_date.setdefault(absence.date, []).append(absence)
+    absences_by_date = _group_by_date(absences)  # #219: shared
 
     # Get public holidays for the year (tenant-scoped; see generate_monthly_report).
     holidays = db.query(PublicHoliday).filter(

--- a/frontend/src/components/MonthlyJournal.tsx
+++ b/frontend/src/components/MonthlyJournal.tsx
@@ -4,7 +4,7 @@ import { de } from 'date-fns/locale';
 import { Pencil, Plus, Trash2, Check, X } from 'lucide-react';
 import apiClient from '../api/client';
 import { getErrorMessage } from '../utils/errorMessage';
-import { formatHoursHMText } from '../utils/formatters';
+import { formatHoursHMText, parseHours } from '../utils/formatters';
 import { submitWithBreakWaiver } from '../utils/breakWaiverRetry';
 import { useToast } from '../contexts/ToastContext';
 import { useConfirm } from '../hooks/useConfirm';
@@ -211,7 +211,7 @@ export default function MonthlyJournal({ userId, isAdminView }: MonthlyJournalPr
           user_id: userId,
           date: dateStr,
           type: editState.entryType,
-          hours: parseFloat(editState.absenceHours) || 0,
+          hours: parseHours(editState.absenceHours),
           keep_time_entries: hasExistingEntries,
         });
       }
@@ -274,7 +274,7 @@ export default function MonthlyJournal({ userId, isAdminView }: MonthlyJournalPr
           user_id: userId,
           date: day.date,
           type: editState.entryType,
-          hours: parseFloat(editState.absenceHours) || 0,
+          hours: parseHours(editState.absenceHours),
           keep_time_entries: remainingEntries.length > 0,
         });
       }
@@ -359,7 +359,7 @@ export default function MonthlyJournal({ userId, isAdminView }: MonthlyJournalPr
           reason: submitReason.trim(),
           proposed_date: day.date,
           proposed_absence_type: editState.entryType,
-          proposed_absence_hours: parseFloat(editState.absenceHours) || 0,
+          proposed_absence_hours: parseHours(editState.absenceHours),
         };
       }
 

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -9,7 +9,7 @@ import { useConfirm } from '../../hooks/useConfirm';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import MonthSelector from '../../components/MonthSelector';
 import { getErrorMessage } from '../../utils/errorMessage';
-import { formatHoursHM } from '../../utils/formatters';
+import { formatHoursHM, parseHours } from '../../utils/formatters';
 import { submitWithBreakWaiver } from '../../utils/breakWaiverRetry';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import UpdateBanner from '../../components/UpdateBanner';
@@ -1253,7 +1253,7 @@ export default function AdminDashboard() {
                               min="0"
                               max="24"
                               value={entryForm.absence_hours}
-                              onChange={(e) => setEntryForm({ ...entryForm, absence_hours: parseFloat(e.target.value) || 0 })}
+                              onChange={(e) => setEntryForm({ ...entryForm, absence_hours: parseHours(e.target.value) })}
                               placeholder="Stunden"
                               aria-label="Stunden"
                               className="px-2 py-1 border border-gray-300 rounded-sm text-sm"


### PR DESCRIPTION
## #219 — Code Duplication: Audit + careful consolidation

Multi-Agent-Audit über Backend + Frontend (28 Kandidaten → 10 do / 9 defer / 9 skip), triagiert auf real/sicher/wertvoll und gegen die intentional-sync-Muster (SSL-Generatoren, Lizenz-Keys, DocViewer). Die sicheren, gut getesteten Konsolidierungen umgesetzt:

- **Enrichment vereinheitlicht** (größte Dup ~65 LOC + N+1): VR-Enricher nach `admin_helpers` (neben CR/Audit), `admin_vacations` + `vacation_requests` + `change_requests` nutzen die EINE Quelle. Per-Item-N+1 in der MA-Urlaubsliste (3 Queries × bis 500) durch Batch ersetzt. **F-026-Tenant-Scoping exakt erhalten.**
- **Pydantic-Validatoren** → neues `app/schemas/validators.py`: half_day-Einzeltag, Soll-Fenster-Reihenfolge (`_SCHEDULED_WINDOW_PAIRS`), absence_type-Set (`allow_none`-Param für exakte Create/Update-Semantik).
- **`_filtered_user_list_query`** für `list_users`+`users_overview` (#194-Kontrakt, Pagination unverändert).
- **`_group_by_date`** in export_service (4× setdefault-Gruppieren ersetzt).
- **Frontend**: `parseFloat||0` → `parseHours()` (F-048 NaN/Infinity-Guard) ×4.

**Bewusst NICHT angefasst** (intentional / zu riskant / schon erledigt): SSL-Cert-Generatoren, Lizenz-Keys, DocViewer-Handbuch, statusConfig, die per-Tag-Berechnungsschleifen (#146, hohes Regressionsrisiko → DEFER).

### Verifiziert
- Focused gate **134 passed** (inkl. F-026 cross-tenant)
- **Postgres** RLS + cross-tenant **38 passed**
- Volle Backend-Suite **982 passed / 49 skipped**
- Frontend **tsc** + **116 vitest** grün

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)