### PR TITLE
docs: CLAUDE.md Aktuelle Version → 1.12.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.12.0 (Stand 2026-06-27)
+**Aktuelle Version:** 1.12.1 (Stand 2026-06-28)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---


### PR DESCRIPTION
Nachzug der `Aktuelle Version`-Zeile auf 1.12.1 nach Release v1.12.1.