### PR TITLE
release: 1.10.6 — Schichtplanung + Review-Härtung

### DIFF
--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.10.5"
+APP_VERSION = "1.10.6"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/routers/shift_planning.py
+++ b/backend/app/routers/shift_planning.py
@@ -15,12 +15,8 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, field_validator
-
-# Hex colour `#RRGGBB` — the workstation colour column is String(7); anything
-# longer would StringDataRightTruncation (500) on Postgres (SQLite tests don't
-# enforce varchar length), so validate format + length at the edge.
-_HEX_COLOR_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -34,6 +30,26 @@ from app.models.shift_planning import (
     ShiftAssignment,
 )
 from app.services import settings_service, shift_planning_service
+
+# Hex colour `#RRGGBB` — the workstation colour column is String(7); anything
+# longer would StringDataRightTruncation (500) on Postgres (SQLite tests don't
+# enforce varchar length), so validate format + length at the edge.
+_HEX_COLOR_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+
+
+def _commit_or_conflict(db: Session, detail: str) -> None:
+    """Commit, translating a unique-constraint violation into a clean 409.
+
+    The create/update endpoints pre-check names with a SELECT, but two admins
+    racing on the same new name can both pass the check and then collide on the
+    ``uq_tenant_*_name`` constraint at COMMIT. Without this guard the loser gets
+    a 500 instead of the advertised 409 (no data is corrupted either way).
+    """
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
 
 
 def require_shift_planning_enabled(
@@ -186,7 +202,7 @@ def create_location(
         raise HTTPException(status_code=409, detail="Ein Standort mit diesem Namen existiert bereits")
     loc = Location(tenant_id=current_user.tenant_id, name=name, sort_order=data.sort_order)
     db.add(loc)
-    db.commit()
+    _commit_or_conflict(db, "Ein Standort mit diesem Namen existiert bereits")
     db.refresh(loc)
     return _loc_dict(loc)
 
@@ -221,7 +237,7 @@ def update_location(
         raise HTTPException(status_code=409, detail="Ein Standort mit diesem Namen existiert bereits")
     loc.name = name
     loc.sort_order = data.sort_order
-    db.commit()
+    _commit_or_conflict(db, "Ein Standort mit diesem Namen existiert bereits")
     db.refresh(loc)
     return _loc_dict(loc)
 
@@ -319,7 +335,7 @@ def create_workstation(
         sort_order=data.sort_order,
     )
     db.add(ws)
-    db.commit()
+    _commit_or_conflict(db, "Ein Arbeitsplatz mit diesem Namen existiert bereits")
     db.refresh(ws)
     loc_names = _location_name_map(db, current_user.tenant_id)
     return _ws_dict(ws, loc_names.get(ws.location_id))
@@ -358,7 +374,7 @@ def update_workstation(
     ws.location_id = data.location_id
     ws.color = data.color
     ws.sort_order = data.sort_order
-    db.commit()
+    _commit_or_conflict(db, "Ein Arbeitsplatz mit diesem Namen existiert bereits")
     db.refresh(ws)
     loc_names = _location_name_map(db, current_user.tenant_id)
     return _ws_dict(ws, loc_names.get(ws.location_id))
@@ -555,7 +571,7 @@ def create_plan(
         created_by=current_user.id,
     )
     db.add(plan)
-    db.commit()
+    _commit_or_conflict(db, "Ein Schichtplan mit diesem Namen existiert bereits")
     db.refresh(plan)
     return _plan_summary(plan)
 
@@ -584,7 +600,7 @@ def update_plan(
         raise HTTPException(status_code=409, detail="Ein Schichtplan mit diesem Namen existiert bereits")
     plan.name = name
     plan.description = data.description
-    db.commit()
+    _commit_or_conflict(db, "Ein Schichtplan mit diesem Namen existiert bereits")
     db.refresh(plan)
     return _plan_summary(plan)
 

--- a/backend/tests/test_shift_planning.py
+++ b/backend/tests/test_shift_planning.py
@@ -323,6 +323,20 @@ class TestReviewFixes:
         )
         assert r.status_code == 422, r.text
 
+    def test_commit_conflict_guard_returns_409(self, db, default_tenant):
+        """A unique-name collision at COMMIT is translated to 409, not a 500."""
+        from fastapi import HTTPException
+        from app.routers.shift_planning import _commit_or_conflict
+        from app.models.shift_planning import Location
+
+        db.add(Location(tenant_id=DEFAULT_TENANT_ID, name="Dup"))
+        db.commit()
+        # second row violates uq_tenant_location_name (SQLite enforces UNIQUE)
+        db.add(Location(tenant_id=DEFAULT_TENANT_ID, name="Dup"))
+        with pytest.raises(HTTPException) as exc:
+            _commit_or_conflict(db, "Standort existiert bereits")
+        assert exc.value.status_code == 409
+
     def test_purge_user_reassigns_created_shift_plans(self, enabled, admin_client, db, test_admin):
         """DSGVO Art.17 purge of a user who created a shift plan must not orphan/FK-fail."""
         from app.models import User, UserRole

--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -1,6 +1,6 @@
 # PraxisZeit – Handbuch für Administratoren
 
-**Version 2.4 | Stand: Juni 2026 (für PraxisZeit 1.9.0)**
+**Version 2.5 | Stand: Juni 2026 (für PraxisZeit 1.10.6)**
 
 ---
 
@@ -832,4 +832,4 @@ Dashboard. Details: [`docs/SCHICHTPLANUNG.md`](../SCHICHTPLANUNG.md).
 ---
 
 *PraxisZeit – Zeiterfassungssystem für Arztpraxen und kleine Unternehmen*
-*Stand: Juni 2026 (für PraxisZeit 1.9.0)*
+*Stand: Juni 2026 (für PraxisZeit 1.10.6)*

--- a/docs/handbuch/HANDBUCH-MITARBEITER.md
+++ b/docs/handbuch/HANDBUCH-MITARBEITER.md
@@ -555,4 +555,4 @@ legt Ihr Administrator fest.
 
 ---
 
-*PraxisZeit – Zeiterfassungssystem | Mitarbeiter-Handbuch v2.3 | Juni 2026 (PraxisZeit 1.9.0)*
+*PraxisZeit – Zeiterfassungssystem | Mitarbeiter-Handbuch v2.4 | Juni 2026 (PraxisZeit 1.10.6)*

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.10.5",
+      "version": "1.10.6",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.10.5",
+  "version": "1.10.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.10.5"
+APP_VERSION="1.10.6"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
Release **1.10.6** (PATCH). Inhalt seit 1.10.5: das Schichtplanungs-Feature (#305, bereits gemerged) wird als Release ausgeliefert; dieser PR enthält den Version-Bump + zwei LOW-Review-Fixes.

## Version-Bump (3 Stellen + Lock)
`updater.py` · `tools/build-release.sh` · `frontend/package.json` (+ `package-lock.json`) → **1.10.6**.

## Phase-2-Release-Review (4 Lanes, adversarial verifiziert) → 2 Findings, beide LOW, beide gefixt
- **shift_planning-Router:** Unique-Name-Kollision am COMMIT lieferte unter einem Admin-Race ein 500 statt des vertraglichen 409 → `_commit_or_conflict`-Guard (6 create/update-Pfade) + deterministischer Test.
- **Handbuch-Footer** (Admin/MA) trugen noch „1.9.0" über 1.10.x-Inhalt → auf 1.10.6 aktualisiert.

## Verifikation
- Backend **1040 grün** (SQLite) + **21 grün** (Postgres RLS/Concurrency, live DB).
- Build: **6 Artefakte**. Windows-Integrität: PG **18.4** SHA-Pin im Bundle, **kein** doppeltes `setup.exe` im ZIP (~500 MB), Bundle-`APP_VERSION = 1.10.6`. SHA256SUMS ok.
- **validate-release 5/5** (Ubuntu 22/24, Debian 12, Rocky 9, Arch — PG18 initdb).
- **Local Docker 1.10.6**: fresh migrate (053) + **Real-Browser-Login-E2E** (Schichtplanung CRUD + 404-wenn-aus) + Version 1.10.6.
- **Update-Survival** 1.10.5(052)→1.10.6(053) auf echtem Postgres: Bestandsdaten **byte-identisch**, +5 Tabellen, alembic head.
- Windows-Emulator (dockur/Win11): voller Install-Lauf gestartet (Ergebnis wird vor dem GitHub-Release abgewartet).
- .131: erreichbar + gesund auf Vorgänger (1.10.5); native theseus-PG18-Pfad für diesen Build durch validate-release (Ubuntu 24.04) abgedeckt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
