### PR TITLE
fix: Service-/DB-Review — Security-Gate, F-026-Lücken, Robustheit (sichere Welle)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -499,7 +499,12 @@ app.include_router(feedback.router)
 app.include_router(public_signup.router)
 app.include_router(billing.router)
 app.include_router(billing.webhook_router)
-app.include_router(admin_backups.router)  # #213 DB-Backup-Verwaltung
+# #213 DB-Backup-Verwaltung — NUR On-Prem einbinden. Im SaaS-Modus darf ein
+# Mandant nicht per API den (nicht tenant-scoped) DB-Server sichern/herunterladen
+# (Daten-Exfiltration über Tenant-Grenzen). Hart gaten statt nur per Doku-Kommentar.
+from app.core.deployment import is_onprem as _is_onprem
+if _is_onprem():
+    app.include_router(admin_backups.router)
 
 
 @app.middleware("http")

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -345,10 +345,9 @@ def purge_user(
 @router.get("/users/{user_id}", response_model=UserResponse)
 def get_user(user_id: str, db: Session = Depends(get_db), current_user: User = Depends(require_admin)):
     """Get a specific user by ID (admin only)."""
-    user = _get_user_in_tenant(db, user_id, current_user)
-    if not user:
-        raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
-    return user
+    # _get_user_in_tenant raises 404 itself (never returns None) — the former
+    # `if not user` guard here was dead code; the tenant scope is already enforced.
+    return _get_user_in_tenant(db, user_id, current_user)
 
 
 @router.post("/users", response_model=UserCreateResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -39,6 +39,7 @@ def _get_missing_bookings_for_user(db: Session, user: User, tenant_id=None) -> L
     # 1) Open entries: end_time is NULL, date < today
     open_entries = db.query(TimeEntry).filter(
         TimeEntry.user_id == user.id,
+        TimeEntry.tenant_id == tenant_id,  # F-026
         TimeEntry.end_time.is_(None),
         TimeEntry.date < today,
     ).order_by(TimeEntry.date).all()
@@ -64,6 +65,7 @@ def _get_missing_bookings_for_user(db: Session, user: User, tenant_id=None) -> L
     entry_dates = set(
         row[0] for row in db.query(TimeEntry.date).filter(
             TimeEntry.user_id == user.id,
+            TimeEntry.tenant_id == tenant_id,  # F-026
             TimeEntry.date >= start_date,
             TimeEntry.date <= end_date,
         ).all()
@@ -73,6 +75,7 @@ def _get_missing_bookings_for_user(db: Session, user: User, tenant_id=None) -> L
     absence_dates = set()
     absences = db.query(Absence).filter(
         Absence.user_id == user.id,
+        Absence.tenant_id == tenant_id,  # F-026
         Absence.date >= start_date,
         Absence.date <= end_date,
     ).all()

--- a/backend/app/routers/vacation_requests.py
+++ b/backend/app/routers/vacation_requests.py
@@ -242,6 +242,14 @@ def create_vacation_request(
             status_code=400,
             detail="Enddatum muss nach dem Startdatum liegen",
         )
+    # Bound the range: an approved request books an absence per workday AND
+    # overwrites time entries on those days — an unbounded span is a data-loss
+    # amplifier and never a legitimate single request.
+    if (end_date - start_date).days > 366:
+        raise HTTPException(
+            status_code=400,
+            detail="Der Zeitraum darf maximal ein Jahr umfassen",
+        )
 
     # 2. first_work_day / last_work_day (parity with create_absence)
     if current_user.first_work_day and start_date < current_user.first_work_day:

--- a/backend/app/services/error_log_service.py
+++ b/backend/app/services/error_log_service.py
@@ -311,7 +311,14 @@ class DBErrorHandler(logging.Handler):
                 traceback_str=tb,
             )
         except Exception:
-            pass  # Never let logging break the application
+            # Never let logging break the application — but don't go fully silent.
+            # Write to stderr (NOT via the logging module → no recursion into this
+            # handler) so a broken DB-logger is still visible in container logs.
+            try:
+                import sys
+                sys.stderr.write("DBErrorHandler.emit failed:\n" + traceback.format_exc())
+            except Exception:
+                pass
         finally:
             try:
                 db.close()

--- a/backend/app/services/lifecycle_service.py
+++ b/backend/app/services/lifecycle_service.py
@@ -25,6 +25,7 @@ All mutations commit the DB session themselves.
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
@@ -44,6 +45,8 @@ from app.models import (
     VacationRequest,
 )
 from app.models.tenant import Tenant
+
+logger = logging.getLogger(__name__)
 
 
 SUSPEND_GRACE_DAYS = 7
@@ -95,7 +98,8 @@ def request_deletion(db: Session, tenant: Tenant, by_user: User) -> datetime:
         from app.services.alerting import alert_deletion_requested
         alert_deletion_requested(tenant.name)
     except Exception:  # noqa: BLE001
-        pass
+        # Best-effort alert after the commit — log instead of swallowing silently.
+        logger.warning("alert_deletion_requested failed", exc_info=True)
     return now + timedelta(days=DELETE_GRACE_DAYS)
 
 

--- a/backend/app/services/stripe_service.py
+++ b/backend/app/services/stripe_service.py
@@ -319,7 +319,9 @@ def handle_event(db: Session, event) -> dict:
                 from app.services.alerting import alert_plan_upgrade
                 alert_plan_upgrade(tenant.name, plan)
             except Exception:  # noqa: BLE001
-                pass
+                # Best-effort alert — must not break webhook processing, but a
+                # silently swallowed failure left no trace. Log it (no PII).
+                logger.warning("alert_plan_upgrade failed", exc_info=True)
         action = "subscription_activated"
 
     elif etype == "customer.subscription.updated":


### PR DESCRIPTION
## Service-Interface- & DB-Review (Review-Auftrag) — Welle 1 (sichere Fixes)

6-Lane Multi-Agent-Review (deprecated libs · untested critical methods · DB-Funktionen · API-Interface · non-working/dead · robustness): **61 Findings, 20 serious, 16 confirmed**. Hier die **sicheren, hochwertigen** Fixes; riskante separat (s. u.).

### Umgesetzt
- 🔒 **Backup-Router nur On-Prem** (`main.py`): `admin_backups` ist nicht tenant-scoped → im SaaS-Modus Cross-Tenant-Exfiltration möglich. Jetzt hart per `is_onprem()` gegatet (vorher nur Doku-Kommentar). On-Prem-Default unverändert. *(high/security)*
- **F-026** explizite Tenant-Filter in `dashboard._get_missing_bookings_for_user` (3 Queries).
- **Robustheit:** still verschluckte Exceptions geloggt (`stripe_service`, `lifecycle_service` +Logger, `error_log_service` stderr-Fallback ohne Logging-Rekursion).
- **Datenverlust-Schranke:** Urlaubsantrag max. 1 Jahr (`vacation_requests` POST) — ein genehmigter Antrag überschreibt TimeEntries je Tag; unbegrenzter Span = Verstärker.
- **Cleanup:** toter `if not user`-Guard in `get_user` entfernt (`_get_user_in_tenant` wirft selbst 404).

### Verifiziert
focused gate **114 passed** (admin users · cross-tenant F-026 · vacation · backup-router · plan-enforcement) + volle Backend-Suite **982 passed / 49 skipped**.

### Bewusst NICHT hier (Begründung) — Follow-ups
- **Libs:** überwiegend „NO ACTION" (aktuell/sicher). `xlrd 1.2.0` bleibt — openpyxl kann **kein** `.xls` lesen, kein Drop-in (Migration = eigenes Projekt).
- **N+1 in Jahres-/Abwesenheits-Export** (`export_service`) — payroll-load-bearing → eigener Perf-PR (verwandt mit #204).
- **Transaktions-/Rollback-Umbau** in `admin_vacations` (Approval-Loop, precondition-rollback) + `anonymize_tenant`-RLS-Kontext (SaaS) → höheres Risiko, separat.
- **Logout 200→204** = API-Contract-Wechsel → separat.
- **Float/Decimal-Präzision** in Export-Tagesberechnung (medium) → separat mit Test.
- **Test-Coverage-Lücken** (purge_user, delete_working_hours_change, execute_import-Rollback, untracked vacation edge cases) → eigener Test-PR (Review lieferte konkrete Test-Specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)