### PR TITLE
chore(release): 1.10.4 — Phase-2-Review-Fixes + Release

### DIFF
--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.10.3"
+APP_VERSION = "1.10.4"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -1,5 +1,6 @@
 """Admin sub-router: User Management + Working Hours Changes."""
 
+import logging
 from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
 from sqlalchemy import func
@@ -16,6 +17,8 @@ from app.services import auth_service, calculation_service
 from app.core.license import check_employee_limit
 
 router = APIRouter(prefix="/api/admin", tags=["admin"], dependencies=[Depends(require_admin)])
+
+logger = logging.getLogger(__name__)
 
 
 def _get_user_in_tenant(db: Session, user_id: str, current_user: User) -> User:
@@ -57,22 +60,29 @@ def _enroll_user_in_open_closures(db: Session, user: User, current_user: User) -
     from app.models import CompanyClosure
     from app.routers.company_closures import _get_holidays_for_range, _get_workdays, _create_closure_absences
 
-    today = today_local()
-    closures = db.query(CompanyClosure).filter(
-        CompanyClosure.tenant_id == current_user.tenant_id,
-        CompanyClosure.end_date >= today,
-    ).all()
-    for closure in closures:
-        holidays = _get_holidays_for_range(
-            db, closure.start_date, closure.end_date, current_user.tenant_id
-        )
-        workdays = _get_workdays(closure.start_date, closure.end_date, holidays)
-        if user.first_work_day:
-            workdays = [d for d in workdays if d >= user.first_work_day]
-        if workdays:
-            _create_closure_absences(
-                db, closure, workdays, [user], current_user, delete_time_entries=False
+    # Honour the best-effort contract: a failure here must NOT abort the (already
+    # committed) user create/update. Roll back the partial enrolment and log;
+    # the gap can be repaired by re-saving the closure.
+    try:
+        today = today_local()
+        closures = db.query(CompanyClosure).filter(
+            CompanyClosure.tenant_id == current_user.tenant_id,  # F-026
+            CompanyClosure.end_date >= today,
+        ).all()
+        for closure in closures:
+            holidays = _get_holidays_for_range(
+                db, closure.start_date, closure.end_date, current_user.tenant_id
             )
+            workdays = _get_workdays(closure.start_date, closure.end_date, holidays)
+            if user.first_work_day:
+                workdays = [d for d in workdays if d >= user.first_work_day]
+            if workdays:
+                _create_closure_absences(
+                    db, closure, workdays, [user], current_user, delete_time_entries=False
+                )
+    except Exception:  # noqa: BLE001
+        db.rollback()
+        logger.warning("closure auto-enrollment failed for user %s", user.id, exc_info=True)
 
 
 def _filtered_user_list_query(db: Session, current_user: User, include_inactive: bool, include_hidden: bool):

--- a/backend/app/routers/vacation_requests.py
+++ b/backend/app/routers/vacation_requests.py
@@ -93,6 +93,10 @@ def apply_vacation_request_patch(
     effective_end = new_end_date if new_end_date else new_date
     if effective_end < new_date:
         raise HTTPException(status_code=400, detail="Enddatum muss nach dem Startdatum liegen")
+    # Same bound as the POST path: an approved request overwrites time entries
+    # per workday — a PATCH must not be able to silently extend to an unbounded span.
+    if (effective_end - new_date).days > 366:
+        raise HTTPException(status_code=400, detail="Der Zeitraum darf maximal ein Jahr umfassen")
     if target_user.first_work_day and new_date < target_user.first_work_day:
         raise HTTPException(status_code=400, detail="Datum liegt vor dem ersten Arbeitstag")
     if target_user.last_work_day and effective_end > target_user.last_work_day:

--- a/docs/handbuch/CHEATSHEET-ADMIN.md
+++ b/docs/handbuch/CHEATSHEET-ADMIN.md
@@ -111,7 +111,7 @@ Klick auf Pfeil → Detailansicht des Mitarbeiters
 **Abwesenheiten → Tab Betriebsferien → Neue Betriebsferien**
 - Bezeichnung + Von–Bis → Speichern
 - → Alle MA **mit „Nimmt an Betriebsferien teil"** (Standard) erhalten automatisch Abwesenheitseinträge (keine Urlaubstage!) – rollenunabhängig (auch Admins, die MA sind)
-- Nachträglich Berechtigte: Option setzen, dann Betriebsferien **einmal erneut speichern** → Einträge werden nachgetragen
+- Nachträglich Berechtigte: Option setzen → Einträge werden **automatisch** für laufende und künftige Betriebsferien nachgetragen (Neu-Speichern nicht nötig)
 - Löschen: Einträge werden bei allen MA automatisch entfernt
 
 ---

--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -432,7 +432,7 @@ Navigieren Sie zu **Abwesenheiten → Tab „Betriebsferien"** und klicken Sie a
 - Urlaubstage werden **nicht** verbraucht
 - Wochenenden und gesetzliche Feiertage werden übersprungen
 
-> **Tipp – nachträglich Berechtigte ergänzen:** Aktivieren Sie die Option bei einem Mitarbeiter erst nach dem Anlegen der Betriebsferien, **speichern Sie die betreffenden Betriebsferien einmal erneut** (Bearbeiten → Speichern) – die Abwesenheiten werden dann für die nun berechtigten Personen nachgetragen.
+> **Tipp – nachträglich Berechtigte ergänzen:** Aktivieren Sie die Option „Nimmt an Betriebsferien teil" bei einem Mitarbeiter und speichern Sie die Benutzer-Änderung. Die Abwesenheiten werden **automatisch** für alle laufenden und künftigen Betriebsferien nachgetragen – ein erneutes Speichern der Betriebsferien ist nicht mehr nötig, und bereits erfasste Arbeitszeiten bleiben erhalten. (Bereits abgelaufene Betriebsferien werden bewusst nicht rückwirkend ergänzt.)
 
 ### Betriebsferien löschen
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "dependencies": {
         "@fontsource-variable/dm-sans": "^5.2.8",
         "axios": "^1.18.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.10.3",
+  "version": "1.10.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/DocViewer.tsx
+++ b/frontend/src/components/DocViewer.tsx
@@ -233,7 +233,7 @@ export function CheatsheetAdmin() {
       <section>
         <h3 className="text-base font-semibold text-gray-800 border-b border-gray-200 pb-2 mb-3">📅 Betriebsferien</h3>
         <p className="text-sm text-gray-600">Abwesenheiten → Neue Betriebsferien → Bezeichnung + Von–Bis → Speichern</p>
-        <p className="text-sm text-gray-500 mt-1">Alle MA mit „Nimmt an Betriebsferien teil" (Standard) erhalten automatisch Einträge – rollenunabhängig, keine Urlaubstage. Nachträglich Berechtigte: Option setzen, Betriebsferien einmal erneut speichern.</p>
+        <p className="text-sm text-gray-500 mt-1">Alle MA mit „Nimmt an Betriebsferien teil" (Standard) erhalten automatisch Einträge – rollenunabhängig, keine Urlaubstage. Nachträglich Berechtigte: Option setzen – Einträge werden automatisch für laufende und künftige Betriebsferien nachgetragen.</p>
       </section>
 
       {/* ArbZG */}
@@ -415,7 +415,7 @@ export const handbuchAdminSections: AccordionItem[] = [
     content: (
       <div className="space-y-2">
         <p><strong>Urlaubsanträge:</strong> Toggle „Genehmigungspflicht" aktiviert den Workflow. Anträge erscheinen als „Offen" → Genehmigen (grün) oder Ablehnen (rot, optional Grund).</p>
-        <p><strong>Betriebsferien:</strong> Abwesenheiten → Tab „Betriebsferien" → Neue Betriebsferien. Alle aktiven Mitarbeiter mit der Option „Nimmt an Betriebsferien teil" (Standard, rollenunabhängig) erhalten automatisch Abwesenheitseinträge (kein Urlaubsabzug). Nachträglich Berechtigte: Option setzen und die Betriebsferien einmal erneut speichern. Beim Löschen werden alle Einträge entfernt.</p>
+        <p><strong>Betriebsferien:</strong> Abwesenheiten → Tab „Betriebsferien" → Neue Betriebsferien. Alle aktiven Mitarbeiter mit der Option „Nimmt an Betriebsferien teil" (Standard, rollenunabhängig) erhalten automatisch Abwesenheitseinträge (kein Urlaubsabzug). Nachträglich Berechtigte: Option setzen – die Einträge werden automatisch für laufende und künftige Betriebsferien nachgetragen. Beim Löschen werden alle Einträge entfernt.</p>
         <p className="text-gray-700"><strong>Urlaubsberechnung (Tagesprinzip, §3 BUrlG):</strong> Urlaub wird nach Arbeitstagen geführt – ein freier Arbeitstag = <strong>1 Urlaubstag</strong>, unabhängig von Tagesstunden und Wochentag (auch bei individuellen Tagesstunden). Jahresanspruch anteilig: <code>30 × Arbeitstage ÷ 5</code> (überschreibbar beim Anlegen). Verbrauch wird tagebasiert gezählt, intern gespeicherte Stunden dienen nur der Soll-/Ist-Berechnung.</p>
       </div>
     ),

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.10.3"
+APP_VERSION="1.10.4"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
## Release 1.10.4 (Patch)

Bündelt die seit v1.10.3 gemergten PRs als Release **1.10.4**: #286 (Windows-Installer CRLF + Docker-Upgrade-Skripte), #287 (volle Breite), #219 (Code-Dedup), #15 (Service/DB-Härtung), #290 (Betriebsferien-Datenverlust-Fix + Auto-Enrollment). Plus die Phase-2-Review-Fixes dieses Release-Laufs (`/buildrelease`):

- **Handbücher korrigiert (4 Stellen):** der „Betriebsferien neu speichern"-Workaround ist seit #290 obsolet **und** war zuvor datenzerstörend → „Option setzen → automatisch nachgetragen" (CHEATSHEET/HANDBUCH-ADMIN + DocViewer.tsx ×2, In-App + docs/handbuch synchron).
- **`_enroll_user_in_open_closures` best-effort:** try/except + rollback + Logger — eine Enroll-Panne darf das Anlegen/Ändern eines Benutzers nicht mit 500 abbrechen.
- **Urlaubs-PATCH max. 1 Jahr** (war nur im POST).

### Verifiziert (vollständige /buildrelease-Matrix)
- Backend-Suite **985 passed / 49 skipped**; tsc + vite grün.
- Build: 6 Artefakte, Windows-ZIP-Integrität (PG-18.4-SHA-Pin, keine setup.exe-Dopplung, Bundle=1.10.4).
- **validate-release 5/5** (Ubuntu 22/24, Debian 12, Rocky 9, Arch).
- **Local Docker:** DB-State byte-identisch über Restart + echter Login 200.
- **.131 native:** echtes Upgrade 1.10.1→1.10.4 — Dienst aktiv, Health connected, **DB byte-identisch** (alembic 052, User+Zeiteintrag erhalten).
- **.131 Docker:** Fresh-Deploy, Health + echter **Login 200**.
- **Windows-Emulator (dockur/Win11):** `Setup abgeschlossen!`, **HEALTH 200, LOGIN 200, psql 18.4** (kein FEHLER).

Deferred (eigener Perf-PR): N+1 in export_service Jahres-/Abwesenheits-Sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)