### PR TITLE
Release 1.12.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.11.0 (Stand 2026-06-26)
+**Aktuelle Version:** 1.12.0 (Stand 2026-06-27)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.11.0"
+APP_VERSION = "1.12.0"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -88,6 +88,11 @@ Das Admin-Dashboard zeigt alle aktiven Mitarbeiter mit ihren aktuellen Monatsdat
 
 **Monat wechseln:** Mit den Pfeilen `<` und `>` wechseln Sie den angezeigten Monat.
 
+**Soll-Basis umschalten (#313):** Über das Dropdown **„Soll: bis heute / Monatsende"** in der Monatsübersicht steuern Sie, wie das Monats-**Soll** gezählt wird:
+- **bis heute** (Standard): nur bis zum **letzten abgeschlossenen Arbeitstag** des laufenden Monats — so startet der Saldo nicht mit einem Monatsanfangs-Minus.
+- **Monatsende**: der **volle** Monat.
+Für **abgeschlossene** Monate sind beide identisch. (Technisch: der Bericht `/admin/reports/monthly` nimmt den Parameter `soll_basis=bis_heute|monatsende`.) Die heruntergeladenen §16-Exporte bleiben bewusst voll-Monat.
+
 **Suche:** Nutzen Sie das Suchfeld, um nach einem bestimmten Mitarbeiter zu filtern.
 
 **Detailansicht:** Klicken Sie auf den Pfeil am Ende einer Zeile, um die Detailansicht des Mitarbeiters zu öffnen.

--- a/docs/handbuch/HANDBUCH-MITARBEITER.md
+++ b/docs/handbuch/HANDBUCH-MITARBEITER.md
@@ -64,6 +64,8 @@ Das Dashboard zeigt Ihnen auf einen Blick:
 | **Überstundenkonto** | Kumulierter Jahressaldo aller Monate |
 | **Urlaubskonto** | Budget, verbrauchte und verbleibende Urlaubstage |
 
+> **Monatssaldo nur bis zum letzten Arbeitstag:** Im **laufenden** Monat wird das Soll nur bis zum **letzten abgeschlossenen Arbeitstag** gezählt – Sie starten den Monat also **nicht** mit einem dicken Minus, sondern der Saldo baut sich Tag für Tag auf. Der heutige Tag zählt mit, sobald Sie **ausgestempelt** haben. Für **abgeschlossene** Monate entspricht der Saldo wie gewohnt dem vollen Monat.
+
 > **Zeitanzeige:** Stunden werden im Format H:MM angezeigt (z. B. „8:30" für 8 Stunden 30 Minuten). Negative Salden werden mit einem Minus-Zeichen dargestellt (z. B. „-2:15").
 
 > **Hinweis:** Falls Ihre Praxis für Sie **keine Stundenzählung** führt, fehlen die Kacheln **Tagessaldo**, **Monatssaldo** und **Überstundenkonto** – das ist bei Ihnen so eingestellt und kein Fehler. Ihr **Urlaubskonto** wird trotzdem geführt. Mehr dazu in [Abschnitt 6](#6-wenn-für-sie-keine-stunden-gezählt-werden).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/DocViewer.tsx
+++ b/frontend/src/components/DocViewer.tsx
@@ -279,6 +279,7 @@ export const handbuchMitarbeiterSections: AccordionItem[] = [
     content: (
       <div className="space-y-2">
         <p>Das Dashboard zeigt Ihren <strong>Tagessaldo</strong> (heute: Ist vs. Tagessoll), den <strong>Monatssaldo</strong> (Ist – Soll in H:MM), den kumulierten Jahressaldo und das Urlaubskonto.</p>
+        <p>Im <strong>laufenden Monat</strong> zählt das Soll nur bis zum <strong>letzten abgeschlossenen Arbeitstag</strong> – Sie starten den Monat also nicht mit einem dicken Minus; der heutige Tag zählt mit, sobald Sie <strong>ausgestempelt</strong> haben. Abgeschlossene Monate entsprechen dem vollen Monat.</p>
         <p>Grüner Saldo = Überstunden, roter Saldo = Fehlstunden. Auf mobilen Geräten wird die untere Tab-Leiste zur Navigation genutzt.</p>
       </div>
     ),
@@ -388,6 +389,7 @@ export const handbuchAdminSections: AccordionItem[] = [
     content: (
       <div className="space-y-2">
         <p>Das <strong>Admin-Dashboard</strong> zeigt alle aktiven Mitarbeiter mit Soll, Ist, Saldo (H:MM), kumulierten Überstunden, verbleibenden Urlaubstagen und Kranktagen für den gewählten Monat.</p>
+        <p>Das Dropdown <strong>„Soll: bis heute / Monatsende"</strong> schaltet die Soll-Basis um: <strong>bis heute</strong> (Standard) zählt das Soll des laufenden Monats nur bis zum letzten abgeschlossenen Arbeitstag (kein Monatsanfangs-Minus), <strong>Monatsende</strong> den vollen Monat. Für abgeschlossene Monate identisch; die §16-Datei-Exporte bleiben voll-Monat.</p>
         <p>Klicken Sie auf den Pfeil am Ende einer Zeile für die Detailansicht. Nutzen Sie die Suche zum Filtern nach Name.</p>
       </div>
     ),

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.11.0"
+APP_VERSION="1.12.0"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
# PraxisZeit 1.12.0 (MINOR)

Version-Bump auf **1.12.0** + #313-Doku-Nachzug. Die Features dieses Release sind bereits einzeln auf master gemergt:

- **#305 M2 Schichtplanung** — KW-/Ganzjahres-Planung (Datums-Fenster) + Auto-Generierung
- **#312** — eigene Abwesenheitsgründe (Freitext + Farbe + Basis-Verhalten)
- **#311** — Mitarbeitername im Admin-Monatsjournal
- **#313** — Monatssaldo nur bis zum letzten abgeschlossenen Arbeitstag + „bis heute/Monatsende"-Schalter
- **#314** — Betriebsferien über Urlaub hinaus → Überstundenabbau (globaler Schalter)
- **#321** Tagesansicht + **#322** Schicht-kopieren im Schichtplaner

## Diese PR
- `chore(release)`: Bump auf 1.12.0 (updater.py + build-release.sh + package.json + lock)
- `docs(#313)`: Saldo-Stichtag + Soll-Basis-Schalter in beiden Handbüchern + In-App-Hilfe (Phase-2-Review-Finding)

## QA / Release-Pipeline
- **Phase 2 Review** (Workflow, 2 Lanes + adversarial verify): 1 medium (Doku-Lücke #313) → gefixt
- **Backend-Suite**: 1088 passed (+ 1113 in der vollen Integrationssuite)
- **validate-release**: 5/5 Distros (Ubuntu 22/24, Debian 12, Rocky 9, Arch) — PG/initdb 18.4
- **Artefakte**: 6 gebaut, SHA256 ok, Windows-ZIP integritätsgeprüft (kein doppeltes setup.exe, PG-Installer-SHA == 18.4-Pin, Bundle 1.12.0)
- **Local Docker**: Fresh-Install-Login ✓ (#312/#313/users-overview 200) + Migrations-Round-Trip 057↔054 datenerhaltend ✓
- **.131 (real host)**: Native-Update 1.10.6 → 1.12.0 — Migrationen 053→057, Daten **byte-identisch** (hash match), Login ✓, Funktion ✓, **Backup erstellt + restorebar (Roundtrip 0 Fehler)**
- **Windows-Emulator**: läuft (1.12.0 hat **keine** Windows-Installer-Änderungen ggü. dem emulator-getesteten 1.11.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
