### PR TITLE
fix(#314): Betriebsferien-Split — kein 0-Std-Urlaub am Nicht-Arbeitstag

### DIFF
--- a/backend/app/routers/company_closures.py
+++ b/backend/app/routers/company_closures.py
@@ -164,6 +164,24 @@ def _create_closure_absences(
             if not calculation_service._within_employment_window(employee, workday):
                 continue
 
+            # F-027/#204: authoritative weekly_hours lookup (get_daily_target_for_date
+            # must never fall back to user.weekly_hours; wh_changes vorgeladen).
+            weekly_hours = calculation_service.get_weekly_hours_for_date(
+                db, employee, workday, wh_changes=emp_wh
+            )
+            day_target = calculation_service.get_daily_target_for_date(
+                employee, workday, weekly_hours=weekly_hours
+            )
+            # #314 (philvdb): an einem Nicht-Arbeitstag eines use_daily_schedule-
+            # Teilzeitlers (Tagessoll 0 an diesem Wochentag) gibt es nichts zu
+            # schließen — KEINE Buchung (sonst eine irreführende 0h-„Urlaub"-Zeile).
+            # Vor der TimeEntry-Löschung, damit an einem solchen Tag nichts angefasst
+            # wird. Untracked/leitende (track_hours=False → Tagessoll immer 0) NICHT
+            # skippen: die bekommen tagebasiert 1 Urlaubstag pro Closure-Tag (#191).
+            if (employee.track_hours and getattr(employee, "use_daily_schedule", False)
+                    and day_target <= 0):
+                continue
+
             # Skip if any absence already exists for this day (not just vacation)
             if (employee.id, workday) in existing_keys:
                 continue
@@ -190,24 +208,6 @@ def _create_closure_absences(
                     )
                     db.delete(entry)
 
-            # F-027: Use the authoritative weekly_hours lookup so that
-            # a closure spanning a WorkingHoursChange credits the right
-            # daily target. Passing weekly_hours explicitly is a CLAUDE.md
-            # requirement — get_daily_target_for_date must never fall
-            # back to user.weekly_hours. (#204: wh_changes vorgeladen.)
-            # #314/#201: compute the day's target FIRST. A 0-target scheduled day
-            # (a use_daily_schedule part-timer's off-weekday, booked at hours=0)
-            # consumes NO real vacation (get_vacation_account counts only
-            # dt_day>0), so it must NOT decrement the budget snapshot — otherwise
-            # it would wrongly push real working days into OVERTIME and silently
-            # lose paid vacation. hours==0 days are calc-neutral either way.
-            weekly_hours = calculation_service.get_weekly_hours_for_date(
-                db, employee, workday, wh_changes=emp_wh
-            )
-            day_target = calculation_service.get_daily_target_for_date(
-                employee, workday, weekly_hours=weekly_hours
-            )
-
             # #314: decide VACATION vs OVERTIME per day. VACATION while the
             # remaining budget covers a full day; afterwards OVERTIME (no minus-
             # vacation). Only positive-target days consume the budget snapshot.
@@ -215,6 +215,13 @@ def _create_closure_absences(
             if emp_split and day_target > 0:
                 yr = workday.year
                 if yr not in remaining_by_year:
+                    # Resturlaub des Jahres als TAGE-Budget (Tagesprinzip). Die
+                    # closure-eigenen Tage sind beim Re-Save vorher gelöscht+geflusht
+                    # bzw. beim Create noch nicht vorhanden → der Snapshot zählt sie
+                    # nicht doppelt. So zehrt die Closure den VERBLEIBENDEN Urlaub
+                    # chronologisch bis 0 auf, der Rest wird Überstundenausgleich —
+                    # NIE Minus-Urlaub, auch wenn SPÄTER im Jahr Urlaub (z. B. Sommer)
+                    # gebucht ist (der zählt korrekt mit; #314 Folgefix-Review).
                     remaining_by_year[yr] = float(
                         calculation_service.get_vacation_account(db, employee, yr)["remaining_days"]
                     )

--- a/backend/tests/test_closure_overtime_split.py
+++ b/backend/tests/test_closure_overtime_split.py
@@ -7,7 +7,7 @@ ist) und danach als OVERTIME (Überstundenausgleich → Überstundenkonto sinkt,
 darf ins Minus) — statt Minus-Urlaub zu erzeugen.
 """
 import uuid
-from datetime import date
+from datetime import date, timedelta
 
 import pytest
 from fastapi import FastAPI
@@ -245,6 +245,81 @@ class TestClosureOvertimeSplitUpdate:
         # account → the split must NOT apply (legacy VACATION), otherwise the
         # surplus day vanishes from all accounting.
         emp = _make_user(db, "e_unt", vacation_days=0, track_hours=False)
+        _set_toggle(db, True)
+        c = _create_closure(admin_client)
+        assert _types(db, emp, c["id"]) == [AbsenceType.VACATION] * 4
+
+
+def _book_vacation_workdays(db, user, start: date, count: int):
+    """Book `count` VACATION workdays starting at `start` (skips weekends)."""
+    d, booked = start, 0
+    while booked < count:
+        if d.weekday() < 5:
+            db.add(Absence(user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+                           type=AbsenceType.VACATION, hours=8.0, half_day=False))
+            booked += 1
+        d += timedelta(days=1)
+    db.commit()
+
+
+class TestClosureOvertimeSplitBudgetAndOffday:
+    """#314 reopened (philvdb): die Closure zehrt den VERBLEIBENDEN Jahres-Resturlaub
+    chronologisch bis 0 auf und bucht den Rest als Überstundenausgleich — NIE
+    Minus-Urlaub, auch wenn SPÄTER im Jahr Urlaub (Sommer) gebucht ist (der zählt
+    korrekt mit). Plus: an Nicht-Arbeitstagen eines use_daily_schedule-Teilzeitlers
+    wird keine irreführende 0-Std-Urlaubszeile gebucht."""
+
+    def test_future_vacation_consumes_remaining_then_overtime_no_minus(self, db, default_tenant, admin_client):
+        # Bereits (für den Sommer) gebuchter Urlaub schöpft das Jahresbudget mit aus:
+        # die Closure darf nur den VERBLEIBENDEN Urlaub als VACATION nehmen, der Rest
+        # wird Überstundenausgleich. Der Jahresurlaub darf dadurch NIE ins Minus.
+        from app.services import calculation_service
+        emp = _make_user(db, "e_future", vacation_days=10)
+        _book_vacation_workdays(db, emp, date(2025, 8, 4), 8)  # 8 von 10 Tagen im Sommer verplant
+        _set_toggle(db, True)
+        c = _create_closure(admin_client)  # MON..THU (4 Arbeitstage im März)
+        assert _types(db, emp, c["id"]) == [
+            AbsenceType.VACATION, AbsenceType.VACATION, AbsenceType.OVERTIME, AbsenceType.OVERTIME,
+        ]
+        # Kein Minus-Urlaub: 8 (Sommer) + 2 (Closure-Urlaub) = 10 = Budget.
+        assert calculation_service.get_vacation_account(db, emp, 2025)["remaining_days"] == 0.0
+
+    def test_past_vacation_reduces_closure_budget(self, db, default_tenant, admin_client):
+        # 2 vacation days taken BEFORE the closure (February) with budget 3 →
+        # only 1 day left at closure time → 1 VACATION + 3 OVERTIME.
+        emp = _make_user(db, "e_past", vacation_days=3)
+        _book_vacation_workdays(db, emp, date(2025, 2, 3), 2)
+        _set_toggle(db, True)
+        c = _create_closure(admin_client)
+        assert _types(db, emp, c["id"]) == [
+            AbsenceType.VACATION, AbsenceType.OVERTIME, AbsenceType.OVERTIME, AbsenceType.OVERTIME,
+        ]
+
+    def test_use_daily_schedule_offday_not_booked(self, db, default_tenant, admin_client):
+        # #314 secondary: a use_daily_schedule part-timer (Mon/Wed/Fri only) must NOT
+        # get a misleading 0-hour VACATION row on their non-work weekdays (Tue/Thu).
+        FRI = date(2025, 3, 14)
+        emp = User(
+            username="e_offday", email="offday@x.de", password_hash=auth_service.hash_password("test123"),
+            first_name="O", last_name="D", role=UserRole.EMPLOYEE, weekly_hours=24.0, vacation_days=30,
+            work_days_per_week=3, is_active=True, track_hours=True, use_daily_schedule=True,
+            hours_monday=8, hours_tuesday=0, hours_wednesday=8, hours_thursday=0, hours_friday=8,
+            tenant_id=DEFAULT_TENANT_ID,
+        )
+        db.add(emp); db.commit(); db.refresh(emp)
+        _set_toggle(db, True)
+        r = admin_client.post("/api/company-closures/", json={
+            "name": "BF", "start_date": MON.isoformat(), "end_date": FRI.isoformat(), "counts_as_vacation": True})
+        assert r.status_code == 201, r.text
+        booked = {a.date for a in db.query(Absence).filter(
+            Absence.user_id == emp.id, Absence.closure_id == uuid.UUID(r.json()["id"])).all()}
+        assert booked == {MON, WED, FRI}  # Tue/Thu (0-Tagessoll) NOT booked
+
+    def test_untracked_booked_on_all_workdays(self, db, default_tenant, admin_client):
+        # Counter-test to the off-day skip: an untracked MA (track_hours=False,
+        # daily_target always 0) must STILL get one VACATION per workday (Tagesprinzip
+        # #191) — the skip is only for use_daily_schedule off-weekdays.
+        emp = _make_user(db, "e_unt2", vacation_days=30, track_hours=False)
         _set_toggle(db, True)
         c = _create_closure(admin_client)
         assert _types(db, emp, c["id"]) == [AbsenceType.VACATION] * 4


### PR DESCRIPTION
Folge-Review zu philvdbs Reopen von #314. Ein adversarialer Verifikations-Workflow (4 Lanes) hat den zunächst geplanten „as-of-closure"-Ansatz **widerlegt**.

## Verworfen: as-of-closure (hätte Minus-Urlaub erzeugt)
Der Stichtag-Ansatz hätte später im Jahr gebuchten (Sommer-)Urlaub ignoriert → die Closure hätte Urlaub gebucht, der das Jahresbudget ins **Minus** treibt (genau das, was #314 verhindern soll) — und zusätzlich die fixen Sondertage 24./31.12. ausgeblendet. Die **bewährte Jahres-Resturlaub-Logik ist korrekt** und erfüllt philvdbs Wunsch („Resturlaub aufzehren, dann Überstundenausgleich, **nie Minus**"): closure-eigene Tage werden beim Re-Save vorher gelöscht (kein Doppelzählen), bereits verplanter Urlaub reduziert das verfügbare Budget korrekt.

## Behoben (Issue 2)
An einem **Nicht-Arbeitstag** eines `use_daily_schedule`-Teilzeitlers (Tagessoll 0, z. B. Do bei einer Mo/Mi/Fr-Kraft) wird **keine** Closure-Abwesenheit mehr gebucht — vorher entstand eine irreführende 0-Std-„Urlaub"-Zeile. Skip steht **vor** der TimeEntry-Löschung (keine Arbeit verlieren); untracked/leitende (`track_hours=False`) werden NICHT geskippt (tagebasierter Urlaub, #191).

## Tests
4 neue Tests (Sommerurlaub→aufzehren+Überstunden ohne Minus inkl. `remaining_days==0`-Assertion, Vergangenheits-Urlaub, Off-Tag-Skip, untracked-Gegenprobe). 16 Closure-Split + **256 Urlaub/Closure/Calc** grün. `calculation_service.py` ist unverändert (as-of vollständig zurückgerollt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
