### PR TITLE
chore(gitignore): ignore local .claude/ + .win-test/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ docs/generated/
 
 # Raw user feedback inputs (may contain personal data) — never commit
 feedback/
+
+# Local-only tooling & test scaffolds (never commit)
+.claude/
+.win-test/


### PR DESCRIPTION
Hält die lokalen Tooling-/Test-Scaffolds ( Skills,  Windows-Emulator-Tree ~1,2 GB) aus dem (öffentlichen) Repo. Reine .gitignore-Ergänzung.