### PR TITLE
Release 1.12.1

### DIFF
--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.12.0"
+APP_VERSION = "1.12.1"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
-from app.services.date_filters import date_in_year, date_in_month
+from app.services.date_filters import date_in_year, date_in_month, parse_year_month
 from sqlalchemy import extract
 from typing import List, Optional
 from datetime import timedelta, date
@@ -118,7 +118,7 @@ def get_absence_calendar(
     Visible to all authenticated users.
     """
     try:
-        year, month_num = map(int, month.split('-'))
+        year, month_num = parse_year_month(month)
     except ValueError:
         raise HTTPException(status_code=400, detail="Ungültiges Monatsformat (YYYY-MM erwartet)")
 

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -353,13 +353,17 @@ def purge_user(
             )
 
     # Remove FK dependencies before deleting user.
-    # For changed_by references: SET NULL to preserve other users' audit trails.
+    # changed_by is NOT NULL (migration 008) → we must NOT SET NULL (that raises a
+    # NOT NULL IntegrityError and aborts the whole Art.17 erasure for any user who
+    # has ever clocked out, since each clock_out writes an audit row with
+    # changed_by = the employee's own id). Reassign other users' audit rows to the
+    # acting admin instead — preserves the audit trail.
     # F-026: explicit tenant_id filter on every bulk op (CLAUDE.md rule —
     # RLS is belt-and-suspenders but the filter must be present in the query).
     db.query(TimeEntryAuditLog).filter(
         TimeEntryAuditLog.changed_by == user.id,
         TimeEntryAuditLog.tenant_id == current_user.tenant_id,
-    ).update({TimeEntryAuditLog.changed_by: None}, synchronize_session=False)
+    ).update({TimeEntryAuditLog.changed_by: current_user.id}, synchronize_session=False)
     # Delete the purged user's own audit log entries.
     db.query(TimeEntryAuditLog).filter(
         TimeEntryAuditLog.user_id == user.id,
@@ -394,6 +398,13 @@ def purge_user(
     ).update({"reviewed_by": None}, synchronize_session=False)
     db.query(WorkingHoursChange).filter(WorkingHoursChange.user_id == user.id, WorkingHoursChange.tenant_id == current_user.tenant_id).delete(synchronize_session=False)
     db.query(ChangeRequest).filter(ChangeRequest.user_id == user.id, ChangeRequest.tenant_id == current_user.tenant_id).delete(synchronize_session=False)
+    # Nullify reviewed_by on OTHER users' change requests (nullable, no ON DELETE
+    # rule → a raw user delete FK-violates on Postgres). Mirrors the
+    # VacationRequest.reviewed_by nullify above.
+    db.query(ChangeRequest).filter(
+        ChangeRequest.reviewed_by == user.id,
+        ChangeRequest.tenant_id == current_user.tenant_id,
+    ).update({ChangeRequest.reviewed_by: None}, synchronize_session=False)
     db.query(TimeEntry).filter(TimeEntry.user_id == user.id, TimeEntry.tenant_id == current_user.tenant_id).delete(synchronize_session=False)
     db.query(Absence).filter(Absence.user_id == user.id, Absence.tenant_id == current_user.tenant_id).delete(synchronize_session=False)
     # #305 Schichtplanung: shift_plans.created_by is NOT NULL with no ON DELETE
@@ -416,6 +427,21 @@ def purge_user(
     db.query(WorkstationQualification).filter(
         WorkstationQualification.user_id == user.id,
         WorkstationQualification.tenant_id == current_user.tenant_id,
+    ).delete(synchronize_session=False)
+    # company_closure.created_by is NOT NULL with no ON DELETE rule → reassign the
+    # user's Betriebsferien to the acting admin (Postgres FK; SQLite tests run FK off).
+    from app.models import CompanyClosure
+    db.query(CompanyClosure).filter(
+        CompanyClosure.created_by == user.id,
+        CompanyClosure.tenant_id == current_user.tenant_id,
+    ).update({CompanyClosure.created_by: current_user.id}, synchronize_session=False)
+    # signup_tokens.user_id is NOT NULL with no ON DELETE rule and tokens are never
+    # deleted by the signup flow (only consumed_at is set) → delete the purged
+    # user's tokens explicitly. F-026 tenant-scoped.
+    from app.models import SignupToken
+    db.query(SignupToken).filter(
+        SignupToken.user_id == user.id,
+        SignupToken.tenant_id == current_user.tenant_id,
     ).delete(synchronize_session=False)
     db.delete(user)
     db.commit()

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -16,7 +16,7 @@ from app.middleware.auth import require_admin
 from app.schemas.reports import EmployeeMonthlyReport, EmployeeYearlyAbsences
 from app.services import calculation_service, export_service, ods_export_service, rest_time_service
 from app.services.arbzg_utils import is_night_work
-from app.services.date_filters import date_in_year, date_in_month, date_in_range
+from app.services.date_filters import date_in_year, date_in_month, date_in_range, parse_year_month
 from app.core.limiter import limiter
 
 logger = logging.getLogger(__name__)
@@ -59,7 +59,7 @@ def get_monthly_report(
     if soll_basis not in ("bis_heute", "monatsende"):
         raise HTTPException(status_code=400, detail="soll_basis muss 'bis_heute' oder 'monatsende' sein")
     try:
-        year, month_num = map(int, month.split('-'))
+        year, month_num = parse_year_month(month)
     except ValueError:
         raise HTTPException(status_code=400, detail="Ungültiges Monatsformat (YYYY-MM erwartet)")
 
@@ -400,7 +400,7 @@ def export_monthly_report(
     Sick/health data (Art. 9 DSGVO) is omitted by default; pass include_health_data=true to include it (audit-logged).
     """
     try:
-        year, month_num = map(int, month.split('-'))
+        year, month_num = parse_year_month(month)
     except ValueError:
         raise HTTPException(status_code=400, detail="Ungültiges Monatsformat (YYYY-MM erwartet)")
 
@@ -529,7 +529,7 @@ def export_monthly_report_ods(
     """Export monthly report as ODS file (Open Document Spreadsheet).
     Sick/health data (Art. 9 DSGVO) is omitted by default; pass include_health_data=true to include it (audit-logged)."""
     try:
-        year, month_num = map(int, month.split('-'))
+        year, month_num = parse_year_month(month)
     except ValueError:
         raise HTTPException(status_code=400, detail="Ungültiges Monatsformat (YYYY-MM erwartet)")
 
@@ -567,7 +567,7 @@ def export_monthly_report_pdf(
 ):
     """Export monthly report as PDF file (landscape A4, one page per employee)."""
     try:
-        year, month_num = map(int, month.split('-'))
+        year, month_num = parse_year_month(month)
     except ValueError:
         raise HTTPException(status_code=400, detail="Ungültiges Monatsformat (YYYY-MM erwartet)")
 

--- a/backend/app/services/date_filters.py
+++ b/backend/app/services/date_filters.py
@@ -51,6 +51,21 @@ def date_in_range(column, start: date, end: date):
     return and_(column >= start, column <= end)
 
 
+def parse_year_month(month: str) -> tuple:
+    """Parse a ``"YYYY-MM"`` string → ``(year, month)``.
+
+    Raises ``ValueError`` on a malformed string **or an out-of-range month**
+    (1–12). Callers wrap this in their existing ``except ValueError → HTTP 400``
+    so a syntactically valid but out-of-range value like ``"2026-13"``/``"2026-00"``
+    returns 400 instead of leaking an HTTP 500 from a later ``monthrange()`` /
+    ``date()`` call (which raise outside the original parse guard).
+    """
+    year, month_num = map(int, month.split('-'))
+    if not (1 <= month_num <= 12):
+        raise ValueError(f"month out of range: {month_num}")
+    return year, month_num
+
+
 def date_in_year_up_to_month(column, year: int, month: int):
     """
     Range filter ``column IN year AND month <= :month`` as a sargable

--- a/backend/tests/test_month_param.py
+++ b/backend/tests/test_month_param.py
@@ -1,0 +1,41 @@
+"""1.12.1 review regression: out-of-range month in a YYYY-MM query param must
+return HTTP 400, not leak a 500 from a downstream monthrange()/date() call."""
+import pytest
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.middleware.auth import get_current_user, require_admin
+from app.services.date_filters import parse_year_month
+from tests.test_endpoints import test_app
+
+
+def test_parse_year_month_valid():
+    assert parse_year_month("2026-06") == (2026, 6)
+    assert parse_year_month("2026-01") == (2026, 1)
+    assert parse_year_month("2026-12") == (2026, 12)
+
+
+@pytest.mark.parametrize("bad", ["2026-13", "2026-00", "2026-99", "abc-06", "2026", "2026-6-1", ""])
+def test_parse_year_month_invalid_raises(bad):
+    with pytest.raises(ValueError):
+        parse_year_month(bad)
+
+
+@pytest.fixture
+def admin_c(db, test_admin):
+    def _od():
+        yield db
+    test_app.dependency_overrides[get_db] = _od
+    test_app.dependency_overrides[get_current_user] = lambda: test_admin
+    test_app.dependency_overrides[require_admin] = lambda: test_admin
+    yield TestClient(test_app)
+    test_app.dependency_overrides.clear()
+
+
+def test_monthly_report_out_of_range_month_returns_400(admin_c):
+    assert admin_c.get("/api/admin/reports/monthly?month=2026-13").status_code == 400
+    assert admin_c.get("/api/admin/reports/monthly?month=2026-00").status_code == 400
+
+
+def test_absences_calendar_out_of_range_month_returns_400(admin_c):
+    assert admin_c.get("/api/absences/calendar?month=2026-13").status_code == 400

--- a/backend/tests/test_purge_user_fk_cleanup.py
+++ b/backend/tests/test_purge_user_fk_cleanup.py
@@ -1,0 +1,117 @@
+"""1.12.1 review regression: DSGVO Art.17 purge must clean up ALL users.id FK
+dependents without crashing.
+
+- HIGH: time_entry_audit_logs.changed_by is NOT NULL → must be reassigned to the
+  acting admin (a SET NULL raised an IntegrityError and aborted the erasure for
+  any user who had ever clocked out).
+- MEDIUM: company_closure.created_by / change_request.reviewed_by /
+  signup_tokens.user_id have no ON DELETE rule → must be reassigned/nullified/
+  deleted before db.delete(user), else Postgres FK-violates (SQLite runs FK off,
+  so these assert the cleanup *behaviour*).
+"""
+import uuid
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.middleware.auth import get_current_user, require_admin
+from app.models import (
+    User, UserRole, TimeEntryAuditLog, CompanyClosure, ChangeRequest, SignupToken,
+)
+from app.models.change_request import ChangeRequestType
+from tests.conftest import DEFAULT_TENANT_ID
+from tests.test_endpoints import test_app
+
+
+@pytest.fixture
+def admin_client(db, test_admin):
+    def _override_db():
+        yield db
+    test_app.dependency_overrides[get_db] = _override_db
+    test_app.dependency_overrides[get_current_user] = lambda: test_admin
+    test_app.dependency_overrides[require_admin] = lambda: test_admin
+    yield TestClient(test_app)
+    test_app.dependency_overrides.clear()
+
+
+def _deactivated_user(db, name):
+    u = User(
+        username=name, email=f"{name}@x.de", password_hash="x", first_name=name,
+        last_name="P", role=UserRole.EMPLOYEE, weekly_hours=40.0, vacation_days=30,
+        work_days_per_week=5, is_active=False, tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def test_purge_user_with_authored_audit_rows(admin_client, db, test_admin):
+    # HIGH: changed_by is NOT NULL → reassign, never SET NULL.
+    u = _deactivated_user(db, "audit_self")
+    # (a) the user's OWN clock-out row (user_id == changed_by == u.id): the
+    #     reassign touches changed_by BEFORE the user_id-delete removes it → with
+    #     the old SET NULL code this 500s on the NOT NULL column. End state: deleted.
+    own = TimeEntryAuditLog(
+        tenant_id=DEFAULT_TENANT_ID, time_entry_id=None, user_id=u.id,
+        changed_by=u.id, action="clock_out", source="manual",
+    )
+    # (b) a row the purged user authored on SOMEONE ELSE's entry → must be
+    #     reassigned to the acting admin and SURVIVE (its audit trail is kept).
+    other = TimeEntryAuditLog(
+        tenant_id=DEFAULT_TENANT_ID, time_entry_id=None, user_id=test_admin.id,
+        changed_by=u.id, action="update", source="manual",
+    )
+    db.add_all([own, other])
+    db.commit()
+    oid = other.id
+    r = admin_client.delete(f"/api/admin/users/{u.id}/purge")
+    assert r.status_code == 200, r.text  # HIGH regression: no NOT NULL IntegrityError
+    db.expire_all()
+    row = db.query(TimeEntryAuditLog).filter(TimeEntryAuditLog.id == oid).first()
+    assert row is not None and row.changed_by == test_admin.id
+
+
+def test_purge_user_who_created_company_closure(admin_client, db, test_admin):
+    u = _deactivated_user(db, "closure_creator")
+    c = CompanyClosure(
+        tenant_id=DEFAULT_TENANT_ID, name="BF", start_date=date(2020, 1, 1),
+        end_date=date(2020, 1, 3), created_by=u.id,
+    )
+    db.add(c)
+    db.commit()
+    cid = c.id
+    assert admin_client.delete(f"/api/admin/users/{u.id}/purge").status_code == 200
+    db.expire_all()
+    closure = db.query(CompanyClosure).filter(CompanyClosure.id == cid).first()
+    assert closure is not None and closure.created_by == test_admin.id
+
+
+def test_purge_user_with_signup_token(admin_client, db):
+    u = _deactivated_user(db, "token_user")
+    db.add(SignupToken(
+        tenant_id=DEFAULT_TENANT_ID, user_id=u.id, token_hash="h" + uuid.uuid4().hex,
+        expires_at=datetime.now(timezone.utc) + timedelta(days=1),
+    ))
+    db.commit()
+    uid = u.id
+    assert admin_client.delete(f"/api/admin/users/{u.id}/purge").status_code == 200
+    db.expire_all()
+    assert db.query(SignupToken).filter(SignupToken.user_id == uid).count() == 0
+
+
+def test_purge_user_who_reviewed_change_request(admin_client, db, test_user):
+    reviewer = _deactivated_user(db, "cr_reviewer")
+    cr = ChangeRequest(
+        tenant_id=DEFAULT_TENANT_ID, user_id=test_user.id,
+        request_type=ChangeRequestType.UPDATE, reason="x", reviewed_by=reviewer.id,
+    )
+    db.add(cr)
+    db.commit()
+    crid = cr.id
+    assert admin_client.delete(f"/api/admin/users/{reviewer.id}/purge").status_code == 200
+    db.expire_all()
+    got = db.query(ChangeRequest).filter(ChangeRequest.id == crid).first()
+    assert got is not None and got.reviewed_by is None

--- a/docs/INSTALL-NATIVE.md
+++ b/docs/INSTALL-NATIVE.md
@@ -408,10 +408,18 @@ Wenn KEIN Backup der `.db-credentials` existiert, aber die Datenbank inhaltlich
 intakt ist und noch erreichbar (z.B. weil der alte Dienst noch laeuft oder
 sich `psql` lokal noch peer-authentifizieren kann):
 
+> **Hinweis (Linux/macOS):** Der native Cluster lauscht seit 1.8.5 **nur auf dem
+> Unix-Socket** (`listen_addresses=''`), nicht auf TCP `localhost:5432`. Daher
+> verbinden sich `pg_dumpall`/`psql` über das Socket-Verzeichnis `data/run`
+> (`-h .../data/run`), **nicht** über `-h localhost` — sonst „connection refused"
+> bzw., falls eine fremde System-PostgreSQL auf :5432 läuft, ein Treffer auf den
+> **falschen** Cluster. `-w` verhindert ein Aufhängen an der Passwortabfrage.
+> macOS-Pfad: `/usr/local/praxiszeit` statt `/opt/praxiszeit`.
+
 ```bash
-# 1. Backup ziehen, solange der Cluster noch antwortet
+# 1. Backup ziehen, solange der Cluster noch antwortet (Socket-Verbindung!)
 cd /opt/praxiszeit
-bin/postgresql/bin/pg_dumpall -U praxiszeit -h localhost > /root/praxiszeit-rescue.sql
+bin/postgresql/bin/pg_dumpall -w -U praxiszeit -h /opt/praxiszeit/data/run > /root/praxiszeit-rescue.sql
 
 # 2. Dienst stoppen
 sudo systemctl stop praxiszeit
@@ -423,7 +431,7 @@ sudo rm -rf data/db
 sudo systemctl start praxiszeit
 
 # 5. Daten zurueckspielen (nach erfolgreichem Start)
-bin/postgresql/bin/psql -U praxiszeit -h localhost -f /root/praxiszeit-rescue.sql
+bin/postgresql/bin/psql -w -U praxiszeit -h /opt/praxiszeit/data/run -d praxiszeit -f /root/praxiszeit-rescue.sql
 ```
 
 Windows-Aequivalent:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.12.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.12.0"
+APP_VERSION="1.12.1"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
PATCH-Release 1.12.1 — Härtung nach intensivem Pre-Release-Review (keine neuen Features, keine Migration).

## Review-Findings behoben (0 critical, 1 high, 3 medium — alle ≤ medium gefixt)
- **HIGH** `purge_user`: DSGVO-Art.17-Löschung brach für jeden ausgestempelten Nutzer ab (NOT-NULL `changed_by` per SET NULL) → Reassign auf handelnden Admin.
- **MED** `purge_user`: drei users.id-FK-Abhängige ohne ON DELETE (company_closure.created_by / change_request.reviewed_by / signup_tokens.user_id) → Reassign/nullify/delete.
- **MED** `reports.py` + `absences.py`: out-of-range Monat (`?month=2026-13`) → HTTP 500 statt 400 → neuer `parse_year_month`-Helper.
- **MED** `docs/INSTALL-NATIVE.md`: Disaster-Recovery nutzte TCP `-h localhost`, native Unix ist socket-only seit 1.8.5 → Socket `data/run` + `-w`.

## Verifikation
- Backend-Suite: **1126 SQLite + 39 Postgres-Tenant** grün; neue Regressionstests `test_purge_user_fk_cleanup` (4) + `test_month_param` (10).
- Build: 6 Artefakte; SHA256SUMS OK; Windows-ZIP ohne eingebettete `setup.exe`, gebündelte PG = **18.4** (SHA-Pin `44b8187d…` verifiziert), `updater.py` = 1.12.1 in Windows- + Linux-Bundle, alle `.bat` CRLF.
- validate-release: **5/5** Distros (Ubuntu 22/24, Debian 12, Rocky 9, Arch), postgres+initdb 18.4.
- Install/Smoke: lokaler Docker-Stack (echter Login HTTP 200, Monats-Validierung 400 live); **.131 Native-Update 1.12.0→1.12.1** (Dienst aktiv, Daten erhalten: users 2→2, time_entries 1→1, PG 18).
- Windows-Emulator: bewusst übersprungen (0 Windows-Installer-Änderungen ggü. 1.12.0; Artefakt-Integrität vollständig verifiziert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
