### PR TITLE
feat(#339,#340): Saldo-Label dynamisch + aktiven Schichtplan auto-oeffnen

### DIFF
--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -485,7 +485,7 @@ export default function AdminDashboard() {
 
         <div className="bg-white rounded-xl shadow-xs border border-gray-200 p-6">
           <div className="flex items-center justify-between mb-2">
-            <h3 className="text-sm font-medium text-gray-600">Ø Saldo (Monat)</h3>
+            <h3 className="text-sm font-medium text-gray-600">Ø Saldo ({viewMode === 'week' ? 'Woche' : 'Monat'})</h3>
             <TrendingUp
               className={avgBalance >= 0 ? 'text-green-600' : 'text-red-600'}
               size={24}

--- a/frontend/src/pages/admin/ShiftPlanning.tsx
+++ b/frontend/src/pages/admin/ShiftPlanning.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import {
   DndContext,
   PointerSensor,
@@ -172,6 +172,19 @@ export default function AdminShiftPlanning() {
     if (selectedPlanId) loadPlanDetail(selectedPlanId);
     else setPlanDetail(null);
   }, [selectedPlanId, loadPlanDetail]);
+
+  // #340: beim ersten Laden den aktuell aktiven Plan automatisch öffnen (häufigster
+  // Use-Case → spart einen Klick). Greift nur einmal (autoOpenedRef) und nur, wenn
+  // noch keiner gewählt ist — drängt sich nach manueller Aus-/Abwahl nicht erneut auf.
+  const autoOpenedRef = useRef(false);
+  useEffect(() => {
+    if (autoOpenedRef.current || plans.length === 0) return;
+    autoOpenedRef.current = true;
+    if (!selectedPlanId) {
+      const active = plans.find((p) => p.active_today) ?? plans.find((p) => p.is_active);
+      if (active) setSelectedPlanId(active.id);
+    }
+  }, [plans, selectedPlanId]);
 
   const refreshSelected = async () => {
     await loadPlans();


### PR DESCRIPTION
Zwei Frontend-Minor-Verbesserungen (philvdb):
- #339: „Ø Saldo (Monat)"-Kachel zeigt in der Wochenansicht „Ø Saldo (Woche)" (Label war hardcoded; Folgefehler aus #329).
- #340: Schichtplaner öffnet beim ersten Aufruf automatisch den aktuell aktiven Plan (active_today, sonst is_active) — spart einen Klick.

tsc clean.
