### PR TITLE
feat(#338): Schichtplan duplizieren

### DIFF
--- a/backend/app/routers/shift_planning.py
+++ b/backend/app/routers/shift_planning.py
@@ -108,6 +108,10 @@ class PlanIn(BaseModel):
     active_until_date: Optional[date] = None
 
 
+class PlanDuplicateIn(BaseModel):
+    name: str  # #338: Name der Kopie
+
+
 class SlotIn(BaseModel):
     workstation_id: UUID
     weekday: int
@@ -670,6 +674,72 @@ def create_plan(
     _commit_or_conflict(db, "Ein Schichtplan mit diesem Namen existiert bereits")
     db.refresh(plan)
     return _plan_summary(plan)
+
+
+@router.post("/plans/{plan_id}/duplicate", status_code=status.HTTP_201_CREATED)
+def duplicate_plan(
+    plan_id: UUID,
+    data: PlanDuplicateIn,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+):
+    """#338: Schichtplan inkl. Slots + Zuweisungen duplizieren. Die Kopie ist ein
+    INAKTIVER Entwurf OHNE Aktiv-Datumsfenster (sie soll nicht versehentlich neben
+    dem Original aktiv werden); Arbeitsplätze/Einweisungen sind nicht plan-gebunden
+    und werden daher nicht kopiert. Alles tenant-scoped (F-026)."""
+    tid = current_user.tenant_id
+    src = _plan_or_404(db, tid, plan_id)
+    name = data.name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="Name darf nicht leer sein")
+    clash = (
+        db.query(ShiftPlan)
+        .filter(ShiftPlan.tenant_id == tid, ShiftPlan.name == name)
+        .first()
+    )
+    if clash:
+        raise HTTPException(status_code=409, detail="Ein Schichtplan mit diesem Namen existiert bereits")
+
+    new_plan = ShiftPlan(
+        tenant_id=tid,
+        name=name,
+        description=src.description,
+        is_active=False,
+        active_from_date=None,
+        active_until_date=None,
+        created_by=current_user.id,
+    )
+    db.add(new_plan)
+    db.flush()  # new_plan.id
+
+    src_slots = (
+        db.query(ShiftSlot)
+        .filter(ShiftSlot.tenant_id == tid, ShiftSlot.shift_plan_id == src.id)
+        .all()
+    )
+    for s in src_slots:
+        ns = ShiftSlot(
+            tenant_id=tid,
+            shift_plan_id=new_plan.id,
+            workstation_id=s.workstation_id,
+            weekday=s.weekday,
+            start_time=s.start_time,
+            end_time=s.end_time,
+            min_staff=s.min_staff,
+        )
+        db.add(ns)
+        db.flush()  # ns.id
+        src_assigns = (
+            db.query(ShiftAssignment)
+            .filter(ShiftAssignment.tenant_id == tid, ShiftAssignment.shift_slot_id == s.id)
+            .all()
+        )
+        for a in src_assigns:
+            db.add(ShiftAssignment(tenant_id=tid, shift_slot_id=ns.id, user_id=a.user_id))
+
+    _commit_or_conflict(db, "Ein Schichtplan mit diesem Namen existiert bereits")
+    db.refresh(new_plan)
+    return _plan_summary(new_plan)
 
 
 @router.put("/plans/{plan_id}")

--- a/backend/tests/test_shift_planning.py
+++ b/backend/tests/test_shift_planning.py
@@ -430,3 +430,43 @@ class TestMyToday:
         admin_client.post(f"{BASE}/plans/{plan}/activate")
         data = employee_client.get(f"{BASE}/my-today").json()
         assert data["entries"] == []
+
+
+class TestPlanDuplicate:
+    """#338: einen Schichtplan inkl. Slots + Zuweisungen duplizieren (neuer Name,
+    Kopie ist ein inaktiver Entwurf ohne Aktiv-Datumsfenster)."""
+
+    def test_duplicate_copies_slots_and_assignments(self, enabled, admin_client, test_user):
+        ws = _mk_workstation(admin_client, "Tresen")
+        src = _mk_plan(admin_client, "Original")
+        s1 = _mk_slot(admin_client, src, ws, weekday=0, start="08:00", end="12:00", min_staff=2)
+        _mk_slot(admin_client, src, ws, weekday=2, start="13:00", end="17:00")
+        admin_client.put(f"{BASE}/slots/{s1}/assignments", json={"user_ids": [str(test_user.id)]})
+        admin_client.post(f"{BASE}/plans/{src}/activate")  # Kopie darf das NICHT erben
+
+        r = admin_client.post(f"{BASE}/plans/{src}/duplicate", json={"name": "Kopie"})
+        assert r.status_code == 201, r.text
+        new = r.json()
+        assert new["id"] != src
+        assert new["name"] == "Kopie"
+        assert new["is_active"] is False
+
+        detail = admin_client.get(f"{BASE}/plans/{new['id']}").json()
+        slots = sorted(detail["slots"], key=lambda s: s["weekday"])
+        assert len(slots) == 2
+        assert slots[0]["weekday"] == 0 and slots[0]["start_time"] == "08:00" and slots[0]["min_staff"] == 2
+        assert {a["user_id"] for a in slots[0]["assignments"]} == {str(test_user.id)}
+        assert slots[1]["assignments"] == []  # zweiter Slot war unbesetzt
+
+    def test_duplicate_name_conflict(self, enabled, admin_client):
+        _mk_plan(admin_client, "A")
+        b = _mk_plan(admin_client, "B")
+        assert admin_client.post(f"{BASE}/plans/{b}/duplicate", json={"name": "A"}).status_code == 409
+
+    def test_duplicate_empty_name(self, enabled, admin_client):
+        p = _mk_plan(admin_client, "P")
+        assert admin_client.post(f"{BASE}/plans/{p}/duplicate", json={"name": "   "}).status_code == 400
+
+    def test_duplicate_unknown_404(self, enabled, admin_client):
+        import uuid as _uuid
+        assert admin_client.post(f"{BASE}/plans/{_uuid.uuid4()}/duplicate", json={"name": "X"}).status_code == 404

--- a/frontend/src/api/shiftPlanning.ts
+++ b/frontend/src/api/shiftPlanning.ts
@@ -151,6 +151,9 @@ export const updatePlan = (id: string, body: PlanUpdateBody) =>
     })
     .then((r) => r.data);
 export const deletePlan = (id: string) => apiClient.delete(`${BASE}/plans/${id}`);
+// #338: Plan inkl. Slots + Zuweisungen duplizieren (Kopie = inaktiver Entwurf).
+export const duplicatePlan = (id: string, name: string) =>
+  apiClient.post<PlanSummary>(`${BASE}/plans/${id}/duplicate`, { name }).then((r) => r.data);
 
 export interface GenerationResult {
   plan: PlanDetail;

--- a/frontend/src/pages/admin/ShiftPlanning.tsx
+++ b/frontend/src/pages/admin/ShiftPlanning.tsx
@@ -20,6 +20,7 @@ import {
   GraduationCap,
   Pencil,
   Wand2,
+  Copy,
 } from 'lucide-react';
 import apiClient from '../../api/client';
 import Button from '../../components/Button';
@@ -107,6 +108,9 @@ export default function AdminShiftPlanning() {
   const [slotDialog, setSlotDialog] = useState<SlotDialogState | null>(null);
   const [planSettingsOpen, setPlanSettingsOpen] = useState(false);
   const [generateOpen, setGenerateOpen] = useState(false);
+  // #338: Duplizier-Dialog (null = zu); name = vorgeschlagener Name der Kopie.
+  const [duplicateState, setDuplicateState] = useState<{ planId: string; name: string } | null>(null);
+  const [duplicating, setDuplicating] = useState(false);
   // #321 Tagesansicht
   const [shiftView, setShiftView] = useState<'week' | 'day'>('week');
   const [dayWeekday, setDayWeekday] = useState(0);
@@ -215,6 +219,28 @@ export default function AdminShiftPlanning() {
       await refreshSelected();
     } catch (err) {
       toast.error(getErrorMessage(err, 'Fehler beim Umschalten'));
+    }
+  };
+
+  // #338: Plan duplizieren — Dialog mit vorgeschlagenem Namen „… (Kopie)".
+  const openDuplicate = (plan: { id: string; name: string }) =>
+    setDuplicateState({ planId: plan.id, name: `${plan.name} (Kopie)` });
+
+  const confirmDuplicate = async () => {
+    if (!duplicateState || duplicating) return;
+    const name = duplicateState.name.trim();
+    if (!name) return;
+    setDuplicating(true);
+    try {
+      const created = await api.duplicatePlan(duplicateState.planId, name);
+      setDuplicateState(null);
+      toast.success('Schichtplan dupliziert');
+      await loadPlans();
+      setSelectedPlanId(created.id);
+    } catch (err) {
+      toast.error(getErrorMessage(err, 'Fehler beim Duplizieren'));
+    } finally {
+      setDuplicating(false);
     }
   };
 
@@ -517,6 +543,9 @@ export default function AdminShiftPlanning() {
                     <Button variant="secondary" icon={Pencil} onClick={() => setPlanSettingsOpen(true)}>
                       Bearbeiten
                     </Button>
+                    <Button variant="secondary" icon={Copy} onClick={() => openDuplicate(planDetail)}>
+                      Duplizieren
+                    </Button>
                     <Button
                       variant="ghost"
                       icon={Trash2}
@@ -617,6 +646,36 @@ export default function AdminShiftPlanning() {
           onGenerated={refreshSelected}
           onClose={() => setGenerateOpen(false)}
         />
+      )}
+
+      {/* #338: Plan duplizieren — Name der Kopie */}
+      {duplicateState && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="bg-white rounded-xl shadow-lg w-full max-w-md p-5">
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">Schichtplan duplizieren</h3>
+            <p className="text-sm text-gray-500 mb-3">
+              Kopiert alle Zeitslots und Zuweisungen. Die Kopie ist zunächst <strong>inaktiv</strong>.
+            </p>
+            <FormInput
+              label="Name der Kopie"
+              value={duplicateState.name}
+              onChange={(e) => setDuplicateState({ ...duplicateState, name: e.target.value })}
+            />
+            <div className="flex justify-end gap-2 mt-4">
+              <Button variant="secondary" onClick={() => setDuplicateState(null)}>
+                Abbrechen
+              </Button>
+              <Button
+                variant="primary"
+                icon={Copy}
+                onClick={confirmDuplicate}
+                disabled={duplicating || !duplicateState.name.trim()}
+              >
+                Duplizieren
+              </Button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Kundenwunsch (philvdb): Schichtpläne duplizieren, da Varianten sich oft nur in Nuancen unterscheiden.

**Backend:** `POST /api/shift-planning/plans/{id}/duplicate` `{name}` kopiert Plan + alle Slots + alle Zuweisungen. Die Kopie ist ein **inaktiver Entwurf ohne Aktiv-Datumsfenster** (kein versehentliches Parallel-Aktiv). Arbeitsplätze/Einweisungen sind nicht plan-gebunden → werden nicht kopiert. 409 bei Namens-Clash, 400 bei leerem Namen, 404 unbekannt. Tenant-scoped (F-026).

**Frontend:** „Duplizieren"-Button im Plan-Header + Dialog mit vorgeschlagenem Namen „<Original> (Kopie)"; nach dem Duplizieren wird die Kopie geöffnet.

**Tests:** 4 neue Backend-Tests, 31 shift_planning grün, tsc clean.
