### PR TITLE
docs(CLAUDE.md): Aktuelle Version → 1.10.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.9.0 (Stand 2026-06-23)
+**Aktuelle Version:** 1.10.4 (Stand 2026-06-24)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---


### PR DESCRIPTION
Bump the stale 'Aktuelle Version' line (war 1.9.0) auf 1.10.4 nach dem Release-Lauf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)