### PR TITLE
feat(#311): Mitarbeitername in der Monatsjournal-Überschrift

### DIFF
--- a/frontend/src/pages/admin/UserJournal.tsx
+++ b/frontend/src/pages/admin/UserJournal.tsx
@@ -1,11 +1,33 @@
 // frontend/src/pages/admin/UserJournal.tsx
+import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import MonthlyJournal from '../../components/MonthlyJournal';
+import apiClient from '../../api/client';
 
 export default function UserJournal() {
   const { userId } = useParams<{ userId: string }>();
   const navigate = useNavigate();
+  // #311: show whose journal this is in the heading.
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+    apiClient
+      .get(`/admin/users/${userId}`)
+      .then((res) => {
+        if (cancelled) return;
+        const full = `${res.data.first_name ?? ''} ${res.data.last_name ?? ''}`.trim();
+        setName(full || res.data.username || '');
+      })
+      .catch(() => {
+        /* heading just falls back to "Monatsjournal" */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
 
   if (!userId) return null;
 
@@ -20,7 +42,7 @@ export default function UserJournal() {
           <ArrowLeft className="w-5 h-5" />
         </button>
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Monatsjournal</h1>
+          <h1 className="text-2xl font-bold text-gray-900">Monatsjournal{name ? `: ${name}` : ''}</h1>
           <p className="text-sm text-gray-500">Zeiteinträge und Abwesenheiten im Überblick</p>
         </div>
       </div>


### PR DESCRIPTION
Schließt #311.

Zeigt in der Admin-Sicht (Benutzerverwaltung → Monatsjournal) die Überschrift **„Monatsjournal: Vorname Nachname"** — so von dir im Issue gewünscht. Fallback: Benutzername bzw. nur „Monatsjournal", wenn der Name nicht geladen werden kann.

tsc grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
