### PR TITLE
feat(#330): Schichtplaner zeigt zugewiesene vs. Wochenarbeitszeit je MA

### DIFF
--- a/frontend/src/components/shiftplanning/SlotDialog.tsx
+++ b/frontend/src/components/shiftplanning/SlotDialog.tsx
@@ -11,6 +11,7 @@ export interface SlotEmployee {
   id: string;
   first_name: string;
   last_name: string;
+  weekly_hours?: number; // #330: contract weekly hours, for the assigned-vs-contract badge
 }
 
 export interface SlotDialogInitial {

--- a/frontend/src/components/shiftplanning/employeeLoad.test.ts
+++ b/frontend/src/components/shiftplanning/employeeLoad.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { assignedMinutesByUser, formatLoad, loadColor } from './employeeLoad';
+import type { ShiftSlot } from '../../api/shiftPlanning';
+
+function slot(partial: Partial<ShiftSlot> & { start_time: string; end_time: string; assignments: { user_id: string }[] }): ShiftSlot {
+  return {
+    id: Math.random().toString(),
+    workstation_id: 'ws',
+    workstation_name: null,
+    color: null,
+    weekday: 0,
+    min_staff: 1,
+    understaffed: false,
+    ...partial,
+    assignments: partial.assignments.map((a, i) => ({ id: String(i), user_name: 'X', ...a })),
+  } as ShiftSlot;
+}
+
+describe('assignedMinutesByUser', () => {
+  it('sums slot durations per assigned user across the plan', () => {
+    const slots = [
+      slot({ start_time: '08:00', end_time: '12:00', assignments: [{ user_id: 'a' }, { user_id: 'b' }] }), // 240 min
+      slot({ start_time: '13:00', end_time: '16:00', assignments: [{ user_id: 'a' }] }),                    // 180 min
+    ];
+    const m = assignedMinutesByUser(slots);
+    expect(m.get('a')).toBe(420); // 4h + 3h
+    expect(m.get('b')).toBe(240); // 4h
+    expect(m.get('c')).toBeUndefined();
+  });
+
+  it('ignores zero/negative-duration slots', () => {
+    const m = assignedMinutesByUser([slot({ start_time: '10:00', end_time: '10:00', assignments: [{ user_id: 'a' }] })]);
+    expect(m.get('a')).toBeUndefined();
+  });
+});
+
+describe('formatLoad', () => {
+  it('formats as "assigned / contract h" with German decimal comma', () => {
+    expect(formatLoad(915, 17)).toBe('15,25 / 17 h'); // 915 min = 15.25h
+    expect(formatLoad(0, 40)).toBe('0 / 40 h');
+    expect(formatLoad(630, 10.5)).toBe('10,5 / 10,5 h'); // 630 min = 10.5h
+  });
+});
+
+describe('loadColor', () => {
+  it('green within ±30 min of the contract', () => {
+    expect(loadColor(17 * 60, 17)).toBe('green');        // exact
+    expect(loadColor(17 * 60 + 30, 17)).toBe('green');   // +30 min
+    expect(loadColor(17 * 60 - 30, 17)).toBe('green');   // −30 min
+  });
+  it('yellow within ±1 h', () => {
+    expect(loadColor(17 * 60 + 45, 17)).toBe('yellow');
+    expect(loadColor(17 * 60 - 60, 17)).toBe('yellow');
+  });
+  it('red beyond ±1 h', () => {
+    expect(loadColor(17 * 60 + 61, 17)).toBe('red');
+    expect(loadColor(0, 17)).toBe('red');
+  });
+  it('neutral when there is no contract', () => {
+    expect(loadColor(240, 0)).toBe('neutral');
+  });
+});

--- a/frontend/src/components/shiftplanning/employeeLoad.ts
+++ b/frontend/src/components/shiftplanning/employeeLoad.ts
@@ -1,0 +1,44 @@
+import type { ShiftSlot } from '../../api/shiftPlanning';
+import { timeToMinutes } from './weekGridUtils';
+
+/**
+ * #330: assigned slot minutes per user across a plan's weekly template.
+ * Each slot occurs once per week, so the sum is the weekly assigned time.
+ */
+export function assignedMinutesByUser(slots: ShiftSlot[]): Map<string, number> {
+  const byUser = new Map<string, number>();
+  for (const slot of slots) {
+    const duration = timeToMinutes(slot.end_time) - timeToMinutes(slot.start_time);
+    if (duration <= 0) continue;
+    for (const a of slot.assignments) {
+      byUser.set(a.user_id, (byUser.get(a.user_id) ?? 0) + duration);
+    }
+  }
+  return byUser;
+}
+
+/** German number: comma decimal, up to 2 decimals, trailing zeros trimmed. */
+function fmtHours(h: number): string {
+  const rounded = Math.round(h * 100) / 100;
+  return rounded.toFixed(2).replace(/\.?0+$/, '').replace('.', ',');
+}
+
+/** #330 display: e.g. "15,25 / 17 h" (assigned / contract). */
+export function formatLoad(assignedMinutes: number, weeklyHours: number): string {
+  return `${fmtHours(assignedMinutes / 60)} / ${fmtHours(weeklyHours)} h`;
+}
+
+export type LoadColor = 'green' | 'yellow' | 'red' | 'neutral';
+
+/**
+ * #330 colour gimmick: green within ±30 min of the contract weekly hours,
+ * yellow within ±1 h, red beyond. `neutral` when no contract (weekly_hours 0)
+ * — colouring an undefined target would be meaningless.
+ */
+export function loadColor(assignedMinutes: number, weeklyHours: number): LoadColor {
+  if (!weeklyHours || weeklyHours <= 0) return 'neutral';
+  const diffMinutes = Math.abs(assignedMinutes - weeklyHours * 60);
+  if (diffMinutes <= 30) return 'green';
+  if (diffMinutes <= 60) return 'yellow';
+  return 'red';
+}

--- a/frontend/src/pages/admin/ShiftPlanning.tsx
+++ b/frontend/src/pages/admin/ShiftPlanning.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import {
   DndContext,
   PointerSensor,
@@ -47,12 +47,21 @@ import {
 } from '../../components/shiftplanning/weekGridUtils';
 import * as api from '../../api/shiftPlanning';
 import type { Location, Workstation, PlanSummary, PlanDetail, ShiftSlot, SlotInput } from '../../api/shiftPlanning';
+import { assignedMinutesByUser, formatLoad, loadColor } from '../../components/shiftplanning/employeeLoad';
 
-function DraggableEmployee({ emp }: { emp: SlotEmployee }) {
+function DraggableEmployee({ emp, assignedMinutes }: { emp: SlotEmployee; assignedMinutes: number }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: `emp-${emp.id}`,
     data: { type: 'employee', userId: emp.id },
   });
+  // #330: zugewiesene Schichtstunden (dieser Plan) vs. Wochenarbeitszeit.
+  const weekly = emp.weekly_hours ?? 0;
+  const color = loadColor(assignedMinutes, weekly);
+  const loadClass =
+    color === 'green' ? 'text-green-600'
+    : color === 'yellow' ? 'text-amber-600'
+    : color === 'red' ? 'text-red-600'
+    : 'text-gray-400';
   return (
     <div
       ref={setNodeRef}
@@ -64,8 +73,13 @@ function DraggableEmployee({ emp }: { emp: SlotEmployee }) {
       {...listeners}
       {...attributes}
     >
-      <GripVertical size={14} className="text-gray-300" />
-      {emp.first_name} {emp.last_name}
+      <GripVertical size={14} className="text-gray-300 shrink-0" />
+      <div className="min-w-0">
+        <div className="truncate">{emp.first_name} {emp.last_name}</div>
+        <div className={`text-xs ${loadClass}`} title="Zugewiesene Schichtstunden in diesem Plan / Wochenarbeitszeit">
+          {formatLoad(assignedMinutes, weekly)}
+        </div>
+      </div>
     </div>
   );
 }
@@ -97,6 +111,13 @@ export default function AdminShiftPlanning() {
   const [shiftView, setShiftView] = useState<'week' | 'day'>('week');
   const [dayWeekday, setDayWeekday] = useState(0);
 
+  // #330: zugewiesene Minuten je MA für den aktuell offenen Plan — aktualisiert
+  // sich automatisch, sobald sich planDetail (nach Zuweisung) ändert.
+  const assignedByUser = useMemo(
+    () => assignedMinutesByUser(planDetail?.slots ?? []),
+    [planDetail],
+  );
+
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
 
   const loadStations = useCallback(async () => {
@@ -123,7 +144,7 @@ export default function AdminShiftPlanning() {
       setEmployees(
         res.data
           .filter((u: any) => u.is_active && !u.is_hidden)
-          .map((u: any) => ({ id: u.id, first_name: u.first_name, last_name: u.last_name })),
+          .map((u: any) => ({ id: u.id, first_name: u.first_name, last_name: u.last_name, weekly_hours: u.weekly_hours })),
       );
     } catch {
       /* employees are optional for the grid; ignore */
@@ -540,7 +561,9 @@ export default function AdminShiftPlanning() {
                       {employees.length === 0 ? (
                         <p className="text-xs text-gray-400">Keine Mitarbeiter.</p>
                       ) : (
-                        employees.map((emp) => <DraggableEmployee key={emp.id} emp={emp} />)
+                        employees.map((emp) => (
+                          <DraggableEmployee key={emp.id} emp={emp} assignedMinutes={assignedByUser.get(emp.id) ?? 0} />
+                        ))
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
## Kundenwunsch (#330, philvdb)

In der Mitarbeiterliste rechts im Schichtplaner sollen die **aktuell zugewiesenen Stunden** und die **Wochenarbeitszeit** direkt sichtbar sein — eine zweite Zeile unter dem Namen, z. B. „15,25 / 17 h". Optional farbcodiert (grün ±30 min, gelb ±1 h, rot weiter weg). Erleichtert die Einteilung sehr.

## Umsetzung (rein Frontend)

Die zugewiesenen Stunden ergeben sich aus den bereits geladenen Plan-Slots (Summe der Slot-Dauer je zugewiesenem MA) — **kein Backend-Call nötig**. Die Wochenarbeitszeit kommt aus `/admin/users` (`weekly_hours`).

- `employeeLoad.ts` (testbar): `assignedMinutesByUser(slots)`, `formatLoad()` → „15,25 / 17 h" (dt. Dezimalkomma), `loadColor()` → grün ±30 min, gelb ±1 h, rot darüber, `neutral` ohne Vertrag.
- `SlotEmployee` um `weekly_hours` erweitert; `loadEmployees` mappt es.
- `DraggableEmployee`: zweite Zeile mit farbiger Last-Anzeige; aktualisiert sich **live** über `useMemo(planDetail)` nach jeder Zuweisung.

## Verifikation

- 7 `employeeLoad`-Unit-Tests (RED→GREEN); volle Vitest-Suite grün (143 Tests); `tsc --noEmit` clean.
- **Live-Screenshot** im Schichtplaner: „Azu Bine 40 / 40 h" (grün, voll ausgelastet), „Repro Test 8 / 40 h" (rot, nur Montag), korrektes Format + Farben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
