### PR TITLE
chore: Review-Fixes (#329/#330) + Doku-Aktualisierung der letzten Neuerungen

### DIFF
--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -102,6 +102,7 @@ def get_monthly_report(
         # Get vacation and sick hours for the month (F-033: sargable)
         vacation_absences = db.query(Absence).filter(
             Absence.user_id == user.id,
+            Absence.tenant_id == current_user.tenant_id,  # F-026 belt-and-suspenders
             Absence.type == AbsenceType.VACATION,
             date_in_month(Absence.date, year, month_num),
         ).all()
@@ -109,6 +110,7 @@ def get_monthly_report(
 
         sick_absences = db.query(Absence).filter(
             Absence.user_id == user.id,
+            Absence.tenant_id == current_user.tenant_id,  # F-026 belt-and-suspenders
             Absence.type == AbsenceType.SICK,
             date_in_month(Absence.date, year, month_num),
         ).all()
@@ -215,19 +217,28 @@ def get_weekly_report(
             db, user, wk_end.year, wk_end.month, cutoff_date=ot_cutoff
         )
 
-        # Urlaub/Krank in der Woche (F-033: sargable range)
+        # Urlaub/Krank in der Woche (F-033: sargable range). Bei soll_basis=bis_heute
+        # denselben Cutoff wie Soll/Ist anwenden, damit die Tage-Spalten nicht eine
+        # für die laufende Woche vorausgebuchte Abwesenheit zählen, die das (gekappte)
+        # Soll/Ist gar nicht erfasst.
         vacation_absences = db.query(Absence).filter(
             Absence.user_id == user.id,
+            Absence.tenant_id == current_user.tenant_id,  # F-026 belt-and-suspenders
             Absence.type == AbsenceType.VACATION,
             date_in_range(Absence.date, wk_start, wk_end),
         ).all()
+        if cutoff is not None:
+            vacation_absences = [a for a in vacation_absences if a.date <= cutoff]
         vacation_hours = sum(float(a.hours) for a in vacation_absences)
 
         sick_absences = db.query(Absence).filter(
             Absence.user_id == user.id,
+            Absence.tenant_id == current_user.tenant_id,  # F-026 belt-and-suspenders
             Absence.type == AbsenceType.SICK,
             date_in_range(Absence.date, wk_start, wk_end),
         ).all()
+        if cutoff is not None:
+            sick_absences = [a for a in sick_absences if a.date <= cutoff]
         sick_hours = sum(float(a.hours) for a in sick_absences)
 
         # Tagesprinzip (§3 BUrlG, #156/#205): Urlaub/Krank tagebasiert zählen.

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -234,10 +234,19 @@ def get_range_target(
 
     absences = db.query(Absence).filter(
         Absence.user_id == user.id,
+        Absence.tenant_id == user.tenant_id,  # F-026 belt-and-suspenders
         date_in_range(Absence.date, start, end),
         Absence.type.notin_([AbsenceType.TRAINING, AbsenceType.SICK, AbsenceType.OVERTIME]),
     ).all()
     absence_dates = {a.date for a in absences}
+
+    # Preload the user's WorkingHoursChange rows ONCE and resolve the per-day
+    # weekly hours in memory (avoids one SELECT per day — N+1 — for a multi-day
+    # range; mirrors get_overtime_account). F-026: tenant-scoped.
+    wh_changes = db.query(WorkingHoursChange).filter(
+        WorkingHoursChange.user_id == user.id,
+        WorkingHoursChange.tenant_id == user.tenant_id,
+    ).order_by(WorkingHoursChange.effective_from).all()
 
     # #146: special-day config can differ per year (a week may cross Dec/Jan).
     _special_cfg_cache: dict = {}
@@ -269,7 +278,7 @@ def get_range_target(
             d += timedelta(days=1)
             continue
 
-        weekly_hours = get_weekly_hours_for_date(db, user, d)
+        weekly_hours = get_weekly_hours_for_date(db, user, d, wh_changes=wh_changes)
         daily_target = get_daily_target_for_date(user, d, weekly_hours)
 
         # #146: apply the special-day rule (after weekend/holiday/absence so we

--- a/backend/tests/test_weekly_report.py
+++ b/backend/tests/test_weekly_report.py
@@ -12,7 +12,8 @@ from fastapi.testclient import TestClient
 
 from app.database import get_db
 from app.middleware.auth import get_current_user, require_admin
-from app.models import TimeEntry, Absence, AbsenceType
+from app.models import TimeEntry, Absence, AbsenceType, User, UserRole, TimeEntryAuditLog
+from app.services import auth_service
 from tests.conftest import DEFAULT_TENANT_ID
 
 
@@ -129,6 +130,47 @@ def test_weekly_report_sick_masked_without_flag(db, test_user, test_admin):
         assert _row(r1, test_user)["sick_days"] == 0.0   # DSGVO Art. 9
         r2 = client.get(f"/api/admin/reports/weekly?week_start={WK_MON.isoformat()}&include_health_data=true")
         assert _row(r2, test_user)["sick_days"] == pytest.approx(1.0)
+    finally:
+        _app.dependency_overrides.clear()
+
+
+def test_weekly_report_respects_employment_window(db, test_admin):
+    # #193: a mid-week start (first_work_day = Wed 03.06.) means the week's Soll
+    # only counts Wed–Fri, not Mon/Tue before the employee started.
+    emp = User(
+        username="midweek", email="midweek@x.de",
+        password_hash=auth_service.hash_password("test123"),
+        first_name="Mid", last_name="Week", role=UserRole.EMPLOYEE,
+        weekly_hours=40.0, work_days_per_week=5, is_active=True, track_hours=True,
+        first_work_day=date(2026, 6, 3), tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(emp)
+    db.commit()
+    try:
+        client = _client(db, test_admin)
+        r = client.get(f"/api/admin/reports/weekly?week_start={WK_MON.isoformat()}&soll_basis=monatsende")
+        assert r.status_code == 200, r.text
+        assert _row(r, emp)["target_hours"] == 24.0  # Wed/Thu/Fri only
+    finally:
+        _app.dependency_overrides.clear()
+
+
+def test_weekly_report_health_data_writes_audit_log(db, test_user, test_admin):
+    # DSGVO Art. 9: reading sick data with include_health_data must persist a
+    # health_data_read audit entry (L-2 pattern, committed only on success).
+    db.add(Absence(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID, date=date(2026, 6, 3),
+                   type=AbsenceType.SICK, hours=8.0))
+    db.commit()
+    try:
+        client = _client(db, test_admin)
+        r = client.get(f"/api/admin/reports/weekly?week_start={WK_MON.isoformat()}&include_health_data=true")
+        assert r.status_code == 200, r.text
+        log = db.query(TimeEntryAuditLog).filter(
+            TimeEntryAuditLog.action == "health_data_read",
+            TimeEntryAuditLog.source == "dsgvo",
+        ).first()
+        assert log is not None
+        assert "Wochenreport" in (log.new_note or "")
     finally:
         _app.dependency_overrides.clear()
 

--- a/docs/SCHICHTPLANUNG.md
+++ b/docs/SCHICHTPLANUNG.md
@@ -77,6 +77,8 @@ Technisch steuert das tenant-weite Setting `shift_planning_enabled` (Default
 
 **Schicht kopieren (#322):** Beim **Bearbeiten** eines Slots gibt es **„Auf Wochentage kopieren"**: Wochentage anwählen → der Slot (Arbeitsplatz, Zeit, Mindestbesetzung **und** Zuweisungen) wird auf den gewählten Tagen zusätzlich angelegt — spart das wiederholte Eintippen wiederkehrender Schichten.
 
+**Auslastungsanzeige (#330):** In der Mitarbeiterliste des Editors steht unter jedem Namen die **Auslastung** — zugewiesene Schichtstunden (dieses Plans) zur Wochenarbeitszeit, z. B. **„15,25 / 17 h"**. Die Farbe signalisiert die Passung zur Vertragszeit: **grün** bei ±30 Minuten, **gelb** bei ±1 Stunde, sonst **rot** (ohne hinterlegte Wochenarbeitszeit bleibt die Anzeige neutral). Das erleichtert eine ausgewogene Einteilung.
+
 ## Bedienung (Mitarbeitende)
 
 - **Schichtplan** (Menü): aktive Wochenpläne als Übersicht ansehen (nur lesen).

--- a/docs/handbuch/CHEATSHEET-ADMIN.md
+++ b/docs/handbuch/CHEATSHEET-ADMIN.md
@@ -27,6 +27,8 @@
 
 > **Benutzerübersicht (#194)** zeigt je MA Urlaubskonto **und** aktuellen Überstundensaldo in der Spalte **„Überstunden (JTD)"**; „—" bei Mitarbeitern ohne Stundenzählung.
 
+> **Monatsjournal (#311):** Buch-Symbol in der Aktionsspalte öffnet das Journal; Überschrift jetzt **„Monatsjournal: Vorname Nachname"**.
+
 ### Stundenzählung an/aus (#191)
 
 Checkbox **„Stundenzählung aktiv"** (Standard an). Aus = **Mitarbeiter ohne Stundenzählung** (NIE „leitende Angestellte" nennen!).
@@ -68,6 +70,9 @@ Pro MA je Wochentag (Mo–Fr) optionaler **Soll-Beginn / Soll-Ende** (Bereich �
 | **Krank** | Kranktage im Monat |
 
 Klick auf Pfeil → Detailansicht des Mitarbeiters
+
+**Monat ↔ Woche (#329):** Umschalter „Monat / Woche" oben → Wochenansicht zeigt die KW (z. B. „22.–28.06.2026 (KW 26)"), Pfeile blättern wochenweise. Auswahl bleibt pro Browser/Gerät gespeichert.
+**Soll-Basis (#313):** Dropdown „Soll: bis heute / Monatsende (volle Woche)". „bis heute" (Standard) zählt Soll nur bis zum letzten abgeschlossenen Arbeitstag → kein Monatsanfangs-Minus. Nur Live-Anzeigen; Datei-Exporte bleiben voller Monat.
 
 ---
 
@@ -128,6 +133,8 @@ Jeder Bereich hat einen eigenen **Speichern**-Button.
 | **Pflicht-Pause-Ausnahme** | Genehmigungspflicht für §4-Ausnahmen (s. o.) |
 | **Soll-Arbeitszeit-Fenster** | Puffer (Min.) für Soll-Zeiten, Default 15 (s. o.) |
 | **Onboarding / Willkommens-Tour** | Erst-Login-Tour für neue Nutzer an/aus (Standard **an**) |
+| **Eigene Abwesenheitsgründe** | Bezeichnung + Farbe + Basis-Verhalten (#312) – s. u. |
+| **Betriebsferien & Urlaub** | „Überzählige Betriebsferien als Überstundenabbau" (#314, Standard aus – s. Betriebsferien) |
 | **Farben** | Farbe je An-/Abwesenheitstyp |
 
 ### Sondertage 24./31.12. (#188)
@@ -141,6 +148,18 @@ Heiligabend + Silvester sind **keine** gesetzlichen Feiertage → pro Tag getren
 | **Frei** | Tagessoll 0 (wie Feiertag) | **grau** |
 
 Bei „Frei" zusätzlich **Anrechnung:** Urlaub (vom Konto) oder Bezahlte Freistellung (kein Abzug). Wirkt auf Soll, Urlaubskonto und Kalender.
+
+### Eigene Abwesenheitsgründe (#312)
+
+Frei benannte Gründe (z. B. „Schule" für Azubis) mit Farbe + **Basis-Verhalten** (nach Anlegen **fix**):
+
+| Basis-Verhalten | Wirkung |
+|-----------------|---------|
+| **zählt als gearbeitet** | Stunden als Arbeitszeit gutgeschrieben (wie Fortbildung) |
+| **bezahlt frei** | Tagessoll 0, **kein** Urlaubsabzug |
+| **Überstundenabbau** | Überstundenkonto sinkt um Tagessoll |
+
+Erscheinen beim Buchen unter „Eigene Gründe". Im Team-Kalender für Kolleg:innen als **„abwesend"** maskiert (Datenschutz); nur Admins sehen die Bezeichnung. Deaktivierbar.
 
 ---
 
@@ -264,6 +283,9 @@ Pause nicht eingehalten? Statt Blockade → Eintrag mit **Pflicht-Begründung** 
 - **Plan:** beliebig viele Wochenpläne; Slots per Drag & Drop / Klick, Mitarbeitende auf Slot ziehen, Mindestbesetzung optional.
 - **Aktiv schalten** → für alle sichtbar (mehrere Pläne gleichzeitig aktiv möglich).
 - **Einweisungen:** Matrix MA × Arbeitsplätze; nicht eingewiesene Zuweisung → weiche Warnung (blockiert nicht). MA sehen ihre Einweisungen im Profil.
+- **KW-/Jahresplanung (#305 M2):** pro Plan optionales Aktiv-Datums-Fenster („von/bis") + Jahres-Zeitstrahl. **Automatisch füllen** verteilt eingewiesene, verfügbare MA greedy auf die Slots (Zielwoche, ausgewogen nach Auslastung/Überstunden) → Entwurf, aktiviert den Plan **nicht**.
+- **Woche/Tag-Umschalter** (#321); im Slot-Dialog **„Auf Wochentage kopieren"** → Schicht inkl. Zuweisungen auf weitere Tage (#322).
+- **Auslastung (#330):** unter jedem Namen „zugewiesene Std / Wochenarbeitszeit" (z. B. „15,25 / 17 h") – grün ±30 Min, gelb ±1 Std, sonst rot.
 - Reines Planungswerkzeug – **keine** Wirkung auf Zeiterfassung/ArbZG/Urlaub/Überstunden. Details: `docs/SCHICHTPLANUNG.md`.
 
 ---

--- a/docs/handbuch/CHEATSHEET-MITARBEITER.md
+++ b/docs/handbuch/CHEATSHEET-MITARBEITER.md
@@ -104,6 +104,8 @@ Zurückziehen: Button **Zurückziehen** bei offenen Anträgen
 | Zeitraum | Checkbox „Zeitraum" + Enddatum |
 | Speichern | Wochenenden/Feiertage werden übersprungen |
 
+> **Eigene Gründe:** Richtet Ihre Praxis weitere Gründe ein (z. B. „Schule"), erscheinen sie bei „Typ wählen" unter **„Eigene Gründe"**.
+
 **Löschen:** Kalender-Eintrag anklicken → Löschen-Symbol
 
 ### Sondertage 24./31.12.

--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -88,6 +88,8 @@ Das Admin-Dashboard zeigt alle aktiven Mitarbeiter mit ihren aktuellen Monatsdat
 
 **Monat wechseln:** Mit den Pfeilen `<` und `>` wechseln Sie den angezeigten Monat.
 
+**Monat ↔ Woche umschalten (#329):** Über den Umschalter **„Monat / Woche"** oben neben dem Zeitraum wechseln Sie zwischen der Monats- und einer **Wochenansicht**. In der Wochenansicht steht statt „Juni 2026" die Kalenderwoche, z. B. **„22.–28.06.2026 (KW 26)"**; mit den Pfeilen blättern Sie wochenweise. Die Spalten sind dieselben wie im Monat. So erhalten Sie eine schnelle Plausibilitätsübersicht, wer zu viel oder zu wenig gearbeitet hat. Ihre Auswahl (Monat oder Woche) bleibt **pro Browser/Gerät** gespeichert. In der Wochenansicht heißt die zweite Option der Soll-Basis entsprechend **„volle Woche"** statt „Monatsende".
+
 **Soll-Basis umschalten (#313):** Über das Dropdown **„Soll: bis heute / Monatsende"** in der Monatsübersicht steuern Sie, wie das Monats-**Soll** gezählt wird:
 - **bis heute** (Standard): nur bis zum **letzten abgeschlossenen Arbeitstag** des laufenden Monats — so startet der Saldo nicht mit einem Monatsanfangs-Minus.
 - **Monatsende**: der **volle** Monat.
@@ -144,6 +146,8 @@ Die Liste zeigt alle aktiven Mitarbeiter mit:
 - **Urlaubskonto** (Budget, Genommen, Übrig – mit Ampelfarbe)
 
 **Filter:** Aktivieren Sie **„Inaktive anzeigen"** oder **„Ausgeblendete anzeigen"** um deaktivierte Mitarbeiter einzublenden.
+
+**Monatsjournal (#311):** Über das Buch-Symbol in der Aktionsspalte öffnen Sie das **Monatsjournal** des Mitarbeiters. Die Überschrift trägt jetzt den Namen der Person – **„Monatsjournal: Vorname Nachname"** –, damit beim Wechsel zwischen Mitarbeitern sofort klar ist, wessen Journal angezeigt wird.
 
 ### Neuen Mitarbeiter anlegen
 
@@ -440,7 +444,7 @@ Navigieren Sie zu **Abwesenheiten → Tab „Betriebsferien"** und klicken Sie a
 
 > **Tipp – nachträglich Berechtigte ergänzen:** Aktivieren Sie die Option „Nimmt an Betriebsferien teil" bei einem Mitarbeiter und speichern Sie die Benutzer-Änderung. Die Abwesenheiten werden **automatisch** für alle laufenden und künftigen Betriebsferien nachgetragen – ein erneutes Speichern der Betriebsferien ist nicht mehr nötig, und bereits erfasste Arbeitszeiten bleiben erhalten. (Bereits abgelaufene Betriebsferien werden bewusst nicht rückwirkend ergänzt.)
 
-> **Betriebsferien länger als der Jahresurlaub (#314):** Sind die als Urlaub zählenden Betriebsferien länger als das Resturlaubs-Budget einer Mitarbeiterin, entstehen standardmäßig **Minus-Urlaubstage**. Unter **Einstellungen → „Betriebsferien & Urlaub"** können Sie die Option **„Überzählige Betriebsferien als Überstundenabbau"** aktivieren: Dann wird zuerst der Urlaub aufgezehrt und die überzähligen Tage werden als **Überstundenausgleich** gebucht (das Überstundenkonto darf dabei ins Minus gehen) – statt Minus-Urlaub. Die Option ist global und standardmäßig deaktiviert.
+> **Betriebsferien länger als der Jahresurlaub (#314):** Sind die als Urlaub zählenden Betriebsferien länger als das Resturlaubs-Budget einer Mitarbeiterin, entstehen standardmäßig **Minus-Urlaubstage**. Unter **Einstellungen → „Betriebsferien & Urlaub"** können Sie die Option **„Überzählige Betriebsferien als Überstundenabbau"** aktivieren: Dann wird zuerst der Urlaub aufgezehrt und die überzähligen Tage werden als **Überstundenausgleich** gebucht (das Überstundenkonto darf dabei ins Minus gehen) – statt Minus-Urlaub. Die Option ist global und standardmäßig deaktiviert. **Wichtig:** Der Schalter wirkt **beim Anlegen bzw. erneuten Speichern** von Betriebsferien – für **bereits eingetragene** Betriebsferien öffnen Sie diese einmal und speichern erneut.
 
 ### Betriebsferien löschen
 
@@ -860,6 +864,15 @@ nicht); Mitarbeitende sehen ihre Einweisungen im Profil.
 Zeitstrahl). **Automatisch füllen** verteilt eingewiesene, verfügbare
 Mitarbeitende greedy auf die Slots (Zielwoche wählbar, ausgewogen nach
 Auslastung/Überstunden) — als Entwurf zum Review, ohne den Plan zu aktivieren.
+
+Mit dem **Woche/Tag**-Umschalter im Editor zeigen Sie wahlweise die ganze Woche
+oder einen einzelnen Wochentag in voller Breite an (#321). Beim **Bearbeiten**
+eines Slots kopiert **„Auf Wochentage kopieren"** die Schicht inkl. Zuweisungen
+auf weitere Wochentage – praktisch für wiederkehrende Schichten (#322). In der
+Mitarbeiterliste des Editors steht unter jedem Namen die **Auslastung** der
+zugewiesenen Schichtstunden zur Wochenarbeitszeit (z. B. **„15,25 / 17 h"**):
+grün bei ±30 Minuten zur Vertragszeit, gelb bei ±1 Stunde, sonst rot – das
+erleichtert eine ausgewogene Einteilung (#330).
 Details: [`docs/SCHICHTPLANUNG.md`](../SCHICHTPLANUNG.md).
 
 ---

--- a/docs/handbuch/HANDBUCH-MITARBEITER.md
+++ b/docs/handbuch/HANDBUCH-MITARBEITER.md
@@ -303,6 +303,8 @@ Klicken Sie auf **+ Abwesenheit eintragen**.
 | **Fortbildung** | Externe Schulungen, Seminare, Pflichtfortbildungen |
 | **Sonstiges** | Arzttermine, Behördengänge, sonstige Freistellungen |
 
+> **Eigene Gründe:** Hat Ihre Praxis zusätzliche Abwesenheitsgründe eingerichtet (z. B. „Schule"), erscheinen diese bei der Typ-Auswahl unter **„Eigene Gründe"**. Wählen Sie sie wie einen normalen Typ aus.
+
 > **Gut zu wissen – Kranktage und Stundensaldo:** Kranktage werden nach § 3 EntgFG als gearbeitete Stunden angerechnet (Soll-Stunden als Ist), sodass keine Minusstunden entstehen.
 
 ---

--- a/frontend/src/components/DocViewer.tsx
+++ b/frontend/src/components/DocViewer.tsx
@@ -332,7 +332,7 @@ export const handbuchMitarbeiterSections: AccordionItem[] = [
     title: '7. Abwesenheiten eintragen',
     content: (
       <div className="space-y-2">
-        <p>Navigieren Sie zu <strong>Abwesenheiten</strong> und klicken Sie auf <strong>+ Abwesenheit eintragen</strong>. Wählen Sie den Typ (Urlaub, Krank, Fortbildung, Sonstiges) und das Datum.</p>
+        <p>Navigieren Sie zu <strong>Abwesenheiten</strong> und klicken Sie auf <strong>+ Abwesenheit eintragen</strong>. Wählen Sie den Typ (Urlaub, Krank, Fortbildung, Sonstiges) und das Datum. Hat Ihre Praxis zusätzliche Gründe eingerichtet (z. B. „Schule"), erscheinen diese in der Typ-Auswahl unter <strong>„Eigene Gründe"</strong>.</p>
         <p>Für Zeiträume aktivieren Sie die Checkbox <strong>„Zeitraum"</strong> und geben ein Enddatum an. Wochenenden und Feiertage werden automatisch ausgeschlossen.</p>
         <p>Hat Ihre Praxis <strong>Heiligabend (24.12.)</strong> oder <strong>Silvester (31.12.)</strong> als arbeitsfrei oder halben Tag eingestellt, sind diese Tage im Kalender entsprechend markiert: grau „Heiligabend (frei)" bzw. amber „Silvester (½ Tag)" – ähnlich einem Feiertag.</p>
         <p>Wenn Urlaubsgenehmigungspflicht aktiv ist, wechselt die App nach dem Absenden automatisch zum Tab <strong>„Meine Anträge"</strong>.</p>
@@ -389,7 +389,8 @@ export const handbuchAdminSections: AccordionItem[] = [
     content: (
       <div className="space-y-2">
         <p>Das <strong>Admin-Dashboard</strong> zeigt alle aktiven Mitarbeiter mit Soll, Ist, Saldo (H:MM), kumulierten Überstunden, verbleibenden Urlaubstagen und Kranktagen für den gewählten Monat.</p>
-        <p>Das Dropdown <strong>„Soll: bis heute / Monatsende"</strong> schaltet die Soll-Basis um: <strong>bis heute</strong> (Standard) zählt das Soll des laufenden Monats nur bis zum letzten abgeschlossenen Arbeitstag (kein Monatsanfangs-Minus), <strong>Monatsende</strong> den vollen Monat. Für abgeschlossene Monate identisch; die §16-Datei-Exporte bleiben voll-Monat.</p>
+        <p>Mit dem Umschalter <strong>„Monat / Woche"</strong> oben wechseln Sie zwischen Monats- und <strong>Wochenansicht</strong>. In der Wochenansicht steht statt „Juni 2026" die Kalenderwoche (z. B. <em>„22.–28.06.2026 (KW 26)"</em>); die Pfeile blättern wochenweise. Gleiche Spalten wie im Monat – ideal für eine schnelle Plausibilitätsübersicht. Ihre Auswahl bleibt pro Browser/Gerät gespeichert.</p>
+        <p>Das Dropdown <strong>„Soll: bis heute / Monatsende"</strong> schaltet die Soll-Basis um: <strong>bis heute</strong> (Standard) zählt das Soll des laufenden Monats nur bis zum letzten abgeschlossenen Arbeitstag (kein Monatsanfangs-Minus), <strong>Monatsende</strong> den vollen Monat. Für abgeschlossene Monate identisch; die §16-Datei-Exporte bleiben voll-Monat. In der Wochenansicht heißt die zweite Option entsprechend <strong>„volle Woche"</strong>.</p>
         <p>Klicken Sie auf den Pfeil am Ende einer Zeile für die Detailansicht. Nutzen Sie die Suche zum Filtern nach Name.</p>
       </div>
     ),
@@ -404,6 +405,7 @@ export const handbuchAdminSections: AccordionItem[] = [
         <p className="text-amber-700">⚠️ Bei <strong>unterjährigem Eintritt</strong> (nicht seit 1. Januar im System) den „Ersten Arbeitstag" unbedingt setzen – sonst zählt das Soll auch Tage vor dem Eintritt und es entstehen Phantom-Minusstunden.</p>
         <p><strong>Soll-Arbeitszeiten (Arbeitszeit-Fenster):</strong> Im Benutzerformular können Sie pro MA und Wochentag Soll-Beginn und Soll-Ende hinterlegen. Zeiten außerhalb des Fensters (abzüglich Puffer) werden nicht angerechnet; der gestempelte Rohwert bleibt gespeichert (§16). Der systemweite Puffer (Standard 15 Min.) ist unter <strong>Einstellungen → Arbeitszeit-Fenster Puffer</strong> konfigurierbar. Opt-in: ohne Soll-Zeiten kein Eingriff. MA mit deaktivierter Stundenzählung sind ausgenommen.</p>
         <p><strong>Kalenderfarbe:</strong> Im Benutzerformular können Sie die Kalenderfarbe aus einer Palette für jede:n Mitarbeiter:in vorgeben (Badge-Ring im Teamkalender); der/die Mitarbeiter:in kann sie auch selbst im Profil ändern.</p>
+        <p><strong>Monatsjournal:</strong> Das Buch-Symbol in der Aktionsspalte öffnet das Monatsjournal des/der Mitarbeitenden. Die Überschrift trägt den Namen – <strong>„Monatsjournal: Vorname Nachname"</strong> –, damit beim Wechsel zwischen Personen sofort klar ist, wessen Journal angezeigt wird.</p>
       </div>
     ),
   },
@@ -431,6 +433,7 @@ export const handbuchAdminSections: AccordionItem[] = [
       <div className="space-y-2">
         <p><strong>Urlaubsanträge:</strong> Toggle „Genehmigungspflicht" aktiviert den Workflow. Anträge erscheinen als „Offen" → Genehmigen (grün) oder Ablehnen (rot, optional Grund).</p>
         <p><strong>Betriebsferien:</strong> Abwesenheiten → Tab „Betriebsferien" → Neue Betriebsferien. Alle aktiven Mitarbeiter mit der Option „Nimmt an Betriebsferien teil" (Standard, rollenunabhängig) erhalten automatisch Abwesenheitseinträge (kein Urlaubsabzug); Tage außerhalb des Beschäftigungszeitraums (noch nicht eingetreten / bereits ausgetreten) werden übersprungen. Nachträglich Berechtigte: Option setzen – die Einträge werden automatisch für laufende und künftige Betriebsferien nachgetragen. Beim Löschen werden alle Einträge entfernt.</p>
+        <p className="text-gray-700"><strong>Betriebsferien länger als der Jahresurlaub:</strong> Sind als Urlaub zählende Betriebsferien länger als das Resturlaub-Budget, entstehen standardmäßig <strong>Minus-Urlaubstage</strong>. Unter <strong>Einstellungen → „Betriebsferien &amp; Urlaub"</strong> aktivieren Sie optional <strong>„Überzählige Betriebsferien als Überstundenabbau"</strong>: dann wird zuerst der Urlaub aufgezehrt und die überzähligen Tage werden als Überstundenausgleich gebucht (Konto darf ins Minus) – statt Minus-Urlaub. Global, Standard <strong>aus</strong>. Wirkt beim Anlegen/erneuten Speichern – für bestehende Betriebsferien einmal öffnen und neu speichern.</p>
         <p className="text-gray-700"><strong>Urlaubsberechnung (Tagesprinzip, §3 BUrlG):</strong> Urlaub wird nach Arbeitstagen geführt – ein freier Arbeitstag = <strong>1 Urlaubstag</strong>, unabhängig von Tagesstunden und Wochentag (auch bei individuellen Tagesstunden). Jahresanspruch anteilig: <code>30 × Arbeitstage ÷ 5</code> (überschreibbar beim Anlegen). Verbrauch wird tagebasiert gezählt, intern gespeicherte Stunden dienen nur der Soll-/Ist-Berechnung.</p>
       </div>
     ),
@@ -516,6 +519,7 @@ export const handbuchAdminSections: AccordionItem[] = [
         <p>Im Reiter <strong>Einweisungen</strong> legen Sie per Matrix (Mitarbeiter × Arbeitsplätze) fest, wer für welchen Arbeitsplatz <strong>eingewiesen</strong> ist. Weisen Sie eine nicht eingewiesene Person zu, erscheint die weiche Warnung <strong>„nicht eingewiesen"</strong> (blockiert nicht). Mitarbeitende sehen ihre Einweisungen in ihrem Profil.</p>
         <p>Über <strong>Bearbeiten</strong> setzen Sie pro Plan optional ein <strong>Aktiv-Datums-Fenster</strong> („von/bis") — der Plan wird dann im Zeitraum automatisch aktiv; die <strong>Jahresübersicht</strong> zeigt das als Zeitstrahl. Mit <strong>Automatisch füllen</strong> verteilt der Generator eingewiesene, an dem Tag verfügbare Mitarbeitende greedy auf die Slots (ausgewogen nach Auslastung/Überstunden) — als Entwurf zum Review; der Plan wird dabei nicht aktiviert.</p>
         <p>Der <strong>Woche/Tag</strong>-Umschalter zeigt wahlweise die ganze Woche oder einen einzelnen Wochentag in voller Breite. Beim Bearbeiten eines Slots kopiert <strong>„Auf Wochentage kopieren"</strong> denselben Slot (inkl. Zuweisungen) auf weitere Tage — praktisch für wiederkehrende Schichten.</p>
+        <p>In der Mitarbeiterliste des Editors steht unter jedem Namen die <strong>Auslastung</strong> – zugewiesene Schichtstunden zur Wochenarbeitszeit, z. B. <em>„15,25 / 17 h"</em>: grün bei ±30 Min. zur Vertragszeit, gelb bei ±1 Std., sonst rot. Das erleichtert eine ausgewogene Einteilung.</p>
         <p>Mit <strong>Aktiv schalten</strong> machen Sie einen Plan für alle sichtbar; <strong>mehrere Pläne können gleichzeitig aktiv</strong> sein. Mitarbeitende sehen ihre heutige Einteilung im Dashboard.</p>
         <p className="text-gray-500">Die Schichtplanung ist ein reines Planungswerkzeug und berührt <strong>nicht</strong> Zeiterfassung, Soll/Ist-Stunden, ArbZG-Prüfungen, Urlaub oder Überstunden. Details: <code>docs/SCHICHTPLANUNG.md</code>.</p>
       </div>

--- a/frontend/src/components/shiftplanning/employeeLoad.ts
+++ b/frontend/src/components/shiftplanning/employeeLoad.ts
@@ -8,6 +8,9 @@ import { timeToMinutes } from './weekGridUtils';
 export function assignedMinutesByUser(slots: ShiftSlot[]): Map<string, number> {
   const byUser = new Map<string, number>();
   for (const slot of slots) {
+    // Same-day slots only: the shift grid is bounded to GRID_START_HOUR..GRID_END_HOUR,
+    // so overnight slots (end < start) cannot be created via the UI. A non-positive
+    // duration is therefore treated as 0 (skipped), not wrapped past midnight.
     const duration = timeToMinutes(slot.end_time) - timeToMinutes(slot.start_time);
     if (duration <= 0) continue;
     for (const a of slot.assignments) {

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -81,6 +81,10 @@ export default function AdminDashboard() {
   const [currentMonth, setCurrentMonth] = useState(format(new Date(), 'yyyy-MM'));
   const [currentYear, setCurrentYear] = useState(new Date().getFullYear());
   const [selectedEmployee, setSelectedEmployee] = useState<EmployeeReport | null>(null);
+  // #329: the detail modal is always MONTH-scoped (entries/audit/absences by month).
+  // In week view the clicked row holds WEEK figures, so the summary cards read this
+  // month-scoped row instead → header, cards and entry list stay on one scope.
+  const [detailSummary, setDetailSummary] = useState<EmployeeReport | null>(null);
   const [selectedUserDetails, setSelectedUserDetails] = useState<UserDetails | null>(null);
   const [employeeTimeEntries, setEmployeeTimeEntries] = useState<TimeEntry[]>([]);
   const [employeeAbsences, setEmployeeAbsences] = useState<Absence[]>([]);
@@ -235,9 +239,23 @@ export default function AdminDashboard() {
   const fetchEmployeeDetails = async (employee: EmployeeReport) => {
     const seq = ++detailSeq.current;
     setSelectedEmployee(employee);
+    // Month mode: the clicked row IS the monthly row. Week mode: fetch the month
+    // row so the modal's Soll/Ist/Saldo cards match its monthly header + entry list.
+    setDetailSummary(viewMode === 'week' ? null : employee);
     setDetailLoading(true);
     try {
       const [year] = currentMonth.split('-');
+
+      if (viewMode === 'week') {
+        const hp = showHealthData ? '&include_health_data=true' : '';
+        const monthly = await apiClient.get(
+          `/admin/reports/monthly?month=${currentMonth}${hp}&soll_basis=${sollBasis}`,
+        );
+        if (seq !== detailSeq.current) return;
+        setDetailSummary(
+          monthly.data.find((r: EmployeeReport) => r.user_id === employee.user_id) ?? employee,
+        );
+      }
 
       // Fetch user details
       const userResponse = await apiClient.get(`/admin/users/${employee.user_id}`);
@@ -275,6 +293,7 @@ export default function AdminDashboard() {
 
   const closeDetail = () => {
     setSelectedEmployee(null);
+    setDetailSummary(null);
     setSelectedUserDetails(null);
     setEmployeeTimeEntries([]);
     setEmployeeAbsences([]);
@@ -1198,39 +1217,45 @@ export default function AdminDashboard() {
                     </div>
                   )}
 
-                  {/* Summary Cards */}
+                  {/* Summary Cards — month-scoped (matches the modal's monthly header
+                      + entry list); #329: detailSummary holds the monthly row in week view. */}
+                  {(() => {
+                    const summary = detailSummary ?? selectedEmployee;
+                    return (
                   <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                     <div className="bg-gray-50 rounded-lg p-4">
                       <p className="text-xs text-gray-500 mb-1">Soll</p>
-                      <p className="text-xl font-bold">{formatHoursHM(selectedEmployee.target_hours)}</p>
+                      <p className="text-xl font-bold">{formatHoursHM(summary.target_hours)}</p>
                     </div>
                     <div className="bg-gray-50 rounded-lg p-4">
                       <p className="text-xs text-gray-500 mb-1">Ist</p>
-                      <p className="text-xl font-bold">{formatHoursHM(selectedEmployee.actual_hours)}</p>
+                      <p className="text-xl font-bold">{formatHoursHM(summary.actual_hours)}</p>
                     </div>
                     <div className="bg-gray-50 rounded-lg p-4">
                       <p className="text-xs text-gray-500 mb-1">Saldo</p>
                       <p
                         className={`text-xl font-bold ${
-                          selectedEmployee.balance >= 0 ? 'text-green-600' : 'text-red-600'
+                          summary.balance >= 0 ? 'text-green-600' : 'text-red-600'
                         }`}
                       >
-                        {selectedEmployee.balance >= 0 ? '+' : ''}
-                        {formatHoursHM(selectedEmployee.balance)}
+                        {summary.balance >= 0 ? '+' : ''}
+                        {formatHoursHM(summary.balance)}
                       </p>
                     </div>
                     <div className="bg-gray-50 rounded-lg p-4">
                       <p className="text-xs text-gray-500 mb-1">Überstunden kum.</p>
                       <p
                         className={`text-xl font-bold ${
-                          selectedEmployee.overtime_cumulative >= 0 ? 'text-green-600' : 'text-red-600'
+                          summary.overtime_cumulative >= 0 ? 'text-green-600' : 'text-red-600'
                         }`}
                       >
-                        {selectedEmployee.overtime_cumulative >= 0 ? '+' : ''}
-                        {formatHoursHM(selectedEmployee.overtime_cumulative)}
+                        {summary.overtime_cumulative >= 0 ? '+' : ''}
+                        {formatHoursHM(summary.overtime_cumulative)}
                       </p>
                     </div>
                   </div>
+                    );
+                  })()}
 
                   {/* Time Entries */}
                   <div className="bg-white border border-gray-200 rounded-lg">


### PR DESCRIPTION
Nachbereitung der gemergten Features #329 (Monat/Woche) und #330 (Schichtplaner-Auslastung).

## 1. Code- + Funktions-/ArbZG-Review (alle Findings ≤ low behoben)

Zwei parallele Reviews über `efea0c3..HEAD`. Ergebnis: **0 critical/high**, 1 medium, mehrere low; ArbZG/§3 BUrlG/DSGVO Art. 9 konform.

- **MED (#329):** Detail-Modal mischte in der Wochenansicht Wochen-Kennzahlen über einer Monats-Eintragsliste → Modal ist jetzt durchgängig monatsbasiert (Soll/Ist/Saldo/Überstunden lesen die nachgeladene Monatszeile).
- **LOW (#329):** `get_range_target` lädt `WorkingHoursChange` einmal vor (kein N+1; wirkt auch auf den delegierenden Monatsreport).
- **LOW (#329):** F-026 `tenant_id`-Filter auf den Absences-Queries in `/weekly` **und** `/monthly` + in `get_range_target`.
- **LOW (#329):** Wochenreport — Urlaub/Krank-Tage-Spalten respektieren bei `bis_heute` denselben Cutoff wie Soll/Ist.
- **LOW (#329):** Tests ergänzt — Beschäftigungsfenster (#193) + DSGVO-Audit-Log-Schreibtest.
- **LOW (#330):** Kommentar zur Overnight-Slot-Annahme.
- **Intendiert/keine Änderung:** #314 Re-Save-Re-Split + „Arbeit gewinnt"-Delete = das gewünschte Feature (per Settings-Hinweis sichtbar).

## 2. Doku-Aktualisierung

Nutzersichtbare Docs (Markdown-Handbücher + Cheat-Sheets + In-App-Hilfe `DocViewer.tsx`, synchron) um #329, #313, #311, #312, #314 und Schichtplanung-M2 (#305 M2 / #321 / #322 / #330) ergänzt. Keine Dopplungen.

## Verifikation
- 77 gezielte Backend-Tests (range/weekly/calc/closure) grün; Consumer-Regression **497 grün**; neue Weekly-Tests grün.
- `tsc --noEmit` + Vitest grün; Detail-Modal-Screenshot konsistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
