### PR TITLE
fix(#290): Betriebsferien-Speichern löscht keine Arbeitszeiten mehr + Auto-Enrollment neuer MA

### DIFF
--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -39,6 +39,42 @@ def _get_user_in_tenant(db: Session, user_id: str, current_user: User) -> User:
     return user
 
 
+def _enroll_user_in_open_closures(db: Session, user: User, current_user: User) -> None:
+    """#290: fold a newly participating employee into CURRENT + FUTURE company
+    closures so admins never have to re-save a closure (the re-save was the
+    documented #290 workaround and silently deleted logged work).
+
+    - Only closures whose end_date is today or later (PAST closures are NOT
+      backfilled — an employee hired after a closure ended must not get
+      retroactive absences, consistent with #193 _within_employment_window).
+    - Only covered workdays on/after the employee's first_work_day (if set).
+    - delete_time_entries=False: never destroys logged work on those days.
+    Best-effort: a failure here must not abort user creation (the closure
+    enrolment can be repaired by re-saving the closure).
+    """
+    if not (user.receives_company_closures and user.is_active):
+        return
+    from app.models import CompanyClosure
+    from app.routers.company_closures import _get_holidays_for_range, _get_workdays, _create_closure_absences
+
+    today = today_local()
+    closures = db.query(CompanyClosure).filter(
+        CompanyClosure.tenant_id == current_user.tenant_id,
+        CompanyClosure.end_date >= today,
+    ).all()
+    for closure in closures:
+        holidays = _get_holidays_for_range(
+            db, closure.start_date, closure.end_date, current_user.tenant_id
+        )
+        workdays = _get_workdays(closure.start_date, closure.end_date, holidays)
+        if user.first_work_day:
+            workdays = [d for d in workdays if d >= user.first_work_day]
+        if workdays:
+            _create_closure_absences(
+                db, closure, workdays, [user], current_user, delete_time_entries=False
+            )
+
+
 def _tenant_has_other_active_admin(db: Session, current_user: User) -> bool:
     """Audit A01 (4-Augen-Prinzip): does the caller's tenant have ANOTHER
     active admin besides ``current_user``?
@@ -426,6 +462,11 @@ def create_user(user_data: UserCreate, db: Session = Depends(get_db), current_us
     db.commit()
     db.refresh(new_user)
 
+    # #290: enrol the new participant into existing current/future closures now,
+    # so the admin never needs the data-destroying closure re-save workaround.
+    _enroll_user_in_open_closures(db, new_user, current_user)
+    db.commit()
+
     return UserCreateResponse(
         user=UserResponse.model_validate(new_user)
     )
@@ -458,6 +499,11 @@ def update_user(
 
     # VULN-010: invalidate existing JWTs when role is changed
     role_changed = 'role' in update_data and update_data['role'] != user.role
+    # #290: did this update turn closure participation ON? Then enrol below.
+    closures_enabled = (
+        update_data.get('receives_company_closures') is True
+        and not user.receives_company_closures
+    )
 
     for field, value in update_data.items():
         setattr(user, field, value)
@@ -467,6 +513,13 @@ def update_user(
 
     db.commit()
     db.refresh(user)
+
+    # #290: a user newly toggled into Betriebsferien-participation is enrolled
+    # into current/future closures here (never deletes logged work), so no
+    # closure re-save is needed.
+    if closures_enabled:
+        _enroll_user_in_open_closures(db, user, current_user)
+        db.commit()
     return user
 
 

--- a/backend/app/routers/company_closures.py
+++ b/backend/app/routers/company_closures.py
@@ -76,6 +76,7 @@ def _create_closure_absences(
     workdays: List[date],
     employees: List[User],
     current_user: User,
+    delete_time_entries: bool = True,
 ) -> int:
     """Create the closure absences linked to ``closure`` for the given workdays.
 
@@ -133,15 +134,27 @@ def _create_closure_absences(
             if (employee.id, workday) in existing_keys:
                 continue
 
+            day_entries = te_by_key.get((employee.id, workday), [])
+
+            # #290: On a re-save / backfill (delete_time_entries=False) we must
+            # NEVER silently destroy a participant's logged work. If the day
+            # already holds a real time entry, the employee demonstrably worked
+            # despite the closure → leave it untouched and do NOT book a closure
+            # absence over it (work wins; no double-counting). Only the initial
+            # create path (default True) replaces pre-existing entries.
+            if day_entries and not delete_time_entries:
+                continue
+
             # Delete existing time entries on this day with audit log
-            for entry in te_by_key.get((employee.id, workday), []):
-                _create_audit_log(
-                    db, entry.id, employee.id, current_user.id,
-                    action="delete", old_entry=entry,
-                    source="company_closure",
-                    tenant_id=current_user.tenant_id,
-                )
-                db.delete(entry)
+            if delete_time_entries:
+                for entry in day_entries:
+                    _create_audit_log(
+                        db, entry.id, employee.id, current_user.id,
+                        action="delete", old_entry=entry,
+                        source="company_closure",
+                        tenant_id=current_user.tenant_id,
+                    )
+                    db.delete(entry)
 
             # F-027: Use the authoritative weekly_hours lookup so that
             # a closure spanning a WorkingHoursChange credits the right
@@ -380,7 +393,13 @@ def update_closure(
         User.receives_company_closures == True,
         User.tenant_id == current_user.tenant_id,
     ).all()
-    _create_closure_absences(db, closure, workdays, employees, current_user)
+    # #290: re-save must NOT delete logged work. delete_time_entries=False →
+    # days where a participant already logged real time are left intact (no
+    # closure-absence booked over them). New participants still get absences on
+    # their non-worked covered days. Only the initial create_closure clears entries.
+    _create_closure_absences(
+        db, closure, workdays, employees, current_user, delete_time_entries=False
+    )
 
     db.commit()
     db.refresh(closure)

--- a/backend/tests/test_company_closure_edit.py
+++ b/backend/tests/test_company_closure_edit.py
@@ -418,3 +418,117 @@ class TestTenantIsolation:
         assert db.query(CompanyClosure).filter(
             CompanyClosure.id == uuid.UUID(closure["id"]),
         ).count() == 1
+
+
+# ---------------------------------------------------------------------------
+# #290: re-saving a closure must NEVER delete a participant's logged work
+# ---------------------------------------------------------------------------
+
+class TestResavePreservesTimeEntries:
+    def test_resave_does_not_delete_logged_time_entry(self, db, admin, admin_client):
+        """Regression #290: an employee who logged real work on a covered day
+        (because they had no closure-absence — e.g. onboarded after creation)
+        must keep that TimeEntry when the closure is re-saved. Re-save was the
+        documented #290 workaround and silently destroyed worked time."""
+        from datetime import time
+        from app.models import TimeEntry, TimeEntryAuditLog
+
+        emp1 = _make_user(db, DEFAULT_TENANT_ID, "emp_keep_a")
+        closure = _create_closure(admin_client, "Betriebsferien", MON, WED)
+
+        # A second employee, created AFTER the closure -> no closure-absence for them.
+        emp2 = _make_user(db, DEFAULT_TENANT_ID, "emp_keep_b")
+        te = TimeEntry(
+            user_id=emp2.id, tenant_id=DEFAULT_TENANT_ID, date=TUE,
+            start_time=time(8, 0), end_time=time(16, 0), break_minutes=30,
+        )
+        db.add(te)
+        db.commit()
+        te_id = te.id
+
+        # Re-save the UNCHANGED closure (the #290 "Betroffene aktualisieren" workaround).
+        resp = admin_client.put(f"/api/company-closures/{closure['id']}", json={
+            "name": "Betriebsferien",
+            "start_date": MON.isoformat(),
+            "end_date": WED.isoformat(),
+            "counts_as_vacation": True,
+        })
+        assert resp.status_code == 200, resp.text
+
+        survived = db.query(TimeEntry).filter(TimeEntry.id == te_id).first()
+        assert survived is not None, "re-save deleted a real time entry (#290 data loss!)"
+        # And no closure-absence was booked over the worked day (work wins).
+        booked = db.query(Absence).filter(
+            Absence.user_id == emp2.id, Absence.date == TUE,
+            Absence.closure_id == uuid.UUID(closure["id"]),
+        ).count()
+        assert booked == 0, "closure-absence booked over a logged work day"
+
+    def test_create_still_clears_time_entries(self, db, admin, admin_client):
+        """CREATE keeps its original behaviour: a closure replaces pre-existing
+        time entries on covered days (deliberate first-time action)."""
+        from datetime import time
+        from app.models import TimeEntry
+
+        emp = _make_user(db, DEFAULT_TENANT_ID, "emp_create_clear")
+        te = TimeEntry(
+            user_id=emp.id, tenant_id=DEFAULT_TENANT_ID, date=TUE,
+            start_time=time(8, 0), end_time=time(16, 0), break_minutes=30,
+        )
+        db.add(te)
+        db.commit()
+        te_id = te.id
+
+        _create_closure(admin_client, "Neue Ferien", MON, WED)
+
+        # On create, the worked entry is replaced by the closure absence (legacy intent).
+        assert db.query(TimeEntry).filter(TimeEntry.id == te_id).first() is None
+
+
+# ---------------------------------------------------------------------------
+# #290: a newly created participating employee is auto-enrolled into existing
+# current/future closures (no destructive re-save needed); PAST closures are not.
+# ---------------------------------------------------------------------------
+
+class TestNewUserEnrolledInOpenClosures:
+    def test_enroll_current_future_not_past(self, db, admin):
+        from datetime import timedelta
+        from app.models import CompanyClosure
+        from app.routers.admin_users import _enroll_user_in_open_closures
+
+        today = date.today()
+        fut = CompanyClosure(
+            name="Sommer", start_date=today + timedelta(days=7),
+            end_date=today + timedelta(days=13), counts_as_vacation=True,
+            created_by=admin.id, tenant_id=DEFAULT_TENANT_ID,
+        )
+        past = CompanyClosure(
+            name="Winter alt", start_date=today - timedelta(days=30),
+            end_date=today - timedelta(days=24), counts_as_vacation=True,
+            created_by=admin.id, tenant_id=DEFAULT_TENANT_ID,
+        )
+        db.add_all([fut, past])
+        db.commit()
+
+        emp = User(
+            username="emp_enroll", email="emp_enroll@example.com",
+            password_hash="x", first_name="E", last_name="E",
+            role=UserRole.EMPLOYEE, weekly_hours=40.0, vacation_days=30,
+            work_days_per_week=5, is_active=True,
+            receives_company_closures=True, tenant_id=DEFAULT_TENANT_ID,
+        )
+        db.add(emp)
+        db.commit()
+        db.refresh(emp)
+
+        _enroll_user_in_open_closures(db, emp, admin)
+        db.commit()
+
+        fut_abs = db.query(Absence).filter(
+            Absence.user_id == emp.id, Absence.closure_id == fut.id,
+        ).count()
+        past_abs = db.query(Absence).filter(
+            Absence.user_id == emp.id, Absence.closure_id == past.id,
+        ).count()
+        assert fut_abs > 0, "#290: new employee not enrolled in current/future closure"
+        assert past_abs == 0, "#290: new employee wrongly backfilled into a PAST closure"

--- a/docs/recover-closure-deleted-entries.md
+++ b/docs/recover-closure-deleted-entries.md
@@ -1,0 +1,77 @@
+# Recovery: durch Betriebsferien gelöschte Zeiteinträge wiederherstellen (#290)
+
+Bis zum Fix in #290 hat das **Anlegen / Neu-Speichern von Betriebsferien** auf den
+abgedeckten Tagen vorhandene **Zeiteinträge gelöscht** (`company_closures.
+_create_closure_absences`). Jede Löschung wurde aber im **Audit-Log** protokolliert
+(`source='company_closure'`, `action='delete'`) **mit den alten Werten**
+(`old_date` / `old_start_time` / `old_end_time` / `old_break_minutes` / `old_note`)
+— die Einträge sind daher **wiederherstellbar**.
+
+> Hinweis: `raw_start_time` / `raw_end_time` (§16-Rohstempel) liegen nicht im
+> Audit-Log und werden nicht rekonstruiert — nur die regulären Zeiten.
+
+## Ausführen
+
+**Docker:**
+```bash
+docker compose exec -T db psql -U praxiszeit -d praxiszeit \
+  -v tenant="'00000000-0000-0000-0000-000000000001'"   # Tenant-ID anpassen
+```
+**Nativ:** `bin/postgresql/bin/psql` über den Unix-Socket (siehe `INSTALL-NATIVE.md`),
+gleiche `-v tenant=...`-Variable.
+
+Erst die **PREVIEW** prüfen. Stimmt die Liste, den **RESTORE**-Block ausführen.
+Idempotent — bereits vorhandene Einträge werden nicht doppelt angelegt.
+
+## PREVIEW — was würde wiederhergestellt?
+
+```sql
+WITH candidates AS (
+    SELECT DISTINCT ON (a.user_id, a.old_date, a.old_start_time)
+           a.user_id, a.tenant_id, a.old_date, a.old_start_time,
+           a.old_end_time, a.old_break_minutes, a.old_note, a.created_at AS deleted_at
+    FROM time_entry_audit_logs a
+    WHERE a.source = 'company_closure' AND a.action = 'delete'
+      AND a.tenant_id = :tenant::uuid
+      AND a.old_date IS NOT NULL
+    ORDER BY a.user_id, a.old_date, a.old_start_time, a.created_at DESC
+)
+SELECT c.user_id, c.old_date, c.old_start_time, c.old_end_time,
+       c.old_break_minutes, c.deleted_at
+FROM candidates c
+WHERE NOT EXISTS (
+    SELECT 1 FROM time_entries t
+    WHERE t.user_id = c.user_id AND t.date = c.old_date
+      AND t.start_time IS NOT DISTINCT FROM c.old_start_time
+)
+ORDER BY c.user_id, c.old_date;
+```
+
+## RESTORE — Einträge wieder anlegen
+
+```sql
+BEGIN;
+WITH candidates AS (
+    SELECT DISTINCT ON (a.user_id, a.old_date, a.old_start_time)
+           a.user_id, a.tenant_id, a.old_date, a.old_start_time,
+           a.old_end_time, a.old_break_minutes, a.old_note
+    FROM time_entry_audit_logs a
+    WHERE a.source = 'company_closure' AND a.action = 'delete'
+      AND a.tenant_id = :tenant::uuid AND a.old_date IS NOT NULL
+    ORDER BY a.user_id, a.old_date, a.old_start_time, a.created_at DESC
+)
+INSERT INTO time_entries (id, user_id, tenant_id, date, start_time, end_time, break_minutes, note)
+SELECT gen_random_uuid(), c.user_id, c.tenant_id, c.old_date, c.old_start_time,
+       c.old_end_time, COALESCE(c.old_break_minutes, 0), c.old_note
+FROM candidates c
+WHERE NOT EXISTS (
+    SELECT 1 FROM time_entries t
+    WHERE t.user_id = c.user_id AND t.date = c.old_date
+      AND t.start_time IS NOT DISTINCT FROM c.old_start_time
+);
+COMMIT;
+```
+
+Pro `(user, Tag, Startzeit)` wird nur die **zuletzt** gelöschte Version
+wiederhergestellt (mehrfaches Neu-Speichern erzeugte mehrere `delete`-Logs), und nur,
+wenn aktuell **kein** passender Eintrag existiert.


### PR DESCRIPTION
## #290 — Datenverlust beim Betriebsferien-Speichern

### Root cause (reproduziert)
`company_closures._create_closure_absences` **löscht** auf abgedeckten Tagen vorhandene `TimeEntry`-Zeilen. `update_closure` (Neu-Speichern) rief das über den **ganzen** Zeitraum auf → das Neu-Speichern (der dokumentierte #290-Workaround, um neue MA in die „Betroffenen" zu holen) **zerstörte still die bereits erfassten Arbeitszeiten** der betroffenen MA. #282 (1.10.2) hat die „Betroffene"-Zahl auf *pro Closure* umgestellt → genau das lockt Admins ins destruktive Neu-Speichern („erschien mit 1.10.2").

Ein Multi-Agent-Trace+Verify-Workflow hat es mit einem TestClient reproduziert (`TimeEntry survived = 0` nach Re-Save).

### Fix
- **`_create_closure_absences(delete_time_entries=True)`** — `update_closure` ruft mit `False`: Tage mit echtem Zeiteintrag werden **nicht** gelöscht, es wird keine Betriebsferien-Absence darüber gebucht (*Arbeit gewinnt*). `create_closure` behält das bisherige Verhalten (löscht beim Ersteinrichten).
- **Auto-Enrollment (#290-Kern):** neue/umgestellte teilnehmende MA werden in `create_user`/`update_user` automatisch in **current+future** Betriebsferien aufgenommen (`_enroll_user_in_open_closures`, `delete_time_entries=False`; PAST-Closures ausgeschlossen, #193). Das destruktive Neu-Speichern ist damit **gar nicht mehr nötig**.

### Recovery für bereits betroffene Kunden
Die Löschungen sind **wiederherstellbar** (Audit-Log `source='company_closure'`, `action='delete'`, `old_*` erhalten): `docs/recover-closure-deleted-entries.md` (idempotente Preview+Restore-SQL).

### Verifiziert
Neue Regressionstests (Re-Save erhält Zeiteintrag · create löscht weiterhin · Enrollment current/future nicht past) + **985 passed / 49 skipped** + focused 80 passed.

### Offen / refuted
- **„alle Betriebsferien-Records weg"** ist aus dem Code **nicht** reproduzierbar (Re-Save löscht nie Closures; nur explizites DELETE). Wartet auf die Version/Backup-Antwort des Kunden (#290-Kommentare werden überwacht).
- **first_work_day=2026-06-01:** kein Code-Pfad; Restore nur per CLI erreichbar (nicht App/Job).
- **Separater Vektor (Follow-up, nicht hier):** `review_vacation_request`/`create_absence` überschreiben TimeEntries im genehmigten Zeitraum (bounded, erklärt die Reports nicht) → max-span-Guard empfohlen.

Refs #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)