### PR TITLE
feat(#329): Admin-Dashboard Monat ↔ Woche umschalten

### DIFF
--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -7,7 +7,7 @@ from starlette.requests import Request
 from typing import List
 from decimal import Decimal
 from io import BytesIO
-from datetime import date
+from datetime import date, timedelta
 from urllib.parse import quote
 from app.database import get_db
 from app.models import User, Absence, AbsenceType, TimeEntry, TimeEntryAuditLog
@@ -16,7 +16,7 @@ from app.middleware.auth import require_admin
 from app.schemas.reports import EmployeeMonthlyReport, EmployeeYearlyAbsences
 from app.services import calculation_service, export_service, ods_export_service, rest_time_service
 from app.services.arbzg_utils import is_night_work
-from app.services.date_filters import date_in_year, date_in_month
+from app.services.date_filters import date_in_year, date_in_month, date_in_range
 from app.core.limiter import limiter
 
 logger = logging.getLogger(__name__)
@@ -143,6 +143,116 @@ def get_monthly_report(
 
     # L-2: Report erfolgreich gebaut -> jetzt erst den (ggf. oben geflushten)
     # health_data_read-Audit-Eintrag dauerhaft festschreiben.
+    if include_health_data:
+        db.commit()
+
+    return reports
+
+
+@router.get("/weekly", response_model=List[EmployeeMonthlyReport])
+def get_weekly_report(
+    week_start: str = Query(..., description="Beliebiges Datum der Woche (YYYY-MM-DD); wird auf Montag normalisiert"),
+    include_health_data: bool = Query(False, description="Krankheitsdaten einschließen (Art. 9 DSGVO)"),
+    soll_basis: str = Query(
+        "bis_heute",
+        description="#313 Soll-Basis: 'bis_heute' (bis letzter abgeschlossener Arbeitstag) oder 'monatsende' (volle Woche)",
+    ),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    """#329: Wochenreport für alle Mitarbeiter — gleiches Schema wie ``/monthly``,
+    aber für eine ISO-Kalenderwoche (Mo–So).
+
+    ``week_start`` wird auf den **Montag** der Woche normalisiert, daher darf die
+    Woche eine Monats-/Jahresgrenze überschreiten. ``soll_basis`` wirkt wie bei
+    ``/monthly``: ``bis_heute`` (Default) kappt die laufende Woche am letzten
+    abgeschlossenen Arbeitstag, ``monatsende`` zählt die volle Woche. Die
+    Überstunden-Spalte ist der kumulative laufende Saldo zum Ende der Woche.
+    """
+    if soll_basis not in ("bis_heute", "monatsende"):
+        raise HTTPException(status_code=400, detail="soll_basis muss 'bis_heute' oder 'monatsende' sein")
+    try:
+        anchor = date.fromisoformat(week_start)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Ungültiges Datumsformat (YYYY-MM-DD erwartet)")
+
+    wk_start = anchor - timedelta(days=anchor.weekday())  # Monday
+    wk_end = wk_start + timedelta(days=6)                  # Sunday
+
+    if include_health_data:
+        logger.info(
+            "DSGVO-Datenzugriff: Wochenreport %s–%s aufgerufen von Admin %s",
+            wk_start, wk_end, current_user.username,
+        )
+        # F-020: Audit log for sensitive health data read (Art. 9 – sick_hours in response)
+        audit = TimeEntryAuditLog(
+            time_entry_id=None,
+            user_id=current_user.id,
+            changed_by=current_user.id,
+            action="health_data_read",
+            source="dsgvo",
+            new_note=f"Wochenreport {wk_start}–{wk_end} (inkl. Krankheitsstunden) gelesen von Admin: {current_user.username}",
+            tenant_id=current_user.tenant_id,
+        )
+        db.add(audit)
+        # L-2: nur flushen — Commit erst nach erfolgreichem Aufbau (siehe /monthly).
+        db.flush()
+
+    users = _get_active_visible_users(db, current_user.tenant_id)
+
+    reports = []
+
+    for user in users:
+        # #313: per-user cutoff (last finished workday) unless run on the full basis.
+        cutoff = calculation_service.get_soll_cutoff_date(db, user) if soll_basis == "bis_heute" else None
+        target = calculation_service.get_range_target(db, user, wk_start, wk_end, up_to_date=cutoff)
+        actual = calculation_service.get_range_actual(db, user, wk_start, wk_end, up_to_date=cutoff)
+        balance = (actual - target).quantize(Decimal('0.01'))
+        # Überstunden = kumulativer laufender Saldo zum Wochenende (für die laufende
+        # Woche am bis_heute-Cutoff gekappt).
+        ot_cutoff = wk_end if cutoff is None else min(wk_end, cutoff)
+        overtime = calculation_service.get_overtime_account(
+            db, user, wk_end.year, wk_end.month, cutoff_date=ot_cutoff
+        )
+
+        # Urlaub/Krank in der Woche (F-033: sargable range)
+        vacation_absences = db.query(Absence).filter(
+            Absence.user_id == user.id,
+            Absence.type == AbsenceType.VACATION,
+            date_in_range(Absence.date, wk_start, wk_end),
+        ).all()
+        vacation_hours = sum(float(a.hours) for a in vacation_absences)
+
+        sick_absences = db.query(Absence).filter(
+            Absence.user_id == user.id,
+            Absence.type == AbsenceType.SICK,
+            date_in_range(Absence.date, wk_start, wk_end),
+        ).all()
+        sick_hours = sum(float(a.hours) for a in sick_absences)
+
+        # Tagesprinzip (§3 BUrlG, #156/#205): Urlaub/Krank tagebasiert zählen.
+        vacation_days = float(calculation_service.absence_days(db, user, vacation_absences).quantize(Decimal('0.1')))
+        sick_days = float(calculation_service.absence_days(db, user, sick_absences).quantize(Decimal('0.1')))
+
+        # weekly_hours valid at the week's Monday (mirrors /monthly's report_date).
+        hist_weekly = calculation_service.get_weekly_hours_for_date(db, user, wk_start)
+
+        reports.append(EmployeeMonthlyReport(
+            user_id=str(user.id),
+            first_name=user.first_name,
+            last_name=user.last_name,
+            weekly_hours=float(hist_weekly),
+            target_hours=float(target),
+            actual_hours=float(actual),
+            balance=float(balance),
+            overtime_cumulative=float(overtime),
+            vacation_used_hours=vacation_hours,
+            vacation_used_days=vacation_days,
+            sick_hours=sick_hours if include_health_data else 0.0,
+            sick_days=sick_days if include_health_data else 0.0,
+            exempt_from_arbzg=bool(user.exempt_from_arbzg),
+        ))
+
     if include_health_data:
         db.commit()
 

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime, timedelta
 from app.services.timezone_service import today_local
-from app.services.date_filters import date_in_year, date_in_month
+from app.services.date_filters import date_in_year, date_in_month, date_in_range
 from decimal import Decimal
 from calendar import monthrange
 from typing import Dict, List, Optional
@@ -204,155 +204,154 @@ def get_soll_cutoff_date(db: Session, user: User, today: date = None) -> date:
     return today if has_completed_today else today - timedelta(days=1)
 
 
-def get_monthly_target(
-    db: Session, user: User, year: int, month: int, up_to_date: date = None
+def get_range_target(
+    db: Session, user: User, start: date, end: date, up_to_date: date = None
 ) -> Decimal:
+    """Soll hours for an arbitrary inclusive ``[start, end]`` range.
+
+    Same per-day logic as :func:`get_monthly_target` (skip weekends / public
+    holidays / soll-reducing absences, respect the employment window #193 and the
+    #313 ``up_to_date`` cutoff, apply the #146 special-day factor), but over a
+    range that may cross a month or year boundary. ``get_monthly_target``
+    delegates here so there is a single source of truth.
+
+    Absences REDUCE the target (the employee need not work those days), except
+    TRAINING/SICK/OVERTIME (credited / Überstundenausgleich — see
+    get_monthly_target's original note). The special-day config is fetched per
+    year so a range spanning Dec/Jan stays correct.
+
+    Returns 0 if ``track_hours`` is False or the range is empty.
     """
-    Calculate monthly target hours.
-
-    Formula:
-    For each weekday (Mon-Fri) in month:
-        - Skip public holidays
-        - Skip absence days
-        - Add daily target (based on weekly hours valid for that date)
-
-    IMPORTANT: Absences REDUCE the target, because the employee
-    doesn't need to work on those days.
-
-    This function now considers historical working hours changes,
-    so if hours changed mid-month, both values are used correctly.
-
-    Args:
-        db: Database session
-        user: User object
-        year: Year
-        month: Month (1-12)
-
-    Returns:
-        Monthly target hours as Decimal (0 if track_hours is False)
-    """
-    if not user.track_hours:
+    if not user.track_hours or end < start:
         return Decimal('0')
 
-    # Get holidays and absences for the month (F-033: sargable date range)
+    # F-033: sargable date range.
     holidays = db.query(PublicHoliday).filter(
-        date_in_month(PublicHoliday.date, year, month),
+        date_in_range(PublicHoliday.date, start, end),
         PublicHoliday.tenant_id == user.tenant_id,
     ).all()
     holiday_dates = {h.date for h in holidays}
 
-    # Exclude TRAINING, SICK, and OVERTIME from target reduction:
-    # - TRAINING counts as worked time (außer Haus)
-    # - SICK: §3 EntgFG - employee must be credited as if they worked the planned hours
-    # - OVERTIME: Überstundenausgleich – Soll bleibt bestehen, Tag zählt als 0h Ist,
-    #   dadurch reduziert sich das Überstundenkonto um die geplanten Stunden
-    # VACATION, OTHER and PAID_LEAVE (#145) are NOT excluded -> they all
-    # reduce the target (the employee doesn't have to work those days). For
-    # PAID_LEAVE the rechen-mechanik is identical to OTHER; the difference is
-    # only that PAID_LEAVE is paid and doesn't touch the vacation budget
-    # (see get_vacation_account, which sums only VACATION).
     absences = db.query(Absence).filter(
         Absence.user_id == user.id,
-        date_in_month(Absence.date, year, month),
+        date_in_range(Absence.date, start, end),
         Absence.type.notin_([AbsenceType.TRAINING, AbsenceType.SICK, AbsenceType.OVERTIME]),
     ).all()
     absence_dates = {a.date for a in absences}
 
-    # #146: configurable handling of 24./31.12. (working_day | half_day | free).
-    # Loaded once per call; applied per day below.
-    special_day_config = special_days_service.get_special_day_config(
-        db, user.tenant_id, year
-    )
+    # #146: special-day config can differ per year (a week may cross Dec/Jan).
+    _special_cfg_cache: dict = {}
 
-    # Calculate target by iterating through each day
-    _, last_day = monthrange(year, month)
-    monthly_target = Decimal('0')
+    def _special_cfg(yr: int) -> dict:
+        if yr not in _special_cfg_cache:
+            _special_cfg_cache[yr] = special_days_service.get_special_day_config(
+                db, user.tenant_id, yr
+            )
+        return _special_cfg_cache[yr]
 
-    for day in range(1, last_day + 1):
-        d = date(year, month, day)
-
+    total = Decimal('0')
+    d = start
+    while d <= end:
         # Skip weekends
         if d.weekday() >= 5:  # Saturday or Sunday
+            d += timedelta(days=1)
             continue
-
         # #313: only count up to the running cutoff (e.g. last finished workday)
         if up_to_date is not None and d > up_to_date:
+            d += timedelta(days=1)
             continue
-
         # #193: skip days outside the employment window (before entry / after exit)
         if not _within_employment_window(user, d):
+            d += timedelta(days=1)
             continue
-
         # Skip holidays and absences
         if d in holiday_dates or d in absence_dates:
+            d += timedelta(days=1)
             continue
 
-        # Get weekly hours valid for this specific date
         weekly_hours = get_weekly_hours_for_date(db, user, d)
         daily_target = get_daily_target_for_date(user, d, weekly_hours)
 
         # #146: apply the special-day rule (after weekend/holiday/absence so we
         # never double-handle a 24./31.12. that already is a weekend or holiday).
-        factor = special_days_service.special_day_target_factor(d, special_day_config)
+        factor = special_days_service.special_day_target_factor(d, _special_cfg(d.year))
         if factor is not None:
             daily_target = (daily_target * factor)
 
-        monthly_target += daily_target
+        total += daily_target
+        d += timedelta(days=1)
 
-    return monthly_target.quantize(Decimal('0.01'))
+    return total.quantize(Decimal('0.01'))
 
 
-def get_monthly_actual(
-    db: Session, user: User, year: int, month: int, up_to_date: date = None
+def get_range_actual(
+    db: Session, user: User, start: date, end: date, up_to_date: date = None
 ) -> Decimal:
+    """Ist hours worked in an arbitrary inclusive ``[start, end]`` range.
+
+    Sum of TimeEntry net_hours + credited TRAINING/SICK hours, both windowed by
+    the employment window (#195) and the optional ``up_to_date`` cutoff.
+    ``get_monthly_actual`` delegates here.
     """
-    Calculate actual hours worked in a month.
-    Sum of all net_hours from TimeEntry records + credited absence hours.
+    if end < start:
+        return Decimal('0')
 
-    Training (Fortbildung) and sick-leave (Kranktage) hours count as worked time:
-    - Training: employee is absent but credited for the planned hours.
-    - Sick: §3 EntgFG – employee must be credited as if they worked the planned hours.
-
-    Args:
-        db: Database session
-        user: User object
-        year: Year
-        month: Month (1-12)
-
-    Returns:
-        Actual hours worked as Decimal
-    """
-    # F-033: sargable date range. The Python-level Decimal sum is kept
-    # because the SQL @expression for net_hours relies on Postgres's
-    # EXTRACT(EPOCH FROM time - time) semantics which do not port to
-    # SQLite used by the test suite. Fetching the rows is still faster
-    # than per-day queries thanks to the composite index from Sprint 3.1.
+    # F-033: sargable date range. The Python-level Decimal sum is kept because
+    # the SQL @expression for net_hours relies on Postgres EXTRACT(EPOCH ...)
+    # semantics that do not port to the SQLite test suite.
     entries = db.query(TimeEntry).filter(
         TimeEntry.user_id == user.id,
-        date_in_month(TimeEntry.date, year, month),
+        date_in_range(TimeEntry.date, start, end),
     ).all()
     # #195: only count Ist within the employment window — symmetric to the Soll
-    # guard (_within_employment_window in get_monthly_target). A TimeEntry before
-    # first_work_day / after last_work_day (rehire, import, date corrected after
-    # the fact) must contribute neither Soll nor Ist, otherwise the balance shows
-    # phantom overtime.
+    # guard. A TimeEntry before first_work_day / after last_work_day must
+    # contribute neither Soll nor Ist, otherwise the balance shows phantom overtime.
     total = sum((entry.net_hours for entry in entries
                  if _within_employment_window(user, entry.date)
                  and (up_to_date is None or entry.date <= up_to_date)), start=Decimal('0'))
 
-    # Training and sick hours count as actual worked hours:
-    # - TRAINING: außer Haus, credited as worked
-    # - SICK: §3 EntgFG - credited as if the planned hours were worked
+    # Training and sick hours count as actual worked hours (außer Haus / §3 EntgFG).
     credited_absences = db.query(Absence).filter(
         Absence.user_id == user.id,
         Absence.type.in_([AbsenceType.TRAINING, AbsenceType.SICK]),
-        date_in_month(Absence.date, year, month),
+        date_in_range(Absence.date, start, end),
     ).all()
     credited_hours = sum((Decimal(str(a.hours)) for a in credited_absences
                           if _within_employment_window(user, a.date)
                           and (up_to_date is None or a.date <= up_to_date)), Decimal('0'))
 
     return (Decimal(str(total)) + credited_hours).quantize(Decimal('0.01'))
+
+
+def get_monthly_target(
+    db: Session, user: User, year: int, month: int, up_to_date: date = None
+) -> Decimal:
+    """
+    Calculate monthly target hours (thin wrapper over :func:`get_range_target`).
+
+    For each weekday (Mon-Fri) in the month: skip public holidays + soll-reducing
+    absences, add the daily target (based on the weekly hours valid for that date,
+    so a mid-month WorkingHoursChange is handled correctly). Absences REDUCE the
+    target. Returns 0 if track_hours is False.
+    """
+    _, last_day = monthrange(year, month)
+    return get_range_target(
+        db, user, date(year, month, 1), date(year, month, last_day), up_to_date=up_to_date
+    )
+
+
+def get_monthly_actual(
+    db: Session, user: User, year: int, month: int, up_to_date: date = None
+) -> Decimal:
+    """
+    Calculate actual hours worked in a month (thin wrapper over
+    :func:`get_range_actual`). Sum of TimeEntry net_hours + credited
+    TRAINING/SICK hours (§3 EntgFG / Fortbildung außer Haus).
+    """
+    _, last_day = monthrange(year, month)
+    return get_range_actual(
+        db, user, date(year, month, 1), date(year, month, last_day), up_to_date=up_to_date
+    )
 
 
 def get_gross_monthly_target(db: Session, user: User, year: int, month: int) -> Decimal:

--- a/backend/app/services/date_filters.py
+++ b/backend/app/services/date_filters.py
@@ -42,6 +42,15 @@ def date_in_month(column, year: int, month: int):
     return and_(column >= start, column < end)
 
 
+def date_in_range(column, start: date, end: date):
+    """Inclusive range filter ``start <= column <= end`` (sargable).
+
+    Used by the #329 weekly admin view, whose range can cross a month/year
+    boundary and therefore cannot use ``date_in_month``.
+    """
+    return and_(column >= start, column <= end)
+
+
 def date_in_year_up_to_month(column, year: int, month: int):
     """
     Range filter ``column IN year AND month <= :month`` as a sargable

--- a/backend/tests/test_range_calculations.py
+++ b/backend/tests/test_range_calculations.py
@@ -1,0 +1,75 @@
+"""#329: arbitrary date-range Soll/Ist helpers (basis for the weekly admin view).
+
+``get_range_target`` / ``get_range_actual`` mirror the monthly versions but take
+an explicit ``[start, end]`` (inclusive) range, so a calendar week — which may
+span a month (or year) boundary — can be computed in one call.
+"""
+from decimal import Decimal
+from datetime import date, time
+
+from app.models import TimeEntry, Absence, AbsenceType
+from app.services import calculation_service
+from tests.conftest import DEFAULT_TENANT_ID
+
+# KW 26/2026 — Mon 22.06. .. Sun 28.06.
+MON = date(2026, 6, 22)
+TUE = date(2026, 6, 23)
+WED = date(2026, 6, 24)
+SUN = date(2026, 6, 28)
+
+
+def _entry(user, d, start=time(8, 0), end=time(17, 0), break_min=60):
+    return TimeEntry(
+        user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+        start_time=start, end_time=end, break_minutes=break_min,
+    )
+
+
+class TestRangeTarget:
+    def test_full_week_is_five_workdays(self, db, test_user):
+        # 40h/5d → 8h/day; Mon–Sun has 5 workdays → 40h. Weekend contributes 0.
+        target = calculation_service.get_range_target(db, test_user, MON, SUN)
+        assert target == Decimal('40.00')
+
+    def test_partial_mon_to_wed(self, db, test_user):
+        target = calculation_service.get_range_target(db, test_user, MON, WED)
+        assert target == Decimal('24.00')
+
+    def test_respects_cutoff(self, db, test_user):
+        # up_to_date trims the range (e.g. #313 "bis heute"): Mon–Sun capped at Wed → 24h.
+        target = calculation_service.get_range_target(db, test_user, MON, SUN, up_to_date=WED)
+        assert target == Decimal('24.00')
+
+    def test_absence_reduces_target(self, db, test_user):
+        db.add(Absence(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID, date=TUE,
+                       type=AbsenceType.VACATION, hours=8.0))
+        db.commit()
+        target = calculation_service.get_range_target(db, test_user, MON, SUN)
+        assert target == Decimal('32.00')  # 5 workdays − 1 vacation day
+
+    def test_spans_month_boundary(self, db, test_user):
+        # Mon 29.06. .. Sun 05.07. → workdays Jun 29/30 + Jul 1/2/3 = 5 × 8h = 40h.
+        target = calculation_service.get_range_target(
+            db, test_user, date(2026, 6, 29), date(2026, 7, 5)
+        )
+        assert target == Decimal('40.00')
+
+
+class TestRangeActual:
+    def test_empty_range_is_zero(self, db, test_user):
+        assert calculation_service.get_range_actual(db, test_user, MON, SUN) == Decimal('0.00')
+
+    def test_sums_only_entries_in_range(self, db, test_user):
+        db.add(_entry(test_user, MON))   # 8h, in range
+        db.add(_entry(test_user, TUE))   # 8h, in range
+        db.add(_entry(test_user, date(2026, 6, 19)))  # 8h, previous week — must NOT count
+        db.commit()
+        actual = calculation_service.get_range_actual(db, test_user, MON, SUN)
+        assert actual == Decimal('16.00')
+
+    def test_respects_cutoff(self, db, test_user):
+        db.add(_entry(test_user, MON))   # 8h
+        db.add(_entry(test_user, WED))   # 8h, after the cutoff
+        db.commit()
+        actual = calculation_service.get_range_actual(db, test_user, MON, SUN, up_to_date=TUE)
+        assert actual == Decimal('8.00')

--- a/backend/tests/test_weekly_report.py
+++ b/backend/tests/test_weekly_report.py
@@ -1,0 +1,142 @@
+"""#329: weekly admin report endpoint (GET /api/admin/reports/weekly).
+
+Same response schema as /monthly (EmployeeMonthlyReport) but computed for an
+ISO calendar week (Mon–Sun). week_start is normalised to the Monday of its week,
+so a week crossing a month boundary works in one call.
+"""
+from datetime import date, time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.middleware.auth import get_current_user, require_admin
+from app.models import TimeEntry, Absence, AbsenceType
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _reports_app() -> FastAPI:
+    from app.routers import reports as reports_router
+    from app.core.limiter import limiter
+    from slowapi import _rate_limit_exceeded_handler
+    from slowapi.errors import RateLimitExceeded
+
+    app = FastAPI(title="PraxisZeit Weekly Report Test")
+    limiter.enabled = False
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.include_router(reports_router.router)
+    return app
+
+
+_app = _reports_app()
+
+# A clearly-past week so the #313 "bis heute" cutoff never trims it:
+# Mon 01.06.2026 .. Sun 07.06.2026.
+WK_MON = date(2026, 6, 1)
+
+
+def _entry(user, d, start=time(8, 0), end=time(17, 0), break_min=60):
+    return TimeEntry(user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+                     start_time=start, end_time=end, break_minutes=break_min)
+
+
+def _client(db, admin):
+    def override_db():
+        yield db
+    _app.dependency_overrides[get_db] = override_db
+    _app.dependency_overrides[get_current_user] = lambda: admin
+    _app.dependency_overrides[require_admin] = lambda: admin
+    return TestClient(_app)
+
+
+def _row(resp, user):
+    return next(r for r in resp.json() if r["user_id"] == str(user.id))
+
+
+def test_weekly_report_basic(db, test_user, test_admin):
+    db.add(_entry(test_user, WK_MON))                 # Mon 8h
+    db.add(_entry(test_user, date(2026, 6, 2)))       # Tue 8h
+    db.commit()
+    try:
+        client = _client(db, test_admin)
+        r = client.get(f"/api/admin/reports/weekly?week_start={WK_MON.isoformat()}")
+        assert r.status_code == 200, r.text
+        row = _row(r, test_user)
+        assert row["weekly_hours"] == 40.0
+        assert row["target_hours"] == 40.0   # 5 workdays × 8h, full past week
+        assert row["actual_hours"] == 16.0   # Mon+Tue
+        assert row["balance"] == -24.0
+    finally:
+        _app.dependency_overrides.clear()
+
+
+def test_weekly_report_normalises_non_monday(db, test_user, test_admin):
+    # Passing a Wednesday must resolve to the same Mon–Sun week.
+    db.add(_entry(test_user, WK_MON))
+    db.commit()
+    try:
+        client = _client(db, test_admin)
+        wed = date(2026, 6, 3)
+        r = client.get(f"/api/admin/reports/weekly?week_start={wed.isoformat()}")
+        assert r.status_code == 200, r.text
+        assert _row(r, test_user)["actual_hours"] == 8.0
+    finally:
+        _app.dependency_overrides.clear()
+
+
+def test_weekly_report_spans_month_boundary(db, test_user, test_admin):
+    # Mon 29.06. .. Sun 05.07. → target spans June+July (5 workdays = 40h).
+    # This week is in the future relative to "today"; use soll_basis=monatsende
+    # so the #313 bis_heute cutoff doesn't trim it (which is itself correct).
+    db.add(_entry(test_user, date(2026, 6, 30)))   # Tue 8h (June)
+    db.add(_entry(test_user, date(2026, 7, 1)))    # Wed 8h (July)
+    db.commit()
+    try:
+        client = _client(db, test_admin)
+        r = client.get("/api/admin/reports/weekly?week_start=2026-06-29&soll_basis=monatsende")
+        assert r.status_code == 200, r.text
+        row = _row(r, test_user)
+        assert row["target_hours"] == 40.0
+        assert row["actual_hours"] == 16.0
+    finally:
+        _app.dependency_overrides.clear()
+
+
+def test_weekly_report_vacation_reduces_target_and_counts_days(db, test_user, test_admin):
+    db.add(Absence(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID, date=date(2026, 6, 2),
+                   type=AbsenceType.VACATION, hours=8.0))
+    db.commit()
+    try:
+        client = _client(db, test_admin)
+        r = client.get(f"/api/admin/reports/weekly?week_start={WK_MON.isoformat()}")
+        assert r.status_code == 200, r.text
+        row = _row(r, test_user)
+        assert row["target_hours"] == 32.0          # 5 workdays − 1 vacation day
+        assert row["vacation_used_days"] == pytest.approx(1.0)
+    finally:
+        _app.dependency_overrides.clear()
+
+
+def test_weekly_report_sick_masked_without_flag(db, test_user, test_admin):
+    db.add(Absence(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID, date=date(2026, 6, 3),
+                   type=AbsenceType.SICK, hours=8.0))
+    db.commit()
+    try:
+        client = _client(db, test_admin)
+        r1 = client.get(f"/api/admin/reports/weekly?week_start={WK_MON.isoformat()}")
+        assert _row(r1, test_user)["sick_days"] == 0.0   # DSGVO Art. 9
+        r2 = client.get(f"/api/admin/reports/weekly?week_start={WK_MON.isoformat()}&include_health_data=true")
+        assert _row(r2, test_user)["sick_days"] == pytest.approx(1.0)
+    finally:
+        _app.dependency_overrides.clear()
+
+
+def test_weekly_report_invalid_week_start(db, test_admin):
+    try:
+        client = _client(db, test_admin)
+        r = client.get("/api/admin/reports/weekly?week_start=not-a-date")
+        assert r.status_code == 400
+    finally:
+        _app.dependency_overrides.clear()

--- a/frontend/src/components/WeekSelector.test.ts
+++ b/frontend/src/components/WeekSelector.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { weekLabel, isoWeekMonday } from './WeekSelector';
+
+describe('weekLabel', () => {
+  it('formats a within-month week like the customer requested (#329)', () => {
+    // Mon 22.06.2026 .. Sun 28.06.2026 = ISO week 26.
+    expect(weekLabel('2026-06-22')).toBe('22.–28.06.2026 (KW 26)');
+  });
+
+  it('keeps both months when the week crosses a month boundary', () => {
+    // Mon 29.06.2026 .. Sun 05.07.2026.
+    expect(weekLabel('2026-06-29')).toBe('29.06.2026–05.07.2026 (KW 27)');
+  });
+
+  it('computes the ISO week number at year start (week 1)', () => {
+    // Mon 05.01.2026 is in ISO week 2; 29.12.2025 (Mon) is ISO week 1 of 2026.
+    expect(weekLabel('2025-12-29')).toContain('(KW 1)');
+  });
+});
+
+describe('isoWeekMonday', () => {
+  it('returns the Monday of the week containing the given date', () => {
+    expect(isoWeekMonday(new Date('2026-06-24T12:00:00'))).toBe('2026-06-22'); // Wed → Mon
+    expect(isoWeekMonday(new Date('2026-06-28T12:00:00'))).toBe('2026-06-22'); // Sun → Mon
+    expect(isoWeekMonday(new Date('2026-06-22T00:00:00'))).toBe('2026-06-22'); // Mon → Mon
+  });
+});

--- a/frontend/src/components/WeekSelector.tsx
+++ b/frontend/src/components/WeekSelector.tsx
@@ -1,0 +1,78 @@
+import { ChevronLeft, ChevronRight, Calendar } from 'lucide-react';
+import { format, addWeeks, subWeeks, parseISO, startOfWeek, endOfWeek, getISOWeek } from 'date-fns';
+import { de } from 'date-fns/locale';
+
+interface WeekSelectorProps {
+  value: string; // Monday of the week, format "YYYY-MM-DD"
+  onChange: (mondayIso: string) => void;
+  className?: string;
+}
+
+/** Returns the Monday (YYYY-MM-DD) of the ISO week containing `d` (default: today). */
+export function isoWeekMonday(d: Date = new Date()): string {
+  return format(startOfWeek(d, { weekStartsOn: 1 }), 'yyyy-MM-dd');
+}
+
+/** Human label like "22.–28.06.2026 (KW 26)" (drops the redundant first month within one month). */
+export function weekLabel(mondayIso: string): string {
+  const monday = parseISO(mondayIso);
+  const sunday = endOfWeek(monday, { weekStartsOn: 1 });
+  const kw = getISOWeek(monday);
+  const sameMonth = format(monday, 'MM.yyyy') === format(sunday, 'MM.yyyy');
+  const startStr = sameMonth
+    ? format(monday, 'dd.', { locale: de })
+    : format(monday, 'dd.MM.yyyy', { locale: de });
+  const endStr = format(sunday, 'dd.MM.yyyy', { locale: de });
+  return `${startStr}–${endStr} (KW ${kw})`;
+}
+
+export default function WeekSelector({ value, onChange, className = '' }: WeekSelectorProps) {
+  const monday = parseISO(value);
+  const thisMonday = startOfWeek(new Date(), { weekStartsOn: 1 });
+  const isCurrentWeek = format(monday, 'yyyy-MM-dd') === format(thisMonday, 'yyyy-MM-dd');
+
+  const handlePrevious = () => onChange(format(subWeeks(monday, 1), 'yyyy-MM-dd'));
+  const handleNext = () => onChange(format(addWeeks(monday, 1), 'yyyy-MM-dd'));
+  const handleToday = () => onChange(format(thisMonday, 'yyyy-MM-dd'));
+
+  return (
+    <div className={`flex items-center space-x-2 ${className}`}>
+      {/* Previous Week Button */}
+      <button
+        onClick={handlePrevious}
+        className="p-2.5 rounded-xl hover:bg-muted transition"
+        aria-label="Vorherige Woche"
+        title="Vorherige Woche"
+      >
+        <ChevronLeft size={20} />
+      </button>
+
+      {/* Current Week Display */}
+      <div className="flex items-center space-x-2 px-4 py-2 bg-muted rounded-xl min-w-[220px] justify-center">
+        <Calendar size={18} className="text-text-secondary" />
+        <span className="font-semibold text-text-primary">{weekLabel(value)}</span>
+      </div>
+
+      {/* Next Week Button */}
+      <button
+        onClick={handleNext}
+        className="p-2.5 rounded-xl hover:bg-muted transition"
+        aria-label="Nächste Woche"
+        title="Nächste Woche"
+      >
+        <ChevronRight size={20} />
+      </button>
+
+      {/* Today Button (only show if not current week) */}
+      {!isCurrentWeek && (
+        <button
+          onClick={handleToday}
+          className="px-3 py-2 text-sm font-medium text-primary hover:bg-primary-light rounded-xl transition"
+          title="Zur aktuellen Woche springen"
+        >
+          Heute
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -8,6 +8,7 @@ import { useToast } from '../../contexts/ToastContext';
 import { useConfirm } from '../../hooks/useConfirm';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import MonthSelector from '../../components/MonthSelector';
+import WeekSelector, { isoWeekMonday, weekLabel } from '../../components/WeekSelector';
 import { getErrorMessage } from '../../utils/errorMessage';
 import { formatHoursHM, parseHours } from '../../utils/formatters';
 import { submitWithBreakWaiver } from '../../utils/breakWaiverRetry';
@@ -114,11 +115,28 @@ export default function AdminDashboard() {
   // #313: Soll-Basis — 'bis_heute' (bis zum letzten abgeschlossenen Arbeitstag,
   // kein Monatsanfangs-Minus) oder 'monatsende' (voller Monat).
   const [sollBasis, setSollBasis] = useState<'bis_heute' | 'monatsende'>('bis_heute');
+  // #329: Monat ↔ Woche umschalten. Auswahl persistiert pro Browser-User.
+  const [viewMode, setViewMode] = useState<'month' | 'week'>(
+    () => (localStorage.getItem('adminDashboardViewMode') as 'month' | 'week') || 'month',
+  );
+  const [currentWeek, setCurrentWeek] = useState<string>(() => isoWeekMonday());
+
+  const changeViewMode = (mode: 'month' | 'week') => {
+    setViewMode(mode);
+    localStorage.setItem('adminDashboardViewMode', mode);
+  };
+
+  // Bei Wochenwechsel auch den Monat mitführen, damit die Mitarbeiter-Detailansicht
+  // (monatsbasiert) zum betrachteten Zeitraum passt.
+  const handleWeekChange = (mondayIso: string) => {
+    setCurrentWeek(mondayIso);
+    setCurrentMonth(mondayIso.slice(0, 7));
+  };
 
   useEffect(() => {
     fetchReport();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentMonth, showHealthData, sollBasis]);
+  }, [viewMode, currentMonth, currentWeek, showHealthData, sollBasis]);
 
   useEffect(() => {
     // Re-fetch des offenen Mitarbeiters bei Monatswechsel. selectedEmployee ist
@@ -142,13 +160,14 @@ export default function AdminDashboard() {
     const seq = ++reportSeq.current;
     try {
       const hp = showHealthData ? '&include_health_data=true' : '';
-      const response = await apiClient.get(
-        `/admin/reports/monthly?month=${currentMonth}${hp}&soll_basis=${sollBasis}`,
-      );
+      const url = viewMode === 'week'
+        ? `/admin/reports/weekly?week_start=${currentWeek}${hp}&soll_basis=${sollBasis}`
+        : `/admin/reports/monthly?month=${currentMonth}${hp}&soll_basis=${sollBasis}`;
+      const response = await apiClient.get(url);
       if (seq !== reportSeq.current) return;
       setReport(response.data);
     } catch (error) {
-      if (seq === reportSeq.current) toast.error('Fehler beim Laden des Monatsberichts');
+      if (seq === reportSeq.current) toast.error('Fehler beim Laden des Berichts');
     } finally {
       if (seq === reportSeq.current) setLoading(false);
     }
@@ -481,21 +500,49 @@ export default function AdminDashboard() {
 
         <div className="bg-white rounded-xl shadow-xs border border-gray-200 p-6">
           <div className="flex items-center justify-between mb-2">
-            <h3 className="text-sm font-medium text-gray-600">Monat</h3>
+            <h3 className="text-sm font-medium text-gray-600">{viewMode === 'week' ? 'Woche' : 'Monat'}</h3>
             <Clock className="text-primary" size={24} />
           </div>
           <p className="text-xl font-bold text-gray-900">
-            {format(new Date(currentMonth + '-01T00:00:00'), 'MMMM yyyy')}
+            {viewMode === 'week'
+              ? weekLabel(currentWeek)
+              : format(new Date(currentMonth + '-01T00:00:00'), 'MMMM yyyy')}
           </p>
         </div>
       </div>
 
-      {/* Month Selector */}
-      <MonthSelector
-        value={currentMonth}
-        onChange={setCurrentMonth}
-        className="mb-6"
-      />
+      {/* Period selector: Monat ↔ Woche umschalten (#329) */}
+      <div className="flex items-center gap-3 mb-6 flex-wrap">
+        <div
+          className="inline-flex rounded-xl border border-gray-300 overflow-hidden"
+          role="group"
+          aria-label="Zeitraum-Ansicht"
+        >
+          <button
+            onClick={() => changeViewMode('month')}
+            aria-pressed={viewMode === 'month'}
+            className={`px-4 py-2 text-sm font-medium transition ${
+              viewMode === 'month' ? 'bg-primary text-white' : 'bg-white text-gray-700 hover:bg-muted'
+            }`}
+          >
+            Monat
+          </button>
+          <button
+            onClick={() => changeViewMode('week')}
+            aria-pressed={viewMode === 'week'}
+            className={`px-4 py-2 text-sm font-medium transition ${
+              viewMode === 'week' ? 'bg-primary text-white' : 'bg-white text-gray-700 hover:bg-muted'
+            }`}
+          >
+            Woche
+          </button>
+        </div>
+        {viewMode === 'week' ? (
+          <WeekSelector value={currentWeek} onChange={handleWeekChange} />
+        ) : (
+          <MonthSelector value={currentMonth} onChange={setCurrentMonth} />
+        )}
+      </div>
 
       {/* Filter Input */}
       <div className="bg-white rounded-xl shadow-xs border border-gray-200 p-4 mb-4">
@@ -516,18 +563,18 @@ export default function AdminDashboard() {
       {/* Employee Table */}
       <div className="bg-white rounded-xl shadow-xs border border-gray-200 overflow-hidden">
         <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between gap-4 flex-wrap">
-          <h2 className="text-lg font-semibold">Monatsübersicht</h2>
-          {/* #313: Soll-Basis umschalten — bis heute (kein Monatsanfangs-Minus) oder voller Monat. */}
+          <h2 className="text-lg font-semibold">{viewMode === 'week' ? 'Wochenübersicht' : 'Monatsübersicht'}</h2>
+          {/* #313: Soll-Basis umschalten — bis heute (kein Anfangs-Minus) oder voller Zeitraum. */}
           <label className="flex items-center gap-2 text-sm text-gray-600">
             Soll:
             <select
               value={sollBasis}
               onChange={(e) => setSollBasis(e.target.value as 'bis_heute' | 'monatsende')}
               className="rounded border-gray-300 text-sm py-1"
-              title="Soll nur bis zum letzten abgeschlossenen Arbeitstag oder für den vollen Monat"
+              title="Soll nur bis zum letzten abgeschlossenen Arbeitstag oder für den vollen Zeitraum"
             >
               <option value="bis_heute">bis heute</option>
-              <option value="monatsende">Monatsende</option>
+              <option value="monatsende">{viewMode === 'week' ? 'volle Woche' : 'Monatsende'}</option>
             </select>
           </label>
           {/* DSGVO Art. 9: Krankheitstage nur auf ausdrücklichen Opt-in zeigen


### PR DESCRIPTION
## Kundenwunsch (#329, philvdb)

Eine **Wochenansicht** im Admin-Dashboard zusätzlich zur Monatsansicht — für eine schnelle Plausibilitätsübersicht (wer hat zu viel/zu wenig gearbeitet), die in der Monatsansicht verschwimmt. Gleiche Spalten, Umschalter neben dem Zeitraum-Selektor, „Juni 2026" wird zu „22.–28.06.2026 (KW 26)", vor-/zurück-Blättern wie bei den Monaten. Auswahl persistiert pro Frontend-User.

## Umsetzung

**Backend**
- `date_filters.date_in_range()` — inklusiver, sargabler `[start,end]`-Filter.
- `calculation_service.get_range_target()` / `get_range_actual()` — Soll/Ist über einen beliebigen Datumsbereich mit identischer Per-Tag-Logik (Wochenende, Feiertage, Soll-mindernde Abwesenheiten, Beschäftigungsfenster #193/#195, Sondertage #146, #313-Cutoff). Eine Kalenderwoche darf Monats-/Jahresgrenzen überschreiten. `get_monthly_target`/`get_monthly_actual` **delegieren** jetzt an die Range-Variante → eine Quelle der Wahrheit.
- `GET /api/admin/reports/weekly` — gleiches Response-Schema wie `/monthly` (Tabelle 1:1 wiederverwendbar). ISO-Woche Mo–So, `week_start` wird auf den Montag normalisiert. Überstunden-Spalte = kumulativer laufender Saldo zum Wochenende. Gleicher DSGVO-Audit-Log wie `/monthly`.

**Frontend**
- `WeekSelector.tsx` (spiegelt `MonthSelector`), Label „22.–28.06.2026 (KW 26)", monatsübergreifend mit beiden Monaten.
- `AdminDashboard`: Segmented-Toggle „Monat | Woche", Wochen-Fetch, Stat-Card/Tabellen-Überschrift/Soll-Label dynamisch, **localStorage**-Persistenz (Default Monat → Bestandsnutzer unverändert).

## Verifikation

- **Backend:** 8 Range-Helper-Tests + 6 Weekly-Endpoint-Tests (je RED→GREEN); volle Unit-Suite grün; **497 Consumer-Tests** des Calc-Refactors (dashboard/overtime/ytd/journal/year_closing/vacation/reports/carryover) ohne Regression.
- **Frontend:** 4 `WeekSelector`-Vitest-Tests, `tsc --noEmit` + Prod-Build clean.
- **Live:** Endpoint 200 (beide `soll_basis`), invalides Datum → 400; UI-Screenshot bestätigt Toggle + Wochen-Selektor + „Wochenübersicht" + korrekte Wochendaten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
