### PR TITLE
fix(#296,#297): Wording Einträge + Admin-Kalenderfarbe je Mitarbeiter

### DIFF
--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -7,22 +7,7 @@ import { QRCodeSVG } from 'qrcode.react';
 import PasswordInput from '../components/PasswordInput';
 import { getErrorMessage } from '../utils/errorMessage';
 import { useToast } from '../contexts/ToastContext';
-
-// 12 beautiful pastel colors for calendar
-const PASTEL_COLORS = [
-  { name: 'Blau', hex: '#93C5FD' },
-  { name: 'Rosa', hex: '#F9A8D4' },
-  { name: 'Lila', hex: '#DDD6FE' },
-  { name: 'Grün', hex: '#86EFAC' },
-  { name: 'Gelb', hex: '#FDE047' },
-  { name: 'Orange', hex: '#FDBA74' },
-  { name: 'Türkis', hex: '#5EEAD4' },
-  { name: 'Mint', hex: '#A7F3D0' },
-  { name: 'Pfirsich', hex: '#FED7AA' },
-  { name: 'Lavendel', hex: '#E9D5FF' },
-  { name: 'Hellblau', hex: '#BAE6FD' },
-  { name: 'Koralle', hex: '#FCA5A5' },
-];
+import { PASTEL_COLORS, DEFAULT_CALENDAR_COLOR } from '../utils/calendarColors';
 
 export default function Profile() {
   const toast = useToast();
@@ -39,7 +24,7 @@ export default function Profile() {
     new_password: '',
     confirm_password: '',
   });
-  const [selectedColor, setSelectedColor] = useState(user?.calendar_color || '#93C5FD');
+  const [selectedColor, setSelectedColor] = useState(user?.calendar_color || DEFAULT_CALENDAR_COLOR);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [colorMessage, setColorMessage] = useState('');

--- a/frontend/src/pages/admin/AdminAbsences.tsx
+++ b/frontend/src/pages/admin/AdminAbsences.tsx
@@ -718,7 +718,7 @@ export default function AdminAbsences() {
                     </span>
                     {empAbsences.length > 0 && (
                       <span className="text-sm text-gray-500">
-                        {empAbsences.length} Eintrag{empAbsences.length !== 1 ? 'träge' : ''}
+                        {empAbsences.length} {empAbsences.length === 1 ? 'Eintrag' : 'Einträge'}
                       </span>
                     )}
                     {empAbsences.length === 0 && (

--- a/frontend/src/pages/admin/users/UserForm.tsx
+++ b/frontend/src/pages/admin/users/UserForm.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '../../../stores/authStore';
 import PasswordInput from '../../../components/PasswordInput';
 import { getErrorMessage } from '../../../utils/errorMessage';
 import { parseHours } from '../../../utils/formatters';
+import { PASTEL_COLORS, DEFAULT_CALENDAR_COLOR } from '../../../utils/calendarColors';
 
 import type { User } from '../../../types/user';
 
@@ -34,6 +35,7 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
     exempt_from_arbzg: false,
     is_night_worker: false,
     receives_company_closures: true,
+    calendar_color: DEFAULT_CALENDAR_COLOR,
     first_work_day: '',
     last_work_day: '',
     department: '',
@@ -74,6 +76,7 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
         exempt_from_arbzg: editUser.exempt_from_arbzg ?? false,
         is_night_worker: editUser.is_night_worker ?? false,
         receives_company_closures: editUser.receives_company_closures ?? true,
+        calendar_color: editUser.calendar_color || DEFAULT_CALENDAR_COLOR,
         first_work_day: editUser.first_work_day || '',
         last_work_day: editUser.last_work_day || '',
         department: editUser.department || '',
@@ -424,6 +427,47 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
             <label htmlFor="receives_company_closures" className="text-sm font-medium text-gray-700 cursor-pointer">
               Nimmt an Betriebsferien teil (Betriebsferien werden automatisch eingetragen)
             </label>
+          </div>
+
+          {/* #297: Kalenderfarbe — vom Admin für jede:n Mitarbeiter:in setzbar
+              (ergänzt die Selbst-Auswahl im Profil). */}
+          <div className="md:col-span-2">
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Kalenderfarbe
+              <span
+                className="ml-2 inline-block w-4 h-4 rounded-full align-middle border border-gray-300"
+                style={{ backgroundColor: formData.calendar_color }}
+              />
+            </label>
+            <div className="grid grid-cols-6 sm:grid-cols-12 gap-2">
+              {PASTEL_COLORS.map((color) => (
+                <button
+                  key={color.hex}
+                  type="button"
+                  onClick={() => setFormData({ ...formData, calendar_color: color.hex })}
+                  aria-label={`Farbe ${color.name}`}
+                  aria-pressed={formData.calendar_color === color.hex}
+                  title={color.name}
+                  className={`relative w-full aspect-square rounded-lg transition-all hover:scale-110 ${
+                    formData.calendar_color === color.hex
+                      ? 'ring-4 ring-primary ring-offset-2 scale-110'
+                      : 'hover:ring-2 hover:ring-gray-300'
+                  }`}
+                  style={{ backgroundColor: color.hex }}
+                >
+                  {formData.calendar_color === color.hex && (
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <div className="w-3 h-3 bg-white rounded-full flex items-center justify-center">
+                        <div className="w-1.5 h-1.5 bg-primary rounded-full" />
+                      </div>
+                    </div>
+                  )}
+                </button>
+              ))}
+            </div>
+            <p className="text-xs text-gray-500 mt-2">
+              Farbe des Badge-Rings im Kalender. Mitarbeitende können sie auch selbst im Profil ändern.
+            </p>
           </div>
 
           {/* First / Last Work Day */}

--- a/frontend/src/utils/calendarColors.ts
+++ b/frontend/src/utils/calendarColors.ts
@@ -1,0 +1,18 @@
+// Shared calendar-color palette (Mitarbeiterfarbe für den Kalender, #157).
+// Used by the self-service Profile picker AND the admin UserForm (#297).
+export const DEFAULT_CALENDAR_COLOR = '#93C5FD';
+
+export const PASTEL_COLORS: ReadonlyArray<{ name: string; hex: string }> = [
+  { name: 'Blau', hex: '#93C5FD' },
+  { name: 'Rosa', hex: '#F9A8D4' },
+  { name: 'Lila', hex: '#DDD6FE' },
+  { name: 'Grün', hex: '#86EFAC' },
+  { name: 'Gelb', hex: '#FDE047' },
+  { name: 'Orange', hex: '#FDBA74' },
+  { name: 'Türkis', hex: '#5EEAD4' },
+  { name: 'Mint', hex: '#A7F3D0' },
+  { name: 'Pfirsich', hex: '#FED7AA' },
+  { name: 'Lavendel', hex: '#E9D5FF' },
+  { name: 'Hellblau', hex: '#BAE6FD' },
+  { name: 'Koralle', hex: '#FCA5A5' },
+];


### PR DESCRIPTION
Zwei kleine UI-Verbesserungen aus dem Beta-Feedback (@philvdb).

### #296 — Wording in „Abwesenheiten verwalten"
Der Zähler je Mitarbeiter:in zeigte `N Eintragträge` (Basis „Eintrag" + naiver Plural-Suffix „träge"). Korrigiert zu **„1 Eintrag" / „N Einträge"** (deutscher Plural mit Umlaut a→ä).

### #297 — Admin kann Kalenderfarbe je Mitarbeiter setzen
Bisher nur Selbst-Auswahl im Profil. Admins können die Farbe jetzt im Benutzer-Formular (Anlegen **und** Bearbeiten) für jede:n MA festlegen. Backend (`calendar_color` in `UserCreate`/`UserUpdate`) unterstützte das bereits — reine Frontend-Ergänzung. Palette nach `utils/calendarColors.ts` ausgelagert (geteilt von Profil + UserForm, kein Duplikat — vgl. #219).

**Verifiziert:** tsc grün, 116 Frontend-Tests grün.

Closes #296, closes #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
