### PR TITLE
docs(CLAUDE.md): Aktuelle Version 1.10.6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.10.5 (Stand 2026-06-24)
+**Aktuelle Version:** 1.10.6 (Stand 2026-06-26)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---


### PR DESCRIPTION
Bumpt die CLAUDE.md-Versionszeile auf das gerade veröffentlichte Release 1.10.6 (Tag v1.10.6, GitHub-Release live).