### PR TITLE
docs(uc): durchsuchbares Use-Case-Verzeichnis (177 UCs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,7 @@ JSON-Body über `sort_keys=True, separators=(",",":")` kanonisiert, mit Ed25519 
 | Thema | Datei |
 |-------|-------|
 | **Glossar (Stunden vs. Tage, Soll/Ist/Urlaub/Überstunden — verbindliche Begriffe)** | [docs/GLOSSAR.md](docs/GLOSSAR.md) |
+| **Use-Case-Verzeichnis (177 UCs, durchsuchbar, Doku-/Impl-Status)** | [docs/uc/index.html](docs/uc/index.html) ([README](docs/uc/README.md)) |
 | Deployment & Prod | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) |
 | Infrastruktur (Docker, nginx, Caddy, Mail, Monitoring) | [docs/INFRASTRUCTURE.md](docs/INFRASTRUCTURE.md) |
 | Backend-Architektur (Router, Services, Patterns) | [docs/BACKEND-ARCHITEKTUR.md](docs/BACKEND-ARCHITEKTUR.md) |

--- a/docs/uc/README.md
+++ b/docs/uc/README.md
@@ -1,0 +1,31 @@
+# Use-Case-Verzeichnis (UC-Inventar)
+
+[`index.html`](index.html) ist das **durchsuchbare Use-Case-Verzeichnis** von PraxisZeit
+— alle aus dem Code inventarisierten Use-Cases (Akteur, Auslöser, Hauptablauf,
+beteiligte Endpoints/Frontend-Seiten, relevante ArbZG-/BUrlG-/DSGVO-Regeln) plus
+ihr **Doku-Status** (dokumentiert / nicht) und **Implementierungs-Status**
+(korrekt / Abweichung). Oben listet die Seite die offenen Findings (≥ medium).
+
+Im Browser öffnen (Datei genügt, kein Server nötig):
+
+```
+xdg-open docs/uc/index.html      # Linux
+open docs/uc/index.html          # macOS
+```
+
+Filter: Volltextsuche (ID/Titel/Endpoint/Ablauf), Akteur, Bereich, „nur
+undokumentierte", „nur Impl.-Abweichungen". Karten zum Aufklappen anklicken.
+
+## Pflege
+
+Die Seite wird aus dem Ergebnis des UC-Review-Workflows generiert (ein JSON mit
+`result.ucs[]` + `result.findings*`):
+
+```
+python3 docs/uc/_generate.py <uc-review.json>   # schreibt index.html neben das Skript
+```
+
+Bei größeren Funktionsänderungen den UC-Review erneut laufen lassen und neu
+generieren, damit das Inventar aktuell bleibt. Quelle der Wahrheit für das
+Verhalten bleibt der Code + `CLAUDE.md`/[`../GLOSSAR.md`](../GLOSSAR.md); dieses
+Verzeichnis ist die navigierbare Übersicht.

--- a/docs/uc/_generate.py
+++ b/docs/uc/_generate.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Generiert docs/uc/index.html aus dem UC-Review-JSON.
+
+Das JSON ist das Ergebnis des UC-Review-Workflows: ein Objekt mit
+{result: {ucs[], findingsActionable[], findingsLow[], counts{}}}.
+Aufruf:  python3 docs/uc/_generate.py <uc-review.json> [out.html]
+"""
+import json, html, sys, datetime, collections, os
+
+SRC = sys.argv[1] if len(sys.argv) > 1 else "uc-review.json"
+OUT = sys.argv[2] if len(sys.argv) > 2 else os.path.join(os.path.dirname(os.path.abspath(__file__)), "index.html")
+
+d = json.load(open(SRC))
+r = d.get("result", d)
+ucs = r.get("ucs", [])
+counts = r.get("counts", {})
+findings = r.get("findingsActionable", [])
+findings_low = r.get("findingsLow", [])
+
+def e(x):
+    return html.escape(str(x if x is not None else ""))
+
+# kurze Bereichs-Labels (area-Strings sind lang; auf den Teil vor "(" kürzen)
+def short_area(a):
+    return a.split("(")[0].strip() if a else "Sonstige"
+
+by_area = collections.OrderedDict()
+for u in ucs:
+    by_area.setdefault(short_area(u.get("area", "")), []).append(u)
+
+actors = sorted({u.get("actor", "") for u in ucs if u.get("actor")})
+areas = list(by_area.keys())
+gen_date = datetime.date.today().isoformat()
+
+def badge(ok, yes, no):
+    cls = "ok" if ok else "warn"
+    return f'<span class="badge {cls}">{yes if ok else no}</span>'
+
+# --- Findings-HTML ---
+sev_order = {"critical": 0, "high": 1, "medium": 2}
+findings_sorted = sorted(findings, key=lambda f: sev_order.get(f.get("severity"), 9))
+findings_rows = ""
+for f in findings_sorted:
+    sev = f.get("severity", "")
+    findings_rows += f'''<tr class="f-{e(sev)}">
+      <td><span class="sev sev-{e(sev)}">{e(sev.upper())}</span></td>
+      <td>{e(f.get("kind",""))}</td>
+      <td><code>{e(f.get("uc_id",""))}</code></td>
+      <td><strong>{e(f.get("title",""))}</strong><div class="muted">{e(f.get("problem","")[:400])}</div><div class="fix">→ {e(f.get("fix","")[:300])}</div></td>
+    </tr>'''
+
+# --- UC-Karten ---
+sections = ""
+for area, items in by_area.items():
+    cards = ""
+    for u in sorted(items, key=lambda x: x.get("id", "")):
+        doc = badge(u.get("documented"), "dokumentiert", "nicht dokumentiert")
+        impl = badge(u.get("implemented_correctly"), "korrekt", "Abweichung")
+        cards += f'''<div class="uc" data-actor="{e(u.get("actor",""))}" data-area="{e(area)}" data-doc="{'1' if u.get('documented') else '0'}" data-impl="{'1' if u.get('implemented_correctly') else '0'}" data-text="{e((u.get('id','')+' '+u.get('title','')+' '+u.get('main_flow','')+' '+u.get('endpoints','')).lower())}">
+          <div class="uc-head">
+            <code class="uc-id">{e(u.get("id",""))}</code>
+            <span class="uc-title">{e(u.get("title",""))}</span>
+            <span class="actor actor-{e(u.get('actor','').lower())}">{e(u.get("actor",""))}</span>
+            {doc} {impl}
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">{e(u.get("trigger",""))}</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">{e(u.get("main_flow",""))}</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>{e(u.get("endpoints",""))}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">{e(u.get("ui",""))}</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">{e(u.get("doc_location",""))}</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">{e(u.get("rules",""))}</span></div>
+          </div>
+        </div>'''
+    sections += f'''<section class="area" data-area="{e(area)}">
+      <h2>{e(area)} <span class="count">{len(items)}</span></h2>
+      {cards}
+    </section>'''
+
+actor_opts = "".join(f'<option value="{e(a)}">{e(a)}</option>' for a in actors)
+area_opts = "".join(f'<option value="{e(a)}">{e(a)}</option>' for a in areas)
+
+htmldoc = f'''<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PraxisZeit — Use-Case-Verzeichnis</title>
+<style>
+:root{{--p:#2563eb;--bg:#f8fafc;--card:#fff;--bd:#e2e8f0;--mut:#64748b;--ok:#16a34a;--warn:#dc2626;}}
+*{{box-sizing:border-box}}
+body{{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:0;background:var(--bg);color:#0f172a;line-height:1.45}}
+header{{background:linear-gradient(135deg,#1e3a8a,#2563eb);color:#fff;padding:24px 32px}}
+header h1{{margin:0 0 4px;font-size:24px}}
+header .sub{{opacity:.9;font-size:14px}}
+.stats{{display:flex;gap:14px;flex-wrap:wrap;margin-top:16px}}
+.stat{{background:rgba(255,255,255,.15);border-radius:10px;padding:10px 16px;min-width:90px}}
+.stat b{{display:block;font-size:22px}}
+.stat span{{font-size:12px;opacity:.9}}
+.wrap{{max-width:1100px;margin:0 auto;padding:24px 32px}}
+.toolbar{{position:sticky;top:0;background:var(--bg);padding:14px 0;display:flex;gap:10px;flex-wrap:wrap;align-items:center;z-index:10;border-bottom:1px solid var(--bd)}}
+.toolbar input,.toolbar select{{padding:8px 10px;border:1px solid var(--bd);border-radius:8px;font-size:14px}}
+.toolbar input[type=search]{{flex:1;min-width:220px}}
+label.chk{{font-size:13px;color:var(--mut);display:flex;align-items:center;gap:5px}}
+section.area h2{{font-size:18px;border-left:4px solid var(--p);padding-left:10px;margin:28px 0 12px}}
+section.area h2 .count{{background:var(--bd);color:var(--mut);border-radius:10px;padding:1px 9px;font-size:13px;font-weight:600;margin-left:8px}}
+.uc{{background:var(--card);border:1px solid var(--bd);border-radius:12px;margin-bottom:12px;overflow:hidden}}
+.uc-head{{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:12px 16px;cursor:pointer;background:#fafcff}}
+.uc-id{{background:#eef2ff;color:#3730a3;padding:2px 8px;border-radius:6px;font-size:12px;font-weight:700}}
+.uc-title{{font-weight:600;flex:1;min-width:200px}}
+.uc-body{{padding:4px 16px 14px;display:none}}
+.uc.open .uc-body{{display:block}}
+.row{{display:flex;gap:12px;padding:4px 0;border-top:1px solid #f1f5f9;font-size:14px}}
+.row .k{{flex:0 0 90px;color:var(--mut);font-size:12px;text-transform:uppercase;letter-spacing:.03em;padding-top:2px}}
+.row .v{{flex:1}}
+code{{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12.5px;background:#f1f5f9;padding:1px 5px;border-radius:4px}}
+.badge{{font-size:11px;padding:2px 8px;border-radius:10px;font-weight:600}}
+.badge.ok{{background:#dcfce7;color:#166534}}
+.badge.warn{{background:#fee2e2;color:#991b1b}}
+.actor{{font-size:11px;padding:2px 8px;border-radius:10px;background:#e2e8f0;color:#334155;font-weight:600}}
+.actor-admin{{background:#fef3c7;color:#92400e}} .actor-mitarbeiter{{background:#dbeafe;color:#1e40af}}
+.actor-system{{background:#ede9fe;color:#5b21b6}} .actor-superadmin{{background:#fae8ff;color:#86198f}} .actor-interessent{{background:#ccfbf1;color:#115e59}}
+details.findings{{background:#fff;border:1px solid var(--bd);border-radius:12px;margin:18px 0;padding:8px 16px}}
+details.findings summary{{font-weight:700;cursor:pointer;padding:6px 0}}
+table{{width:100%;border-collapse:collapse;font-size:13px}}
+td{{border-top:1px solid var(--bd);padding:8px 6px;vertical-align:top}}
+.sev{{font-size:10px;font-weight:700;padding:2px 7px;border-radius:6px}}
+.sev-high{{background:#fee2e2;color:#991b1b}} .sev-critical{{background:#7f1d1d;color:#fff}} .sev-medium{{background:#fef3c7;color:#92400e}}
+.muted{{color:var(--mut);font-size:12px;margin-top:3px}} .fix{{color:#166534;font-size:12px;margin-top:3px}}
+.hidden{{display:none!important}}
+footer{{color:var(--mut);font-size:12px;text-align:center;padding:24px}}
+</style>
+</head>
+<body>
+<header>
+  <h1>PraxisZeit — Use-Case-Verzeichnis</h1>
+  <div class="sub">Automatisch aus dem Code inventarisiert &amp; geprüft · Stand {gen_date}</div>
+  <div class="stats">
+    <div class="stat"><b>{counts.get("ucs",len(ucs))}</b><span>Use-Cases</span></div>
+    <div class="stat"><b>{len(areas)}</b><span>Bereiche</span></div>
+    <div class="stat"><b>{counts.get("documented","?")}</b><span>dokumentiert</span></div>
+    <div class="stat"><b>{counts.get("undocumented","?")}</b><span>nicht dokumentiert</span></div>
+    <div class="stat"><b>{counts.get("impl_issues","?")}</b><span>Impl.-Abweichungen</span></div>
+    <div class="stat"><b>{len(findings)}</b><span>Findings ≥ medium</span></div>
+  </div>
+</header>
+<div class="wrap">
+  <div class="toolbar">
+    <input type="search" id="q" placeholder="Suche (ID, Titel, Endpoint, Ablauf)…">
+    <select id="fActor"><option value="">Alle Akteure</option>{actor_opts}</select>
+    <select id="fArea"><option value="">Alle Bereiche</option>{area_opts}</select>
+    <label class="chk"><input type="checkbox" id="fUndoc"> nur undokumentierte</label>
+    <label class="chk"><input type="checkbox" id="fImpl"> nur Impl.-Abweichungen</label>
+  </div>
+
+  <details class="findings" open>
+    <summary>Offene Findings ≥ medium ({len(findings)}) · low: {len(findings_low)}</summary>
+    <table><tbody>{findings_rows}</tbody></table>
+  </details>
+
+  {sections}
+</div>
+<footer>PraxisZeit UC-Inventar · {counts.get("ucs",len(ucs))} Use-Cases · generiert aus dem UC-Review-Workflow</footer>
+<script>
+const q=document.getElementById('q'),fa=document.getElementById('fActor'),far=document.getElementById('fArea'),fu=document.getElementById('fUndoc'),fi=document.getElementById('fImpl');
+function apply(){{
+  const t=q.value.trim().toLowerCase(),a=fa.value,ar=far.value,u=fu.checked,im=fi.checked;
+  document.querySelectorAll('.uc').forEach(c=>{{
+    let ok=true;
+    if(t&&!c.dataset.text.includes(t))ok=false;
+    if(a&&c.dataset.actor!==a)ok=false;
+    if(ar&&c.dataset.area!==ar)ok=false;
+    if(u&&c.dataset.doc!=='0')ok=false;
+    if(im&&c.dataset.impl!=='0')ok=false;
+    c.classList.toggle('hidden',!ok);
+    if(ok&&(t||u||im))c.classList.add('open');
+  }});
+  document.querySelectorAll('section.area').forEach(s=>{{
+    const vis=[...s.querySelectorAll('.uc')].some(c=>!c.classList.contains('hidden'));
+    s.classList.toggle('hidden',!vis);
+  }});
+}}
+[q,fa,far,fu,fi].forEach(el=>el.addEventListener('input',apply));
+document.querySelectorAll('.uc-head').forEach(h=>h.addEventListener('click',()=>h.parentNode.classList.toggle('open')));
+</script>
+</body></html>'''
+
+open(OUT, "w").write(htmldoc)
+print(f"geschrieben: {OUT} ({len(htmldoc)} bytes, {len(ucs)} UCs, {len(areas)} Bereiche)")

--- a/docs/uc/index.html
+++ b/docs/uc/index.html
@@ -1,0 +1,2869 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PraxisZeit — Use-Case-Verzeichnis</title>
+<style>
+:root{--p:#2563eb;--bg:#f8fafc;--card:#fff;--bd:#e2e8f0;--mut:#64748b;--ok:#16a34a;--warn:#dc2626;}
+*{box-sizing:border-box}
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:0;background:var(--bg);color:#0f172a;line-height:1.45}
+header{background:linear-gradient(135deg,#1e3a8a,#2563eb);color:#fff;padding:24px 32px}
+header h1{margin:0 0 4px;font-size:24px}
+header .sub{opacity:.9;font-size:14px}
+.stats{display:flex;gap:14px;flex-wrap:wrap;margin-top:16px}
+.stat{background:rgba(255,255,255,.15);border-radius:10px;padding:10px 16px;min-width:90px}
+.stat b{display:block;font-size:22px}
+.stat span{font-size:12px;opacity:.9}
+.wrap{max-width:1100px;margin:0 auto;padding:24px 32px}
+.toolbar{position:sticky;top:0;background:var(--bg);padding:14px 0;display:flex;gap:10px;flex-wrap:wrap;align-items:center;z-index:10;border-bottom:1px solid var(--bd)}
+.toolbar input,.toolbar select{padding:8px 10px;border:1px solid var(--bd);border-radius:8px;font-size:14px}
+.toolbar input[type=search]{flex:1;min-width:220px}
+label.chk{font-size:13px;color:var(--mut);display:flex;align-items:center;gap:5px}
+section.area h2{font-size:18px;border-left:4px solid var(--p);padding-left:10px;margin:28px 0 12px}
+section.area h2 .count{background:var(--bd);color:var(--mut);border-radius:10px;padding:1px 9px;font-size:13px;font-weight:600;margin-left:8px}
+.uc{background:var(--card);border:1px solid var(--bd);border-radius:12px;margin-bottom:12px;overflow:hidden}
+.uc-head{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:12px 16px;cursor:pointer;background:#fafcff}
+.uc-id{background:#eef2ff;color:#3730a3;padding:2px 8px;border-radius:6px;font-size:12px;font-weight:700}
+.uc-title{font-weight:600;flex:1;min-width:200px}
+.uc-body{padding:4px 16px 14px;display:none}
+.uc.open .uc-body{display:block}
+.row{display:flex;gap:12px;padding:4px 0;border-top:1px solid #f1f5f9;font-size:14px}
+.row .k{flex:0 0 90px;color:var(--mut);font-size:12px;text-transform:uppercase;letter-spacing:.03em;padding-top:2px}
+.row .v{flex:1}
+code{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12.5px;background:#f1f5f9;padding:1px 5px;border-radius:4px}
+.badge{font-size:11px;padding:2px 8px;border-radius:10px;font-weight:600}
+.badge.ok{background:#dcfce7;color:#166534}
+.badge.warn{background:#fee2e2;color:#991b1b}
+.actor{font-size:11px;padding:2px 8px;border-radius:10px;background:#e2e8f0;color:#334155;font-weight:600}
+.actor-admin{background:#fef3c7;color:#92400e} .actor-mitarbeiter{background:#dbeafe;color:#1e40af}
+.actor-system{background:#ede9fe;color:#5b21b6} .actor-superadmin{background:#fae8ff;color:#86198f} .actor-interessent{background:#ccfbf1;color:#115e59}
+details.findings{background:#fff;border:1px solid var(--bd);border-radius:12px;margin:18px 0;padding:8px 16px}
+details.findings summary{font-weight:700;cursor:pointer;padding:6px 0}
+table{width:100%;border-collapse:collapse;font-size:13px}
+td{border-top:1px solid var(--bd);padding:8px 6px;vertical-align:top}
+.sev{font-size:10px;font-weight:700;padding:2px 7px;border-radius:6px}
+.sev-high{background:#fee2e2;color:#991b1b} .sev-critical{background:#7f1d1d;color:#fff} .sev-medium{background:#fef3c7;color:#92400e}
+.muted{color:var(--mut);font-size:12px;margin-top:3px} .fix{color:#166534;font-size:12px;margin-top:3px}
+.hidden{display:none!important}
+footer{color:var(--mut);font-size:12px;text-align:center;padding:24px}
+</style>
+</head>
+<body>
+<header>
+  <h1>PraxisZeit — Use-Case-Verzeichnis</h1>
+  <div class="sub">Automatisch aus dem Code inventarisiert &amp; geprüft · Stand 2026-06-28</div>
+  <div class="stats">
+    <div class="stat"><b>177</b><span>Use-Cases</span></div>
+    <div class="stat"><b>10</b><span>Bereiche</span></div>
+    <div class="stat"><b>132</b><span>dokumentiert</span></div>
+    <div class="stat"><b>45</b><span>nicht dokumentiert</span></div>
+    <div class="stat"><b>17</b><span>Impl.-Abweichungen</span></div>
+    <div class="stat"><b>16</b><span>Findings ≥ medium</span></div>
+  </div>
+</header>
+<div class="wrap">
+  <div class="toolbar">
+    <input type="search" id="q" placeholder="Suche (ID, Titel, Endpoint, Ablauf)…">
+    <select id="fActor"><option value="">Alle Akteure</option><option value="Admin">Admin</option><option value="Interessent">Interessent</option><option value="Mitarbeiter">Mitarbeiter</option><option value="Superadmin">Superadmin</option><option value="System">System</option></select>
+    <select id="fArea"><option value="">Alle Bereiche</option><option value="Authentifizierung &amp; Account">Authentifizierung &amp; Account</option><option value="Mitarbeiter-Zeiterfassung">Mitarbeiter-Zeiterfassung</option><option value="Mitarbeiter-Abwesenheiten/Anträge">Mitarbeiter-Abwesenheiten/Anträge</option><option value="Mitarbeiter-Sonstiges">Mitarbeiter-Sonstiges</option><option value="Admin-Benutzerverwaltung">Admin-Benutzerverwaltung</option><option value="Admin-Berichte &amp; Datenaustausch">Admin-Berichte &amp; Datenaustausch</option><option value="Admin-Genehmigungen &amp; Kalender">Admin-Genehmigungen &amp; Kalender</option><option value="Admin-Schichtplanung">Admin-Schichtplanung</option><option value="Admin-Betrieb">Admin-Betrieb</option><option value="Querschnitt &amp; System">Querschnitt &amp; System</option></select>
+    <label class="chk"><input type="checkbox" id="fUndoc"> nur undokumentierte</label>
+    <label class="chk"><input type="checkbox" id="fImpl"> nur Impl.-Abweichungen</label>
+  </div>
+
+  <details class="findings" open>
+    <summary>Offene Findings ≥ medium (16) · low: 37</summary>
+    <table><tbody><tr class="f-high">
+      <td><span class="sev sev-high">HIGH</span></td>
+      <td>doku</td>
+      <td><code>ABV-07</code></td>
+      <td><strong>DSGVO-Anonymisierung + endgueltige Loeschung nicht im Benutzer-Handbuch / In-App-Hilfe dokumentiert</strong><div class="muted">Die UI bietet Admins zwei irreversible Art.17-Aktionen mit nichttrivialen Regeln (14-Tage-Sperrfrist, 730-Tage-Aufbewahrung, Unterschied Anonymisierung vs. Purge, anonymisierte User koennen erst danach geloescht werden). Im Admin-Handbuch (HANDBUCH-ADMIN.md), Cheatsheet (CHEATSHEET-ADMIN.md) und der In-App-Hilfe (DocViewer.tsx) ist davon NICHTS beschrieben — dort steht nur die Deaktivierung (&#x27;niem</div><div class="fix">→ In HANDBUCH-ADMIN.md (Abschnitt Benutzerverwaltung) und CHEATSHEET-ADMIN.md einen Abschnitt &#x27;DSGVO-Anonymisierung &amp; endgueltige Loeschung (Art.17)&#x27; ergaenzen: Ablauf Deaktivieren -&gt; 14 Tage Sperrfrist -&gt; Anonymisieren (Name/Email/Profilbild weg, Zeiteintraege bleiben §16) -&gt; nach 730 Tagen endguelti</div></td>
+    </tr><tr class="f-high">
+      <td><span class="sev sev-high">HIGH</span></td>
+      <td>doku</td>
+      <td><code>IMP-01</code></td>
+      <td><strong>Handbuch-Import-Abschnitt beschreibt ein völlig anderes Feature (CSV/Abwesenheiten/Vorlage)</strong><div class="muted">docs/handbuch/HANDBUCH-ADMIN.md Abschnitt 12 (&#x27;Import&#x27;, Z.455-461) sagt: &#x27;Zeiteinträge oder Abwesenheitsdaten aus externen Quellen (z. B. CSV-Dateien) importieren&#x27; und &#x27;Laden Sie die Vorlagendatei herunter, befüllen Sie sie ... und laden Sie die Datei wieder hoch.&#x27; Tatsächlich importiert das Feature ausschließlich TimeRec-.xls (BIFF/OLE2) — CSV und .xlsx/ZIP werden per Magic-Byte-Guard mit HTTP 40</div><div class="fix">→ Abschnitt 12 neu schreiben: TimeRec-.xls (Sheet &#x27;Zeiterfassung&#x27;), nur Zeiteinträge, max. 5 MB, Wizard mit Vorschau (Konflikte/ArbZG-Warnungen) und Überschreiben-Option; ausdrücklich KEIN CSV/xlsx, keine Vorlage, keine Abwesenheiten. Vgl. docs/specs/2026-03-10-xls-import-design.md.</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>implementierung</td>
+      <td><code>AUTH-05</code></td>
+      <td><strong>change_password rotiert Access-Token, aber NICHT das Refresh-Cookie -&gt; stiller Logout nach ~30 min</strong><div class="muted">POST /api/auth/change-password macht token_version++ und gibt einen frischen Access-Token zurueck (Profile.tsx ruft setTokens). Das Refresh-Cookie traegt jedoch weiterhin die ALTE token_version und wird nicht neu gesetzt (der Handler hat gar keinen Response-Parameter, kann also kein Cookie setzen). Sobald der neue Access-Token nach ACCESS_TOKEN_EXPIRE_MINUTES (30 min) ablaeuft, schlaegt /api/auth/</div><div class="fix">→ change_password einen response: Response-Parameter geben und nach dem token_version-Bump ein frisches Refresh-Cookie (_set_refresh_cookie mit neuem create_refresh_token) + CSRF-Cookie setzen, analog zum Login. Alternativ bewusst sofort vollstaendig ausloggen und das im Handbuch so beschreiben.</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>doku</td>
+      <td><code>AUTH-02</code></td>
+      <td><strong>2FA/TOTP komplett undokumentiert (Handbuch, Cheatsheet, In-App-Hilfe)</strong><div class="muted">Die gesamte 2FA-Funktionalitaet (Login-Challenge AUTH-02, Einrichten AUTH-09, Verifizieren AUTH-10, Deaktivieren AUTH-11) ist nirgends dokumentiert: kein Treffer fuer &#x27;2FA/TOTP/Authenticator/Zwei-Faktor&#x27; in HANDBUCH-MITARBEITER.md, HANDBUCH-ADMIN.md, CHEATSHEET-*.md oder frontend/src/components/DocViewer.tsx. Profil §7 listet nur Passwort + Kalenderfarbe unter &#x27;Weitere Einstellungen&#x27;, obwohl 2FA p</div><div class="fix">→ Abschnitt &#x27;Zwei-Faktor-Authentifizierung&#x27; in HANDBUCH-MITARBEITER.md §7, CHEATSHEET-MITARBEITER.md und DocViewer (handbuchMitarbeiterSections) ergaenzen: Aktivieren (QR/Secret), Login-Ablauf, Deaktivieren, Hinweis auf Geraeteverlust/Admin-Kontakt. CLAUDE.md fordert In-App-Hilfe UND Markdown-Handbuch</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>implementierung</td>
+      <td><code>MZ-01</code></td>
+      <td><strong>§5-Ruhezeitwarnung feuert fälschlich beim 2. Einstempeln am selben Tag (Schichtwechsel/Mittagsschließung)</strong><div class="muted">In clock_in (time_entries.py Z.299-320) sucht die §5-Prüfung den letzten ausgestempelten Eintrag mit Filter `TimeEntry.date &lt;= now.date()` ohne Same-Day-Ausschluss. Stempelt ein MA in einer Arztpraxis mit geteilter Sprechzeit vormittags aus (z.B. 12:00) und nachmittags wieder ein (z.B. 15:00), errechnet sich rest_hours ~3h &lt; 11h → es erscheint die Warnung &#x27;Nur 3.0h Ruhezeit seit letztem Arbeitsend</div><div class="fix">→ Die §5-Query auf Einträge VOR dem aktuellen Tag beschränken (`TimeEntry.date &lt; now.date()`) oder den last_entry verwerfen, wenn last_entry.date == now.date(). Nur nicht-blockierende Warnung, daher keine Datenkorrektheits-, aber relevante UX-/Vertrauens-Wirkung.</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>implementierung</td>
+      <td><code>MA-ABS-03</code></td>
+      <td><strong>Picker &#x27;Eigene Gründe&#x27; fehlt im dokumentierten Direkt-Buchungsformular (AbsenceCalendarPage)</strong><div class="muted">Handbuch-MITARBEITER §4.1 und die In-App-Hilfe (DocViewer.tsx ~Z.335) versprechen: Eigene Abwesenheitsgründe &#x27;erscheinen … in der Typ-Auswahl unter &quot;Eigene Gründe&quot;&#x27; im Formular &#x27;+ Abwesenheit eintragen&#x27;. Das ist FALSCH: Die Typ-Auswahl in frontend/src/pages/AbsenceCalendarPage.tsx (Z.569-578) ist hartkodiert (vacation/sick/training/overtime/other), lädt KEINE absence-reasons und sendet im doSubmit</div><div class="fix">→ Entweder den Reason-Picker (myReasons() + optgroup &#x27;Eigene Gründe&#x27; wie in MonthlyJournal) in AbsenceCalendarPage einbauen und reason_id im POST /absences mitschicken; ODER Handbuch-MITARBEITER §4.1 + DocViewer ~Z.335 korrigieren, dass eigene Gründe über die Journal-Seite (als Antrag) gebucht werden.</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>implementierung</td>
+      <td><code>MA-ABS-01</code></td>
+      <td><strong>vacation_approval_required wird auf dem Direkt-Buchungsendpoint nicht erzwungen (Approval-Bypass via API)</strong><div class="muted">Bei aktivierter Genehmigungspflicht routet nur das Frontend (AbsenceCalendarPage doSubmit Z.206) Urlaub auf /vacation-requests. Der Backend-Endpoint POST /api/absences (absences.create_absence) prüft vacation_approval_required NIRGENDS — grep zeigt das Flag wird ausschließlich in vacation_requests.create_vacation_request gelesen. Ein Mitarbeiter kann die Genehmigungspflicht daher mit einem direkte</div><div class="fix">→ In create_absence bei type==VACATION (und ggf. weiteren genehmigungspflichtigen Typen) für Nicht-Admins prüfen: wenn settings_service.get_bool_setting(db,&#x27;vacation_approval_required&#x27;,tenant_id) → 400/403 mit Verweis auf den Antragsweg (Admins/eigene Buchung für andere ausgenommen).</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>implementierung</td>
+      <td><code>MS-06</code></td>
+      <td><strong>DSGVO Art.15-Export enthält keine Schichtplanungs-/Einweisungsdaten</strong><div class="muted">build_self_export_payload (lifecycle_service.py) sammelt TimeEntries, Absences, VacationRequests, ChangeRequests und Audit-Logs, aber KEINE Schichtplanungs-Daten des MA: weder shift_assignments (wann/wo eingeteilt) noch workstation_qualifications (Einweisungen = personenbezogene Kompetenzdaten). Bei aktivierter Schichtplanung ist die Art.15-Auskunft damit unvollständig; auch art15_meta.b_datenkate</div><div class="fix">→ Bei aktiviertem Feature-Flag eigene ShiftAssignments (mit Plan/Slot/Arbeitsplatz/Wochentag/Zeit) und eigene WorkstationQualifications in den Export aufnehmen (tenant- + user_id-gescoped) und b_datenkategorien um &#x27;Schichtplanung/Einweisungen&#x27; ergänzen. Falls bewusst als reines Planungsartefakt ausges</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>implementierung</td>
+      <td><code>ABV-14</code></td>
+      <td><strong>Jahresabschluss uebernimmt Resturlaub von MA ohne Stundenzaehlung NICHT (track_hours-Filter)</strong><div class="muted">create_year_closing-Endpoint (admin_carryovers.py Z.137-141) filtert User auf track_hours==True. MA ohne Stundenzaehlung (#191) fuehren laut GLOSSAR/Handbuch trotzdem tagebasiert Urlaub mit Pro-rata-Anspruch + Vortrag — werden aber beim Jahresabschluss uebersprungen, sodass ihr Resturlaub NICHT als YearCarryover ins Folgejahr uebernommen wird (geht verloren, sofern der Admin ihn nicht manuell per </div><div class="fix">→ Im Jahresabschluss untracked MA fuer die VACATION-Carryover-Berechnung einbeziehen (nur Resturlaub, Ueberstunden=0) ODER bis zur Loesung von #191 die Handbuch-/Cheatsheet-Formulierung praezisieren (&#x27;aktive MA mit Stundenzaehlung; bei MA ohne Stundenzaehlung Resturlaub manuell per Vorjahresuebernahme</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>code-qualitaet</td>
+      <td><code>ABV-12</code></td>
+      <td><strong>Direktes Editieren von weekly_hours im UserForm umgeht die Stundenhistorie (rueckwirkende Soll-Aenderung)</strong><div class="muted">UserForm sendet weekly_hours als regulaeres Update-Feld an PUT /users/{id}, das user.weekly_hours direkt setzt. get_weekly_hours_for_date faellt fuer Daten OHNE passenden WorkingHoursChange auf user.weekly_hours zurueck (calculation_service.py Z.57-63). Bei einem Bestands-MA ohne Stundenhistorie aendert ein Edit der Wochenstunden damit rueckwirkend ALLE vergangenen Monats-Solls/Salden — obwohl Han</div><div class="fix">→ Entweder das weekly_hours-Direktfeld im UserForm beim Bearbeiten read-only/entfernen und konsequent auf die Stundenhistorie verweisen, oder beim Edit eine Warnung/Confirm zeigen (&#x27;aendert rueckwirkend; fuer Teilzeitumstellung Stundenhistorie nutzen&#x27;). Mindestens als Tooltip im Formular klarstellen.</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>doku</td>
+      <td><code>RPT-05</code></td>
+      <td><strong>In-App-Hilfe nennt falsches Exportformat (CSV) und unterschlägt ODS/PDF</strong><div class="muted">frontend/src/components/DocViewer.tsx Z.416 (&#x27;3. Berichte &amp; Excel-Exporte&#x27;): &#x27;Jeder Report ist als Excel oder CSV verfügbar.&#x27; Es gibt KEINEN CSV-Export. Die tatsächlichen Formate sind XLSX, ODS und (für den Monatsreport zusätzlich) PDF — siehe reports.py /export-ods, /export-pdf, /export-yearly-ods etc. Außerdem fehlt die Erwähnung der Art.9-Krankheitsdaten-Checkbox in der In-App-Hilfe.</div><div class="fix">→ DocViewer.tsx Z.416 auf &#x27;Excel (.xlsx), ODS (.ods) und PDF (nur Monatsreport)&#x27; korrigieren; optional Hinweis auf die Krankheitsdaten-Checkbox (Art.9, audit-protokolliert) ergänzen.</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>implementierung</td>
+      <td><code>RPT-12</code></td>
+      <td><strong>§18-befreite MA werden in Sonntags-/Nacht-/Ersatzruhetag-Auswertung nicht ausgeschlossen (inkonsistent)</strong><div class="muted">rest-time-violations (RPT-11, via rest_time_service Z.123 User.exempt_from_arbzg==False) UND 24-week-average (RPT-15 Z.952 &#x27;if user.exempt_from_arbzg: continue&#x27;) überspringen §18-leitende Angestellte. sunday-summary, night-work-summary und compensatory-rest (reports.py Z.710/759/818) iterieren dagegen über _get_active_visible_users OHNE exempt-Filter und können so §18-MA fälschlich als &#x27;§11/§6-Ver</div><div class="fix">→ In sunday-summary, night-work-summary und compensatory-rest entweder analog `if user.exempt_from_arbzg: continue` überspringen oder exempt-MA gesondert kennzeichnen — konsistent zu rest-time/24-week. Falls bewusst inkludiert (rein informativ), als &#x27;exempt&#x27;-Flag pro Zeile ausgeben statt als Verstoß z</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>doku</td>
+      <td><code>AC-08</code></td>
+      <td><strong>Handbuch behauptet Urlaubsgenehmigung sei unwiderruflich – Storno-Funktion existiert</strong><div class="muted">docs/handbuch/HANDBUCH-ADMIN.md §7 sagt: &#x27;Achtung: Eine Genehmigung ist unwiderruflich. Zum Stornieren müssen die erstellten Abwesenheitseinträge manuell gelöscht werden.&#x27; Tatsächlich gibt es DELETE /api/admin/vacation-requests/{id} (cancel_vacation_request_as_admin) plus den UI-Button &#x27;Urlaub stornieren&#x27; in admin/VacationApprovals.tsx, der für genehmigte ZUKÜNFTIGE Anträge die zugehörigen Abwesen</div><div class="fix">→ Handbuch-Abschnitt 7 (und ggf. DocViewer &#x27;5.&#x27;) korrigieren: genehmigte zukünftige Anträge können über &#x27;Urlaub stornieren&#x27; storniert werden (Absencen werden automatisch entfernt); zusätzlich die &#x27;Bearbeiten&#x27;-Funktion (PATCH, AC-07) für offene Anträge erwähnen.</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>implementierung</td>
+      <td><code>AC-11</code></td>
+      <td><strong>Betriebsferien/Urlaubsgenehmigung ignorieren Sondertage 24./31.12.</strong><div class="muted">Die Arbeitstags-Berechnung für Betriebsferien (company_closures._get_workdays) und für die Urlaubsantrags-Genehmigung (admin_vacations.review_vacation_request, Schleife cur.weekday()&lt;5 and cur not in holidays) schließt nur Wochenenden + gesetzliche Feiertage aus, NICHT die konfigurierbaren Sondertage 24./31.12. (free/half_day). day_target kommt aus get_daily_target_for_date, das den Sondertags-Fak</div><div class="fix">→ In _get_workdays bzw. _create_closure_absences und im review_vacation_request-Loop die Sondertage berücksichtigen: free-Tage (special_day_target_factor==0) überspringen (kein Eintrag), half_day-Tage mit half_day=True/halbem Tagessoll buchen – analog zur Feiertags-Behandlung bzw. konsistent mit speci</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>implementierung</td>
+      <td><code>ADM-12</code></td>
+      <td><strong>Compliance-Änderungsprotokoll ohne Pagination: ältere Audit-Einträge werden ab &gt;100/Monat stillschweigend abgeschnitten</strong><div class="muted">AuditLog.tsx (Seite &#x27;Änderungsprotokoll&#x27;) ruft GET /admin/audit-log nur mit month + optional user_id auf, ohne skip/limit/before. Das Backend defaultet limit=100 und sortiert created_at DESC. In einem Monat mit mehr als 100 Audit-Rows (in einer aktiven Praxis mit mehreren MA inkl. Zugriffsmarkern realistisch, da changes_only=false ALLE Ereignisse zeigt) werden die ÄLTESTEN Einträge des Monats nich</div><div class="fix">→ Im Frontend Keyset-Pagination (before=created_at der letzten Zeile) bzw. eine &#x27;Mehr laden&#x27;-Schaltfläche implementieren, oder zumindest sichtbar warnen, wenn die Antwort das Limit erreicht. Backend-Keyset-Cursor ist vorhanden — nur das UI nutzt ihn nicht.</div></td>
+    </tr><tr class="f-medium">
+      <td><span class="sev sev-medium">MEDIUM</span></td>
+      <td>implementierung</td>
+      <td><code>CS-12</code></td>
+      <td><strong>Superadmin §16-Notfall-Export enthält die ungekappten Rohstempel (raw_start_time/raw_end_time) NICHT</strong><div class="muted">superadmin._time_entry_dict (backend/app/routers/superadmin.py:68-78) serialisiert nur start_time/end_time/break_minutes/note/sunday_exception_reason. Die work-window-Kappung (#201) speichert die tatsächlichen Stempel in raw_start_time/raw_end_time; eingehängt an allen Schreibpfaden. Der lifecycle-Export (build_tenant_export_payload._time_entry_dict, lifecycle_service.py:347-365) nimmt diese Felde</div><div class="fix">→ raw_start_time/raw_end_time (und sinnvollerweise created_at) in superadmin._time_entry_dict aufnehmen, analog zu lifecycle_service._time_entry_dict; idealerweise beide Serializer auf den gemeinsamen lifecycle-Helper konsolidieren, damit sie nicht erneut auseinanderlaufen.</div></td>
+    </tr></tbody></table>
+  </details>
+
+  <section class="area" data-area="Authentifizierung &amp; Account">
+      <h2>Authentifizierung &amp; Account <span class="count">18</span></h2>
+      <div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="1" data-impl="1" data-text="auth-01 login mit benutzername/passwort (refresh-cookie, csrf, rate-limit, lockout) post /api/auth/login: account-lockout-pruefung (5 fehlversuche/15min -&gt; 429), superadmin-kontext fuer cross-tenant lookup, case-insensitive username, bcrypt_sha256-verify (dummy-hash bei unbekanntem/inaktivem user gegen timing-leak, f-040), opportunistisches rehash legacy bcrypt (f-041), tenant-aktiv-pruefung, access-token (json) + refresh-token (httponly-cookie /api/auth/refresh) + csrf-double-submit-cookie. security-logging aller events. post /api/auth/login">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-01</code>
+            <span class="uc-title">Login mit Benutzername/Passwort (Refresh-Cookie, CSRF, Rate-Limit, Lockout)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Nutzer gibt Benutzername+Passwort auf der Login-Seite ein</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/auth/login: Account-Lockout-Pruefung (5 Fehlversuche/15min -&gt; 429), Superadmin-Kontext fuer cross-tenant Lookup, case-insensitive username, bcrypt_sha256-Verify (Dummy-Hash bei unbekanntem/inaktivem User gegen Timing-Leak, F-040), opportunistisches Rehash legacy bcrypt (F-041), Tenant-aktiv-Pruefung, Access-Token (JSON) + Refresh-Token (HttpOnly-Cookie /api/auth/refresh) + CSRF-Double-Submit-Cookie. Security-Logging aller Events.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/auth/login</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/Login.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §1 Anmelden; CHEATSHEET-MITARBEITER.md; DocViewer CheatsheetMitarbeiter</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO Art.5 (neutrale Log-Gruende, kein Leak inactive vs unknown M-001); Timing-Equalisierung; per-Username-Lockout zusaetzlich zu slowapi IP-Limit; Multi-Tenant superadmin-Kontext beim Lookup</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="0" data-impl="1" data-text="auth-02 2fa/totp-challenge beim login bei totp_enabled ohne totp_code -&gt; 401 + header x-requires-totp (frontend zeigt code-feld). mit code: decrypt_secret + verify_totp_with_counter (replay-schutz via last_totp_counter), legacy-klartext-secret wird bei erfolg auf fernet migriert. post /api/auth/login (totp_code)">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-02</code>
+            <span class="uc-title">2FA/TOTP-Challenge beim Login</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">User mit totp_enabled loggt sich ein</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Bei totp_enabled ohne totp_code -&gt; 401 + Header X-Requires-TOTP (Frontend zeigt Code-Feld). Mit Code: decrypt_secret + verify_totp_with_counter (Replay-Schutz via last_totp_counter), Legacy-Klartext-Secret wird bei Erfolg auf Fernet migriert.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/auth/login (totp_code)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Login.tsx (totpRequired-Feld)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO Art.32 (TOTP-Secret Fernet-verschluesselt, Migration on-login); Replay-Schutz per Counter; ±30s Fenster</span></div>
+          </div>
+        </div><div class="uc" data-actor="System" data-area="Authentifizierung &amp; Account" data-doc="0" data-impl="1" data-text="auth-03 access-token-refresh ueber refresh-cookie post /api/auth/refresh liest httponly-cookie, decode + type==refresh, token_version-pruefung gegen db, tenant-aktiv, neuer access-token + rotiertes csrf-cookie. refresh-token selbst wird nicht rotiert (7 tage gueltig). post /api/auth/refresh">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-03</code>
+            <span class="uc-title">Access-Token-Refresh ueber Refresh-Cookie</span>
+            <span class="actor actor-system">System</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Frontend-Interceptor bei 401/Ablauf des Access-Tokens</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/auth/refresh liest HttpOnly-Cookie, decode + type==refresh, token_version-Pruefung gegen DB, Tenant-aktiv, neuer Access-Token + rotiertes CSRF-Cookie. Refresh-Token selbst wird NICHT rotiert (7 Tage gueltig).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/auth/refresh</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/api/client.ts (Interceptor)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (internes Mechanismus, kein Handbuch-Bedarf)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">token_version-Revocation; Tenant-aktiv-Check; CSRF-Rotation; COOKIE_SECURE/SAMESITE</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="1" data-impl="1" data-text="auth-04 logout (alle sitzungen invalidieren) post /api/auth/logout (auth-pflichtig): token_version++, refresh- + csrf-cookie loeschen, security-log. post /api/auth/logout">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-04</code>
+            <span class="uc-title">Logout (alle Sitzungen invalidieren)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Nutzer klickt Abmelden</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/auth/logout (auth-pflichtig): token_version++, Refresh- + CSRF-Cookie loeschen, Security-Log.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/auth/logout</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Layout/Navigation (authStore.logout)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">Implizit; HANDBUCH-MITARBEITER §1; Interceptor-Ausschluss /auth/logout in CLAUDE.md dokumentiert</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">token_version-Bump invalidiert ALLE Tokens; 401-Interceptor muss /auth/logout ausschliessen (CLAUDE.md-Regel)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="1" data-impl="0" data-text="auth-05 passwort aendern post /api/auth/change-password (3/min): aktuelles pw verifizieren, komplexitaet (min10+gross+klein+ziffer, backend+frontend), hash setzen, token_version++, neuer access-token in response. post /api/auth/change-password">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-05</code>
+            <span class="uc-title">Passwort aendern</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Profil -&gt; Passwort aendern</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/auth/change-password (3/min): aktuelles PW verifizieren, Komplexitaet (min10+Gross+Klein+Ziffer, Backend+Frontend), Hash setzen, token_version++, NEUER Access-Token in Response.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/auth/change-password</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Profile.tsx (handlePasswordChange)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §7 Passwort aendern; CHEATSHEET-MITARBEITER.md; DocViewer</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Passwort-Komplexitaet doppelt validiert; token_version invalidiert andere Sitzungen (im Handbuch zugesichert); Rate-Limit 3/min</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="0" data-impl="1" data-text="auth-06 profil bearbeiten (name/e-mail, dsgvo art.16) put /api/auth/profile: first_name/last_name/email aendern; e-mail-format-validierung; bei e-mail-aenderung audit-row (action=profile_update, source=self_service) mit alt-&gt;neu. put /api/auth/profile">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-06</code>
+            <span class="uc-title">Profil bearbeiten (Name/E-Mail, DSGVO Art.16)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Profil -&gt; Bearbeiten</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">PUT /api/auth/profile: first_name/last_name/email aendern; E-Mail-Format-Validierung; bei E-Mail-Aenderung Audit-Row (action=profile_update, source=self_service) mit alt-&gt;neu.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/auth/profile</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Profile.tsx (handleProfileUpdate)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (Handbuch zeigt Daten nur als &#x27;vom Admin hinterlegt&#x27;, erwaehnt Eigen-Edit nicht)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO Art.16 Berichtigung; F-060 E-Mail-Aenderung audit-logged; tenant_id am Audit gesetzt</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="1" data-impl="1" data-text="auth-07 kalenderfarbe aendern put /api/auth/calendar-color: hex-pattern-validiert (#rrggbb), auf user gespeichert. put /api/auth/calendar-color">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-07</code>
+            <span class="uc-title">Kalenderfarbe aendern</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Profil -&gt; Weitere Einstellungen -&gt; Kalenderfarbe</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">PUT /api/auth/calendar-color: Hex-Pattern-validiert (#RRGGBB), auf User gespeichert.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/auth/calendar-color</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Profile.tsx (handleColorChange)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §7 Weitere Einstellungen</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Pattern-Validierung Backend+Schema</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="0" data-impl="1" data-text="auth-08 profilbild hochladen/loeschen put /api/auth/profile-picture (20/min): max 500kb (stream-grenze +1 byte gegen memory-dos), magic-bytes jpeg/png (content-type nicht vertraut), als data-uri gespeichert. delete setzt auf null. put/delete /api/auth/profile-picture">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-08</code>
+            <span class="uc-title">Profilbild hochladen/loeschen</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Profil -&gt; Avatar klicken / Entfernen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">PUT /api/auth/profile-picture (20/min): max 500KB (Stream-Grenze +1 Byte gegen Memory-DoS), Magic-Bytes JPEG/PNG (Content-Type nicht vertraut), als data-URI gespeichert. DELETE setzt auf NULL.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT/DELETE /api/auth/profile-picture</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Profile.tsx (handleFileUpload/handleDeleteProfilePicture)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Magic-Byte-Validierung (C1); Groessen-Limit Stream-basiert; Rate-Limit</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="0" data-impl="1" data-text="auth-09 2fa/totp einrichten (setup) post /api/auth/totp/setup (3/min): neues base32-secret generieren, fernet-verschluesselt speichern, counter zuruecksetzen (m-1), otpauth-uri + klartext-secret fuer qr zurueck. totp_enabled bleibt false bis verify. post /api/auth/totp/setup">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-09</code>
+            <span class="uc-title">2FA/TOTP einrichten (Setup)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Profil -&gt; 2FA aktivieren</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/auth/totp/setup (3/min): neues Base32-Secret generieren, Fernet-verschluesselt speichern, Counter zuruecksetzen (M-1), otpauth-URI + Klartext-Secret fuer QR zurueck. totp_enabled bleibt False bis Verify.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/auth/totp/setup</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Profile.tsx (handleTotpSetup, QRCodeSVG)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO Art.32 Fernet-Verschluesselung; Counter-Reset gegen Replay-Block direkt nach Login</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="0" data-impl="1" data-text="auth-10 2fa/totp verifizieren &amp; aktivieren post /api/auth/totp/verify (3/min): verify_totp_with_counter (replay-safe, m-sec4), counter persistieren, totp_enabled=true. post /api/auth/totp/verify">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-10</code>
+            <span class="uc-title">2FA/TOTP verifizieren &amp; aktivieren</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Setup-Wizard Schritt 2: Code eingeben</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/auth/totp/verify (3/min): verify_totp_with_counter (replay-safe, M-SEC4), Counter persistieren, totp_enabled=True.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/auth/totp/verify</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Profile.tsx (handleTotpVerify)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Replay-Schutz (Code darf danach nicht gegen /login wiederholt werden)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="0" data-impl="0" data-text="auth-11 2fa/totp deaktivieren delete /api/auth/totp/disable (3/min): passwort-verify, totp_secret=none, totp_enabled=false, counter-reset (m-1), token_version++ (s-l03). delete /api/auth/totp/disable">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-11</code>
+            <span class="uc-title">2FA/TOTP deaktivieren</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Profil -&gt; 2FA deaktivieren (Passwort bestaetigen)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">DELETE /api/auth/totp/disable (3/min): Passwort-Verify, totp_secret=None, totp_enabled=False, Counter-Reset (M-1), token_version++ (S-L03).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>DELETE /api/auth/totp/disable</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Profile.tsx (handleTotpDisable)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">S-L03 Sessions invalidieren bei sicherheitsrelevanter Aenderung; Passwortbestaetigung Pflicht</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="0" data-impl="1" data-text="auth-12 dsgvo selbstauskunft/export (art.15) - vollstaendig get /api/me/data-export (5/tag/ip): build_self_export_payload (stammdaten, zeiteintraege, abwesenheiten, urlaubs-/aenderungsantraege, audit-logs), rfc-5987-dateiname, audit-row source=self_data_export. get /api/me/data-export">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-12</code>
+            <span class="uc-title">DSGVO Selbstauskunft/Export (Art.15) - vollstaendig</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Profil -&gt; Meine Daten exportieren -&gt; JSON herunterladen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/me/data-export (5/Tag/IP): build_self_export_payload (Stammdaten, Zeiteintraege, Abwesenheiten, Urlaubs-/Aenderungsantraege, Audit-Logs), RFC-5987-Dateiname, Audit-Row source=self_data_export.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/me/data-export</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Profile.tsx (handleDataExport)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">Nur in UI-Text; FEHLT im Handbuch/Cheatsheet/DocViewer</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO Art.15+20; RLS+F-026 tenant-gescoped (nur eigene Daten); Audit-Nachvollziehbarkeit; Rate-Limit gegen Scraping</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="0" data-impl="1" data-text="auth-13 dsgvo datenexport (art.20) - legacy-endpoint get /api/auth/me/export: stammdaten + zeiteintraege (inkl. raw_start/end h-001) + abwesenheiten als json, rfc-5987-dateiname. kein rate-limit, weniger inhalt als auth-12. get /api/auth/me/export">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-13</code>
+            <span class="uc-title">DSGVO Datenexport (Art.20) - Legacy-Endpoint</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Programmgesteuert (Frontend nutzt AUTH-12)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/auth/me/export: Stammdaten + Zeiteintraege (inkl. raw_start/end H-001) + Abwesenheiten als JSON, RFC-5987-Dateiname. Kein Rate-Limit, weniger Inhalt als AUTH-12.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/auth/me/export</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">(keine; durch /me/data-export ersetzt)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO Art.20; user_id-gefiltert + RLS; raw-Stempel als personenbezogene Daten enthalten</span></div>
+          </div>
+        </div><div class="uc" data-actor="Interessent" data-area="Authentifizierung &amp; Account" data-doc="1" data-impl="1" data-text="auth-14 saas self-signup (praxis registrieren) post /api/public/signup (5/h, 404 onprem): _email_already_admin-check (nur aktive admins), slug-erzeugung, inaktiver tenant+inaktiver admin, gehashter verify-token, audit, verify-mail aus saas_app_url (kein origin-header, s-m01). enumeration-safe bei vorhandener e-mail (201 + out-of-band-mail, m-api5). post /api/public/signup">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-14</code>
+            <span class="uc-title">SaaS Self-Signup (Praxis registrieren)</span>
+            <span class="actor actor-interessent">Interessent</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Signup-Seite (nur deployment_mode=saas)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/public/signup (5/h, 404 onprem): _email_already_admin-Check (nur aktive Admins), Slug-Erzeugung, inaktiver Tenant+inaktiver Admin, gehashter Verify-Token, Audit, Verify-Mail aus SAAS_APP_URL (kein Origin-Header, S-M01). Enumeration-safe bei vorhandener E-Mail (201 + Out-of-band-Mail, M-API5).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/public/signup</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/Signup.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/specs/2026-03-25-multi-tenant-phase-1-3-design.md (Spec); FEHLT in Handbuechern</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Enumeration-sicher; Token nur als SHA-256-Hash gespeichert; Verify-URL operator-controlled; Trial 14 Tage</span></div>
+          </div>
+        </div><div class="uc" data-actor="Interessent" data-area="Authentifizierung &amp; Account" data-doc="1" data-impl="1" data-text="auth-15 e-mail-verifikation (signup bestaetigen) get /api/public/verify-email?token (10/min, 404 onprem): token-hash-lookup, consumed/expired (410), admin is_active=true, token consumed, audit email_verified. get /api/public/verify-email">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-15</code>
+            <span class="uc-title">E-Mail-Verifikation (Signup bestaetigen)</span>
+            <span class="actor actor-interessent">Interessent</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Klick auf Verify-Link in der Mail</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/public/verify-email?token (10/min, 404 onprem): Token-Hash-Lookup, consumed/expired (410), Admin is_active=True, Token consumed, Audit email_verified.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/public/verify-email</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/Verify.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/specs multi-tenant Spec; FEHLT in Handbuechern</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Token einmalig + 24h TTL; tz-naive/aware-Normalisierung; 410 statt Leak</span></div>
+          </div>
+        </div><div class="uc" data-actor="Interessent" data-area="Authentifizierung &amp; Account" data-doc="0" data-impl="1" data-text="auth-16 verifizierungs-mail erneut senden post /api/public/resend-verification (3/h, 404 onprem): alte tokens invalidieren, neues ausstellen falls inaktiver admin existiert; immer 202 (enumeration-safe). post /api/public/resend-verification">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-16</code>
+            <span class="uc-title">Verifizierungs-Mail erneut senden</span>
+            <span class="actor actor-interessent">Interessent</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Resend-Anfrage</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/public/resend-verification (3/h, 404 onprem): alte Tokens invalidieren, neues ausstellen falls inaktiver Admin existiert; immer 202 (enumeration-safe).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/public/resend-verification</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">(keine dedizierte Seite gefunden)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Enumeration-sicher (immer 202); Token-Rotation</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="0" data-impl="1" data-text="auth-17 onboarding-tour als gesehen markieren post /api/auth/onboarding/complete: setzt onboarding_completed_at (idempotent), damit modal nicht erneut erscheint. post /api/auth/onboarding/complete">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-17</code>
+            <span class="uc-title">Onboarding-Tour als gesehen markieren</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Erstlogin-Welcome-Modal bestaetigen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/auth/onboarding/complete: setzt onboarding_completed_at (idempotent), damit Modal nicht erneut erscheint.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/auth/onboarding/complete</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Welcome-Modal-Komponente</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (internes UI-Verhalten)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Idempotent; geraeteuebergreifend persistiert</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Authentifizierung &amp; Account" data-doc="0" data-impl="1" data-text="auth-18 eigenes profil/me abrufen get /api/auth/me liefert volles userresponse; get /api/me/type-colors liefert effektive typ-farben des tenants. get /api/auth/me, get /api/me/type-colors">
+          <div class="uc-head">
+            <code class="uc-id">AUTH-18</code>
+            <span class="uc-title">Eigenes Profil/me abrufen</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Lazy-Load nach Login (Profilbild etc.)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/auth/me liefert volles UserResponse; GET /api/me/type-colors liefert effektive Typ-Farben des Tenants.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/auth/me, GET /api/me/type-colors</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">authStore/Profile.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (internes Mechanismus)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">auth-pflichtig; tenant-gescoped</span></div>
+          </div>
+        </div>
+    </section><section class="area" data-area="Mitarbeiter-Zeiterfassung">
+      <h2>Mitarbeiter-Zeiterfassung <span class="count">15</span></h2>
+      <div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="0" data-text="mz-01 einstempeln (clock-in / stoppuhr starten) offenen eintrag per select for update prüfen (vuln-009); stale vortageseintrag in selber tx auto-schließen (23:59 + audit); first/last_work_day prüfen; startzeit auf [soll-beginn − puffer] clampen (#201, raw_start_time gespeichert); §5-ruhezeit-warnung (&lt;11h seit letztem arbeitsende, dst-aware, übersprungen für exempt); early_start-warnung; timeentry mit end_time=null anlegen, 201. post /api/time-entries/clock-in">
+          <div class="uc-head">
+            <code class="uc-id">MZ-01</code>
+            <span class="uc-title">Einstempeln (clock-in / Stoppuhr starten)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA klickt Einstempeln (Dashboard StampWidget / mobiler FAB-Sheet)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Offenen Eintrag per SELECT FOR UPDATE prüfen (VULN-009); stale Vortageseintrag in selber TX auto-schließen (23:59 + Audit); first/last_work_day prüfen; Startzeit auf [Soll-Beginn − Puffer] clampen (#201, raw_start_time gespeichert); §5-Ruhezeit-Warnung (&lt;11h seit letztem Arbeitsende, DST-aware, übersprungen für exempt); EARLY_START-Warnung; TimeEntry mit end_time=NULL anlegen, 201.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/time-entries/clock-in</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">StampWidget.tsx (inline+sheet), Dashboard.tsx, mobiler Stamp-Sheet</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §3.1 Z.125-149; DocViewer.tsx Abschnitt &#x27;Pause beim Ausstempeln&#x27; + Arbeitszeit-Fenster Z.316</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§5 ArbZG Ruhezeit-Warnung; §201 work-window clamp + raw stamp (§16); first/last_work_day; F-026/F-043/VULN-009; exempt_from_arbzg überspringt §5</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="1" data-text="mz-02 ausstempeln (clock-out) offenen eintrag mit lock holen; stale vortageseintrag auto-schließen + 400; endzeit auf [soll-ende + puffer] clampen (raw_end_time); end_time/break_minutes setzen, commit; audit-log source=clock_out (§16); §4-pausenwarnung (nicht blockierend; bei waiver_reason dokumentiert source=break_waiver); §3 &gt;10h-warnung (nicht blockierend), §3 &gt;8h-warnung, 48h-wochenwarnung, sonntag/feiertag, §6 nachtarbeit. post /api/time-entries/clock-out">
+          <div class="uc-head">
+            <code class="uc-id">MZ-02</code>
+            <span class="uc-title">Ausstempeln (clock-out)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA klickt Ausstempeln, trägt Pausenminuten (+ ggf. break_waiver_reason) ein</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Offenen Eintrag mit Lock holen; stale Vortageseintrag auto-schließen + 400; Endzeit auf [Soll-Ende + Puffer] clampen (raw_end_time); end_time/break_minutes setzen, commit; Audit-Log source=clock_out (§16); §4-Pausenwarnung (nicht blockierend; bei waiver_reason dokumentiert source=break_waiver); §3 &gt;10h-Warnung (nicht blockierend), §3 &gt;8h-Warnung, 48h-Wochenwarnung, Sonntag/Feiertag, §6 Nachtarbeit.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/time-entries/clock-out</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">StampWidget.tsx (Pausenfeld + Waiver-Textarea)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §3.1 Z.136-149; DocViewer.tsx &#x27;Pause beim Ausstempeln&#x27; Z.298-307, §3-10h Z.475</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§4 Pause (non-blocking beim Live-Stempeln, R2-b §3 10h non-blocking), §3, §6 Nachtarbeit, §16 Audit, B-H1 commit-vor-raise</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="1" data-text="mz-03 clock-status / laufende stoppuhr abrufen offenen eintrag suchen; falls vortag → auto-schließen + commit, is_clocked_in=false; sonst elapsed_minutes aus eff_start (europe/berlin) berechnen und eintrag zurückgeben. get /api/time-entries/clock-status">
+          <div class="uc-head">
+            <code class="uc-id">MZ-03</code>
+            <span class="uc-title">Clock-Status / laufende Stoppuhr abrufen</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Dashboard/StampWidget lädt Status; periodischer Live-Timer</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Offenen Eintrag suchen; falls Vortag → auto-schließen + commit, is_clocked_in=false; sonst elapsed_minutes aus eff_start (Europe/Berlin) berechnen und Eintrag zurückgeben.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/time-entries/clock-status</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">StampWidget.tsx, Dashboard.tsx Hero-Card</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §2 Tagessaldo Z.62; implizit über Stempeln §3.1</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026, F-043 commit ownership, LOCAL_TZ</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="0" data-text="mz-04 zeiteintrag manuell erstellen ma nur für heute (sonst 403 → änderungsantrag); first/last_work_day; duplikat-start-check (409); clamp (#201); §3 10h harte sperre (422); §4-pausenprüfung → ohne grund 400, mit grund entweder direkt + warnung oder (falls praxis genehmigung verlangt) changerequest create 202; warnungen sammeln; eintrag + ggf. break_waiver-audit. post /api/time-entries/">
+          <div class="uc-head">
+            <code class="uc-id">MZ-04</code>
+            <span class="uc-title">Zeiteintrag manuell erstellen</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA öffnet &#x27;Neuer Eintrag&#x27;, füllt Datum/Von/Bis/Pause/Notiz</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">MA nur für heute (sonst 403 → Änderungsantrag); first/last_work_day; Duplikat-Start-Check (409); clamp (#201); §3 10h harte Sperre (422); §4-Pausenprüfung → ohne Grund 400, mit Grund entweder direkt + Warnung oder (falls Praxis Genehmigung verlangt) ChangeRequest CREATE 202; Warnungen sammeln; Eintrag + ggf. break_waiver-Audit.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/time-entries/</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">TimeTracking.tsx Formular</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §3.2 Z.155-189; DocViewer.tsx Abschnitt 3 Z.291-293, §7 Pflicht-Pause-Ausnahme Z.327</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§3 harte 10h-Sperre (manuell), §4 Pause + #144 Waiver/Approval-CR, §201 clamp, F-026, B-L4 409</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="0" data-text="mz-05 zeiteintrag bearbeiten eintrag tenant-scoped laden (404 bei fremd/unbekannt, #120); ma nur heute (403); end&gt;start; raw-snapshot; partielles update; clamp; §3 10h-sperre (422); §4 → 400/approval-cr update (db.rollback dann cr); audit bei waiver; warnungen (#252 exclude_entry_id). put /api/time-entries/{entry_id}">
+          <div class="uc-head">
+            <code class="uc-id">MZ-05</code>
+            <span class="uc-title">Zeiteintrag bearbeiten</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA klickt Bearbeiten an einem heutigen Eintrag</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Eintrag tenant-scoped laden (404 bei fremd/unbekannt, #120); MA nur heute (403); end&gt;start; raw-Snapshot; partielles Update; clamp; §3 10h-Sperre (422); §4 → 400/Approval-CR UPDATE (db.rollback dann CR); Audit bei waiver; Warnungen (#252 exclude_entry_id).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/time-entries/{entry_id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">TimeTracking.tsx Formular (editingId)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §3.3/3.4 Z.214-227; DocViewer.tsx</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§3/§4, #120 404-statt-403, #144 Approval-CR, #201 clamp, #252 doppelte-Zählung-Fix, F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="1" data-text="mz-06 zeiteintrag löschen eintrag tenant-scoped laden (404 fremd, #120); ma nur heute (403 → löschantrag); audit-log action=delete source=manual (§16); db.delete + commit; 204. delete /api/time-entries/{entry_id}">
+          <div class="uc-head">
+            <code class="uc-id">MZ-06</code>
+            <span class="uc-title">Zeiteintrag löschen</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA klickt Löschen + Bestätigungsdialog</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Eintrag tenant-scoped laden (404 fremd, #120); MA nur heute (403 → Löschantrag); Audit-Log action=delete source=manual (§16); db.delete + commit; 204.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>DELETE /api/time-entries/{entry_id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">TimeTracking.tsx ConfirmDialog</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §3 (Bearbeiten/Löschen); DocViewer.tsx</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§16 Audit auch bei MA-Selbstlöschung, #120 404, F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="1" data-text="mz-07 zeiteinträge auflisten (monatsfilter) tenant-scoped query; ma nur eigene einträge (user_id-param nur admin, sonst 403); optionaler monatsfilter (yyyy-mm, 400 bei fehlformat); sortiert desc, skip/limit≤500; je eintrag is_editable/warnings/nacht/sonntag-flags angereichert. get /api/time-entries/?month=&amp;user_id=&amp;skip=&amp;limit=">
+          <div class="uc-head">
+            <code class="uc-id">MZ-07</code>
+            <span class="uc-title">Zeiteinträge auflisten (Monatsfilter)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA öffnet Zeiterfassung / wechselt Monat</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">tenant-scoped Query; MA nur eigene Einträge (user_id-Param nur Admin, sonst 403); optionaler Monatsfilter (YYYY-MM, 400 bei Fehlformat); sortiert desc, skip/limit≤500; je Eintrag is_editable/warnings/Nacht/Sonntag-Flags angereichert.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/time-entries/?month=&amp;user_id=&amp;skip=&amp;limit=</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">TimeTracking.tsx Tabelle/Cards, Dashboard recentEntries</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §3 Tabelle Z.94-113</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026 + eigener-User-Scope, Admin-Gate für user_id</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="0" data-impl="1" data-text="mz-08 einzelnen zeiteintrag abrufen tenant-scoped laden; 404 wenn nicht gefunden oder fremder same-tenant-eintrag (kein existenz-leak, #120); angereicherte response. get /api/time-entries/{entry_id}">
+          <div class="uc-head">
+            <code class="uc-id">MZ-08</code>
+            <span class="uc-title">Einzelnen Zeiteintrag abrufen</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Detail-/Edit-Zugriff per ID</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">tenant-scoped laden; 404 wenn nicht gefunden ODER fremder Same-Tenant-Eintrag (kein Existenz-Leak, #120); angereicherte Response.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/time-entries/{entry_id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">TimeTracking.tsx (indirekt)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (interner Lookup, nicht eigenständig im Handbuch)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#120 404 statt 403, F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="1" data-text="mz-09 dashboard monatssaldo (soll/ist/saldo) get_soll_cutoff_date (#313: heute nur wenn ausgestempelter eintrag, sonst gestern); get_monthly_target/actual/balance mit up_to_date=cutoff; nur laufender monat getrimmt, abgeschlossene monate voll. get /api/dashboard/">
+          <div class="uc-head">
+            <code class="uc-id">MZ-09</code>
+            <span class="uc-title">Dashboard Monatssaldo (Soll/Ist/Saldo)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Dashboard laden / Stempeln (stampVersion-Refresh)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">get_soll_cutoff_date (#313: heute nur wenn ausgestempelter Eintrag, sonst gestern); get_monthly_target/actual/balance mit up_to_date=cutoff; nur laufender Monat getrimmt, abgeschlossene Monate voll.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/dashboard/</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Dashboard.tsx Monatssaldo-Kachel (formatHoursHM)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §2 Z.63-67; DocViewer.tsx Abschnitt 2 Z.282; GLOSSAR §5</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#313 Stichtag bis-heute, track_hours, §16 Exporte bleiben voll-Monat (hier irrelevant)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="1" data-text="mz-10 überstundenkonto + monatsverlauf erste timeentry → startmonat; get_overtime_history single-pass (#150, cutoff_date=cutoff); je monat target/actual/balance + kumulativer wert aus history_map; current_balance = aktueller monat. get /api/dashboard/overtime">
+          <div class="uc-head">
+            <code class="uc-id">MZ-10</code>
+            <span class="uc-title">Überstundenkonto + Monatsverlauf</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Dashboard laden</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Erste TimeEntry → Startmonat; get_overtime_history Single-Pass (#150, cutoff_date=cutoff); je Monat target/actual/balance + kumulativer Wert aus history_map; current_balance = aktueller Monat.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/dashboard/overtime</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Dashboard.tsx Überstundenkonto-Kachel + Monatsübersicht-Tabelle</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §2 Z.64,75; DocViewer.tsx Z.349-350</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#150 O(n)-Single-Pass, #313 cutoff, Konto darf negativ, F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="1" data-text="mz-11 year-to-date überstunden (01.01.–heute) get_ytd_summary(year, cutoff_date=cutoff) → target/actual/overtime/carryover_hours. get /api/dashboard/ytd-overtime">
+          <div class="uc-head">
+            <code class="uc-id">MZ-11</code>
+            <span class="uc-title">Year-to-Date Überstunden (01.01.–heute)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Dashboard Details-Bereich</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">get_ytd_summary(year, cutoff_date=cutoff) → target/actual/overtime/carryover_hours.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/dashboard/ytd-overtime</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Dashboard.tsx &#x27;Stunden 01.01. bis heute&#x27;</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">DocViewer.tsx Jahresübersicht; HANDBUCH-MITARBEITER.md Saldo-Abschnitt</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#313 cutoff, Carryover Vorjahr</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="1" data-text="mz-12 urlaubskonto-kachel (dashboard-endpoint) get_vacation_account (tage, tagesprinzip §3 burlg); carryover-deadline (individuell oder 31.03. folgejahr); q4-warnung wenn remaining_days&gt;0 &amp; aktuelles jahr &amp; monat≥10. admin kann user_id abfragen (sonst 403/404). get /api/dashboard/vacation">
+          <div class="uc-head">
+            <code class="uc-id">MZ-12</code>
+            <span class="uc-title">Urlaubskonto-Kachel (Dashboard-Endpoint)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Dashboard laden</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">get_vacation_account (Tage, Tagesprinzip §3 BUrlG); Carryover-Deadline (individuell oder 31.03. Folgejahr); Q4-Warnung wenn remaining_days&gt;0 &amp; aktuelles Jahr &amp; Monat≥10. Admin kann user_id abfragen (sonst 403/404).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/dashboard/vacation</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Dashboard.tsx Urlaubskonto-Kachel (Tage)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md Urlaub-Abschnitt; DocViewer.tsx; GLOSSAR §2 Tagesprinzip</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§3 BUrlG Tagesprinzip (Tage, nicht Stunden), F-026 Admin-Scope</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="1" data-text="mz-13 fehlende buchungen (eigene) track_hours-guard (sonst leer); offene vortageseinträge (end_time null, date&lt;today); pro arbeitstag des laufenden monats (tagessoll&gt;0, kein feiertag/eintrag/absence, im beschäftigungsfenster) &#x27;missing&#x27;. get /api/dashboard/missing-bookings">
+          <div class="uc-head">
+            <code class="uc-id">MZ-13</code>
+            <span class="uc-title">Fehlende Buchungen (eigene)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Dashboard laden</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">track_hours-Guard (sonst leer); offene Vortageseinträge (end_time NULL, date&lt;today); pro Arbeitstag des laufenden Monats (Tagessoll&gt;0, kein Feiertag/Eintrag/Absence, im Beschäftigungsfenster) &#x27;missing&#x27;.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/dashboard/missing-bookings</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Dashboard.tsx &#x27;Buchung fehlt&#x27;-Banner</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md (Buchung fehlt); implizit</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">track_hours, per-Tag-Soll via calculation_service, is_holiday tenant_id, F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="1" data-text="mz-14 fehlende buchungen team (admin) require admin (403 sonst); aktive, sichtbare, track_hours-ma des tenants; pro ma missing bookings; nur ma mit treffern. get /api/dashboard/missing-bookings/team">
+          <div class="uc-head">
+            <code class="uc-id">MZ-14</code>
+            <span class="uc-title">Fehlende Buchungen Team (Admin)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin-Dashboard laden</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">require admin (403 sonst); aktive, sichtbare, track_hours-MA des Tenants; pro MA missing bookings; nur MA mit Treffern.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/dashboard/missing-bookings/team</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Dashboard.tsx &#x27;Fehlende Buchungen im Team&#x27; (Admin)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">DocViewer.tsx Admin-Abschnitt; HANDBUCH-ADMIN.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Admin-Gate, F-026, track_hours/is_hidden-Filter</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Zeiterfassung" data-doc="1" data-impl="1" data-text="mz-15 monatsjournal ansehen ma: /journal/me (eigener kontext); admin: /admin/users/{id}/journal tenant-scoped (404 fremd); journal_service.get_journal (voll-monat, kein cutoff → §16-beleg) liefert tageszeilen soll/ist/salden. get /api/journal/me, get /api/admin/users/{user_id}/journal">
+          <div class="uc-head">
+            <code class="uc-id">MZ-15</code>
+            <span class="uc-title">Monatsjournal ansehen</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA wechselt auf Tab &#x27;Journal&#x27; / Admin öffnet MA-Journal</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">MA: /journal/me (eigener Kontext); Admin: /admin/users/{id}/journal tenant-scoped (404 fremd); journal_service.get_journal (voll-Monat, KEIN cutoff → §16-Beleg) liefert Tageszeilen Soll/Ist/Salden.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/journal/me, GET /api/admin/users/{user_id}/journal</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Journal.tsx → MonthlyJournal.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §3 Journal-Tab Z.101; DocViewer.tsx Admin Monatsjournal Z.408</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">voll-Monat = Rechtsbeleg (kein #313-cutoff), F-026, require_admin für Fremd-Journal</span></div>
+          </div>
+        </div>
+    </section><section class="area" data-area="Mitarbeiter-Abwesenheiten/Anträge">
+      <h2>Mitarbeiter-Abwesenheiten/Anträge <span class="count">19</span></h2>
+      <div class="uc" data-actor="Admin" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="1" data-text="adm-ar-02 eigene abwesenheitsgründe verwalten (crud) get/post/put/delete /api/admin/absence-reasons → name/farbe(#rrggbb)/base_behavior/is_active; base_behavior nach anlage fix; löschen nur wenn ungenutzt (sonst 409 → deaktivieren) /api/admin/absence-reasons (crud)">
+          <div class="uc-head">
+            <code class="uc-id">ADM-AR-02</code>
+            <span class="uc-title">Eigene Abwesenheitsgründe verwalten (CRUD)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin verwaltet Gründe in Einstellungen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET/POST/PUT/DELETE /api/admin/absence-reasons → Name/Farbe(#RRGGBB)/base_behavior/is_active; base_behavior nach Anlage fix; Löschen nur wenn ungenutzt (sonst 409 → deaktivieren)</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>/api/admin/absence-reasons (CRUD)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/admin/ (Settings)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md ~Z.531; CHEATSHEET-ADMIN.md #312</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026, base_behavior immutable (v1), In-Use-Schutz (Absence+pending CR), Unique-Name</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="0" data-text="ma-abs-01 abwesenheit direkt eintragen (urlaub/krank/fortbildung/überstundenausgleich/sonstiges) post /api/absences → datums-range expandiert auf werktage (wochenende+feiertage raus), beschäftigungsfenster geprüft, doppelbuchung (with_for_update) verhindert, bei vacation tagebasierter budget-check, voll-tag-typen werden mit tagessoll des tages gebucht (nur overtime behält explizite stunden), bestehende timeentries des tages werden gelöscht (außer keep_time_entries) post /api/absences/ ; get /api/absences/daily-target">
+          <div class="uc-head">
+            <code class="uc-id">MA-ABS-01</code>
+            <span class="uc-title">Abwesenheit direkt eintragen (Urlaub/Krank/Fortbildung/Überstundenausgleich/Sonstiges)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA klickt auf Abwesenheiten → &#x27;+ Abwesenheit eintragen&#x27;, wählt Typ/Datum/Zeitraum</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/absences → Datums-Range expandiert auf Werktage (Wochenende+Feiertage raus), Beschäftigungsfenster geprüft, Doppelbuchung (with_for_update) verhindert, bei VACATION tagebasierter Budget-Check, Voll-Tag-Typen werden mit Tagessoll des Tages gebucht (nur OVERTIME behält explizite Stunden), bestehende TimeEntries des Tages werden gelöscht (außer keep_time_entries)</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/absences/ ; GET /api/absences/daily-target</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/AbsenceCalendarPage.tsx (Formular)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §4.1; DocViewer.tsx ~Z.335; CHEATSHEET-ADMIN.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§3 BUrlG Tagesprinzip (Tagessoll-Buchung), §3 EntgFG (SICK), Calc-Matrix GLOSSAR §3, F-026 Tenant-Scope, F-028 Doppelbuchungs-Race. GAP: vacation_approval_required wird hier NICHT erzwungen (siehe Finding)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="0" data-impl="1" data-text="ma-abs-02 krank während urlaub → urlaubstage zurückerstatten (refund_vacation) post /api/absences mit type=sick &amp; refund_vacation=true → konflikt-check überspringt vacation-tage, refund-block löscht vacation-absence (mit audit source=vacation_refund), legt sick-absence an post /api/absences/">
+          <div class="uc-head">
+            <code class="uc-id">MA-ABS-02</code>
+            <span class="uc-title">Krank während Urlaub → Urlaubstage zurückerstatten (refund_vacation)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA bucht Krank über bestehende VACATION-Tage; UI fragt nach Rückerstattung</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/absences mit type=sick &amp; refund_vacation=true → Konflikt-Check überspringt VACATION-Tage, Refund-Block löscht VACATION-Absence (mit Audit source=vacation_refund), legt SICK-Absence an</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/absences/</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AbsenceCalendarPage.tsx (ConfirmDialog &#x27;Krankmeldung im Urlaub&#x27;)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (UI-Confirm vorhanden, aber keine Handbuch-/DocViewer-Beschreibung der Rückerstattung)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§3 EntgFG (Krankheit im Urlaub gilt nicht als Urlaub), DSGVO Art.5(2) Audit-Log, F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="0" data-text="ma-abs-03 abwesenheit mit eigenem grund buchen (#312) reason_id wird tenant-scoped + is_active aufgelöst, base_behavior → eingebauter absencetype (worked→training, paid_free→paid_leave, overtime_comp→overtime), absence trägt reason_id als label/farbe; berechnung läuft über type post /api/absences/ (reason_id) ; get /api/absence-reasons (picker)">
+          <div class="uc-head">
+            <code class="uc-id">MA-ABS-03</code>
+            <span class="uc-title">Abwesenheit mit eigenem Grund buchen (#312)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA wählt einen tenant-eigenen Grund (z. B. &#x27;Schule&#x27;) beim Buchen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">reason_id wird tenant-scoped + is_active aufgelöst, base_behavior → eingebauter AbsenceType (worked→TRAINING, paid_free→PAID_LEAVE, overtime_comp→OVERTIME), Absence trägt reason_id als Label/Farbe; Berechnung läuft über type</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/absences/ (reason_id) ; GET /api/absence-reasons (Picker)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">NUR frontend/src/components/MonthlyJournal.tsx (Journal) — Picker fehlt in AbsenceCalendarPage.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §4.1; DocViewer.tsx ~Z.335; CHEATSHEET-ADMIN.md #312</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Calc bleibt eingefroren (type treibt Berechnung), DSGVO Art.9 Maskierung im Team-Kalender, F-026. GAP: Picker im dokumentierten Direkt-Buchungsformular nicht vorhanden (siehe Finding)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="1" data-text="ma-abs-04 eigene abwesenheit löschen delete /api/absences/{id} → tenant-scoped lookup, owner-check (fremde → 404 statt 403), audit-log vor löschung, delete delete /api/absences/{id}">
+          <div class="uc-head">
+            <code class="uc-id">MA-ABS-04</code>
+            <span class="uc-title">Eigene Abwesenheit löschen</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA klickt Löschen in der Abwesenheitsliste</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">DELETE /api/absences/{id} → tenant-scoped Lookup, Owner-Check (fremde → 404 statt 403), Audit-Log vor Löschung, delete</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>DELETE /api/absences/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AbsenceCalendarPage.tsx (Löschen-Button)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §4.3</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO Art.5(2) Audit, F-026, #120 kein Existenz-Leak (404)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="1" data-text="ma-abs-05 team-kalender ansehen (dsgvo-maskierung) get /api/absences/calendar?month=yyyy-mm → alle aktiven, nicht-versteckten ma des tenants; sensible typen (sick/other/paid_leave) und jede reason_id-absence für nicht-admin/nicht-eigentümer → &#x27;absent&#x27;; abteilung nur für admins get /api/absences/calendar">
+          <div class="uc-head">
+            <code class="uc-id">MA-ABS-05</code>
+            <span class="uc-title">Team-Kalender ansehen (DSGVO-Maskierung)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA öffnet den Monats-/Jahres-Kalender</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/absences/calendar?month=YYYY-MM → alle aktiven, nicht-versteckten MA des Tenants; sensible Typen (SICK/OTHER/PAID_LEAVE) UND jede reason_id-Absence für Nicht-Admin/Nicht-Eigentümer → &#x27;absent&#x27;; Abteilung nur für Admins</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/absences/calendar</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AbsenceCalendarPage.tsx (Kalender + Abteilungsfilter)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">CHEATSHEET-ADMIN.md #312 (Maskierung); HANDBUCH-ADMIN.md ~Z.543</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO Art.9 (_MASKED_ABSENCE_TYPES + reason_id-Maskierung), Datenminimierung (department admin-only), F-026 Tenant-Scope, PublicHoliday tenant_id</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="0" data-impl="1" data-text="ma-abs-06 anstehende team-abwesenheiten (upcoming) get /api/absences/team/upcoming → zukünftige abwesenheiten aktiver ma, dedup per (user,date,end_date,type), gleiche maskierung wie /calendar get /api/absences/team/upcoming">
+          <div class="uc-head">
+            <code class="uc-id">MA-ABS-06</code>
+            <span class="uc-title">Anstehende Team-Abwesenheiten (Upcoming)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Dashboard/Übersicht lädt kommende Abwesenheiten</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/absences/team/upcoming → zukünftige Abwesenheiten aktiver MA, Dedup per (user,date,end_date,type), gleiche Maskierung wie /calendar</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/absences/team/upcoming</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Dashboard-Widget (nicht in dieser Datei)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (Feed nicht eigenständig dokumentiert)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO Art.9 identische _MASKED_ABSENCE_TYPES + reason_id-Maskierung wie /calendar, F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="0" data-impl="1" data-text="ma-abs-07 nächster eigener urlaub (countdown) get /api/absences/next-vacation → früheste eigene vacation-absence ab heute, days_until get /api/absences/next-vacation">
+          <div class="uc-head">
+            <code class="uc-id">MA-ABS-07</code>
+            <span class="uc-title">Nächster eigener Urlaub (Countdown)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Dashboard zeigt Tage bis zum nächsten Urlaub</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/absences/next-vacation → früheste eigene VACATION-Absence ab heute, days_until</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/absences/next-vacation</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Dashboard</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026 (eigene Daten, tenant-scoped)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="1" data-text="ma-abs-08 eigene abwesenheiten auflisten (admin: fremde mit audit) get /api/absences/?year= → ma nur eigene; admin mit user_id fremde (403 sonst). admin-fremdzugriff wird dsgvo-protokolliert (health_data_read/absence_list_read) get /api/absences/">
+          <div class="uc-head">
+            <code class="uc-id">MA-ABS-08</code>
+            <span class="uc-title">Eigene Abwesenheiten auflisten (Admin: fremde mit Audit)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Liste/Jahresansicht der eigenen Abwesenheiten</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/absences/?year= → MA nur eigene; Admin mit user_id fremde (403 sonst). Admin-Fremdzugriff wird DSGVO-protokolliert (health_data_read/absence_list_read)</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/absences/</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AbsenceCalendarPage.tsx (myAbsences)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md (DSGVO-Audit Abschnitt)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO Art.9/Art.5(2) Audit-Log pro Request, F-026 explizit + RLS</span></div>
+          </div>
+        </div><div class="uc" data-actor="System" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="1" data-text="ma-abs-09 resturlaub/urlaubskonto (tagesprinzip) calculation_service.get_vacation_account(db,user,year) → budget_days (pro-rata ein-/austritt + carryover), used_days tagebasiert (voll=1,0/halb=0,5, 0-tagessoll-tage=0), remaining_days; sondertage 24./31.12. (frei+counts_as_vacation) = 1 tag (intern) get_vacation_account in allen budget-pfaden">
+          <div class="uc-head">
+            <code class="uc-id">MA-ABS-09</code>
+            <span class="uc-title">Resturlaub/Urlaubskonto (Tagesprinzip)</span>
+            <span class="actor actor-system">System</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Budget-Checks beim Buchen/Antrag + Anzeige im Dashboard</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">calculation_service.get_vacation_account(db,user,year) → budget_days (pro-rata Ein-/Austritt + Carryover), used_days tagebasiert (Voll=1,0/Halb=0,5, 0-Tagessoll-Tage=0), remaining_days; Sondertage 24./31.12. (frei+counts_as_vacation) = 1 Tag</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>(intern) get_vacation_account in allen Budget-Pfaden</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Dashboard-Urlaubskonto (Tage)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">GLOSSAR.md §2/§4; HANDBUCH-ADMIN.md §18.7; HANDBUCH-MITARBEITER.md §4.4</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§3 BUrlG Tagesprinzip, #156/#167/#205 tagebasiert, Legacy-Row half_day=None Sonderfall, untracked (#191) reine Tageszählung</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="1" data-text="ma-ar-01 aktive eigene abwesenheitsgründe lesen (picker) get /api/absence-reasons → aktive, sort_order, tenant-scoped get /api/absence-reasons">
+          <div class="uc-head">
+            <code class="uc-id">MA-AR-01</code>
+            <span class="uc-title">Aktive eigene Abwesenheitsgründe lesen (Picker)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Buchungsformular lädt verfügbare Gründe</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/absence-reasons → aktive, sort_order, tenant-scoped</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/absence-reasons</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/api/absenceReasons.ts → MonthlyJournal.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §Eigene Abwesenheitsgründe</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026, nur is_active</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="1" data-text="ma-cr-01 korrekturantrag zeiteintrag (create/update/delete) post /api/change-requests entry_kind=time_entry → nur vergangene tage, beschäftigungsfenster, pausen-/§3-10h-check, §4-waiver, duplikat-check, snapshot der originalwerte; §6-nacht- + 48h-wochenwarnungen post /api/change-requests/">
+          <div class="uc-head">
+            <code class="uc-id">MA-CR-01</code>
+            <span class="uc-title">Korrekturantrag Zeiteintrag (create/update/delete)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA stellt Antrag für gesperrten/alten Zeiteintrag (Zeiterfassung &#x27;Antrag&#x27;)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/change-requests entry_kind=time_entry → nur vergangene Tage, Beschäftigungsfenster, Pausen-/§3-10h-Check, §4-Waiver, Duplikat-Check, Snapshot der Originalwerte; §6-Nacht- + 48h-Wochenwarnungen</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/change-requests/</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/components/ChangeRequestForm.tsx, MonthlyJournal.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §3.5; CHEATSHEET-MITARBEITER.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§3/§4/§6 ArbZG, §18 exempt-Ausnahme, F-026, Duplikat-Schutz</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="1" data-text="ma-cr-02 korrekturantrag abwesenheit (create/update/delete, #312) post /api/change-requests entry_kind=absence → owner-check (404), nur vergangene tage, typ-validierung, stunden-oder-zeit-pflicht, reason_id-auflösung (überschreibt typ), duplikat-check, snapshot; buchung erst bei admin-genehmigung post /api/change-requests/ (entry_kind=absence)">
+          <div class="uc-head">
+            <code class="uc-id">MA-CR-02</code>
+            <span class="uc-title">Korrekturantrag Abwesenheit (create/update/delete, #312)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA beantragt Anlage/Änderung/Löschung einer Abwesenheit für einen vergangenen Tag</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/change-requests entry_kind=absence → Owner-Check (404), nur vergangene Tage, Typ-Validierung, Stunden-oder-Zeit-Pflicht, reason_id-Auflösung (überschreibt Typ), Duplikat-Check, Snapshot; Buchung erst bei Admin-Genehmigung</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/change-requests/ (entry_kind=absence)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/components/MonthlyJournal.tsx (Journal, Self-View)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md ~Z.682 (Absence-CR); CLAUDE.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#312 reason_id durchgereicht, F-026, #120 404. Hinweis: first/last_work_day-Validierung fehlt im Create-Pfad (erst bei Approval, siehe Finding)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="1" data-text="ma-cr-03 eigene änderungsanträge auflisten/ansehen get /api/change-requests?status= (eigene) + get /{id} (owner/admin, 404 sonst) get /api/change-requests/ ; get /api/change-requests/{id}">
+          <div class="uc-head">
+            <code class="uc-id">MA-CR-03</code>
+            <span class="uc-title">Eigene Änderungsanträge auflisten/ansehen</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA öffnet &#x27;Änderungsanträge&#x27;</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/change-requests?status= (eigene) + GET /{id} (Owner/Admin, 404 sonst)</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/change-requests/ ; GET /api/change-requests/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/ChangeRequests.tsx (read-only Liste + Filter)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">CHEATSHEET-MITARBEITER.md; DocViewer.tsx ~Z.326</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026, #120 404</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="1" data-text="ma-cr-04 änderungsantrag zurückziehen delete /api/change-requests/{id} → owner-check (404), nur pending, delete delete /api/change-requests/{id}">
+          <div class="uc-head">
+            <code class="uc-id">MA-CR-04</code>
+            <span class="uc-title">Änderungsantrag zurückziehen</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA zieht offenen Antrag zurück</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">DELETE /api/change-requests/{id} → Owner-Check (404), nur PENDING, delete</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>DELETE /api/change-requests/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">ChangeRequests.tsx (Zurückziehen-Button)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">DocViewer.tsx ~Z.326</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026, #120 404</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="1" data-text="ma-vac-01 urlaubsantrag stellen (bei genehmigungspflicht) post /api/vacation-requests → flag-check, range-sanity (≤366 tage), beschäftigungsfenster, overlap-check offener anträge, tagebasierter budget-check (feiertage ausgeschlossen, half_day=0,5), pending-anlage post /api/vacation-requests/">
+          <div class="uc-head">
+            <code class="uc-id">MA-VAC-01</code>
+            <span class="uc-title">Urlaubsantrag stellen (bei Genehmigungspflicht)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">vacation_approval_required=true, MA bucht Urlaub/Fortbildung/Sonstiges → Antrag statt Direktbuchung</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/vacation-requests → Flag-Check, Range-Sanity (≤366 Tage), Beschäftigungsfenster, Overlap-Check offener Anträge, tagebasierter Budget-Check (Feiertage ausgeschlossen, half_day=0,5), PENDING-Anlage</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/vacation-requests/</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AbsenceCalendarPage.tsx (doSubmit routet auf vacation-requests)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §4.2; DocViewer.tsx</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§3 BUrlG Tagesprinzip, F-045 Validierungs-Parität, F-026, half_day nur Einzeltag (Schema-Validator)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="1" data-text="ma-vac-02 eigene urlaubsanträge auflisten get /api/vacation-requests?year=&amp;status= → eigene anträge, batch-enriched (tage/reviewer/modifier) get /api/vacation-requests/">
+          <div class="uc-head">
+            <code class="uc-id">MA-VAC-02</code>
+            <span class="uc-title">Eigene Urlaubsanträge auflisten</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Tab &#x27;Meine Anträge&#x27;</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/vacation-requests?year=&amp;status= → eigene Anträge, batch-enriched (Tage/Reviewer/Modifier)</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/vacation-requests/</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AbsenceCalendarPage.tsx (Tab &#x27;Meine Anträge&#x27;)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §4.2 (Statusbedeutungen)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026, #219 Batch-Enrich (kein N+1)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="0" data-impl="1" data-text="ma-vac-03 offenen urlaubsantrag bearbeiten patch /api/vacation-requests/{id} (rate-limited) → with_for_update, owner-check (404 sonst), nur pending, no-op-erkennung, re-validierung (range/fenster/overlap/budget tagebasiert), audit source=vacation_request_edit patch /api/vacation-requests/{id}">
+          <div class="uc-head">
+            <code class="uc-id">MA-VAC-03</code>
+            <span class="uc-title">Offenen Urlaubsantrag bearbeiten</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA bearbeitet einen PENDING-Antrag</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">PATCH /api/vacation-requests/{id} (rate-limited) → with_for_update, Owner-Check (404 sonst), nur PENDING, no-op-Erkennung, Re-Validierung (Range/Fenster/Overlap/Budget tagebasiert), Audit source=vacation_request_edit</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PATCH /api/vacation-requests/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/components/VacationRequestEditModal.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (Bearbeiten offener Anträge nicht im Handbuch beschrieben — nur Zurückziehen)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#196 tagebasierter Budget-Check, #120 404, CWE-117 Audit-Normalisierung, F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Abwesenheiten/Anträge" data-doc="1" data-impl="1" data-text="ma-vac-04 urlaubsantrag zurückziehen / genehmigten zukünftigen stornieren delete /api/vacation-requests/{id} → with_for_update; pending→row löschen; approved &amp; start&gt;heute→zugehörige absences löschen (audit) + withdrawn; gestartete/vergangene blockiert (400) delete /api/vacation-requests/{id}">
+          <div class="uc-head">
+            <code class="uc-id">MA-VAC-04</code>
+            <span class="uc-title">Urlaubsantrag zurückziehen / genehmigten zukünftigen stornieren</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA klickt Zurückziehen/Stornieren</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">DELETE /api/vacation-requests/{id} → with_for_update; PENDING→Row löschen; APPROVED &amp; Start&gt;heute→zugehörige Absences löschen (Audit) + WITHDRAWN; gestartete/vergangene blockiert (400)</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>DELETE /api/vacation-requests/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AbsenceCalendarPage.tsx (Confirm &#x27;Antrag zurückziehen&#x27;/&#x27;Urlaub stornieren&#x27;)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-MITARBEITER.md §4.2 (Zurückziehen)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO Art.5(2) Audit pro gelöschter Absence, #120 404, Race (with_for_update), F-026</span></div>
+          </div>
+        </div>
+    </section><section class="area" data-area="Mitarbeiter-Sonstiges">
+      <h2>Mitarbeiter-Sonstiges <span class="count">7</span></h2>
+      <div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Sonstiges" data-doc="1" data-impl="1" data-text="ms-01 eigene heutige schicht-einteilung ansehen (dashboard-widget) shifttodaycard prüft feature-flag (systemstore.isshiftplanningenabled). wenn aktiv → get /api/shift-planning/my-today. service get_my_today() ermittelt heutigen wochentag (europe/berlin via today_local), joint shiftplan×shiftslot×shiftassignment über alle heute aktiven pläne (plan_active_filter: is_active oder datumsfenster deckt heute ab), gefiltert auf eigene user_id + tenant_id. rendert pro eintrag arbeitsplatz/standort/zeit/plan. bei leerer liste oder fehler bleibt das widget unsichtbar. get /api/shift-planning/my-today">
+          <div class="uc-head">
+            <code class="uc-id">MS-01</code>
+            <span class="uc-title">Eigene heutige Schicht-Einteilung ansehen (Dashboard-Widget)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Mitarbeiter öffnet das Dashboard; Widget &#x27;Deine Einteilung heute&#x27; lädt automatisch</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">ShiftTodayCard prüft Feature-Flag (systemStore.isShiftPlanningEnabled). Wenn aktiv → GET /api/shift-planning/my-today. Service get_my_today() ermittelt heutigen Wochentag (Europe/Berlin via today_local), joint ShiftPlan×ShiftSlot×ShiftAssignment über alle HEUTE aktiven Pläne (plan_active_filter: is_active ODER Datumsfenster deckt heute ab), gefiltert auf eigene user_id + tenant_id. Rendert pro Eintrag Arbeitsplatz/Standort/Zeit/Plan. Bei leerer Liste oder Fehler bleibt das Widget unsichtbar.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/shift-planning/my-today</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/components/ShiftTodayCard.tsx (eingebunden in Dashboard.tsx)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">DocViewer.tsx Abschnitt 11; HANDBUCH-MITARBEITER.md &#x27;Schichtplan&#x27; Z.547ff; CHEATSHEET-MITARBEITER.md Z.177ff</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Feature-Flag (404 wenn aus → Widget bleibt still); Multi-Tenant/F-026 (tenant_id-Filter an Plan/Slot/Assignment); entkoppelt von ArbZG/Soll-Ist; Europe/Berlin-Wochentag; Union über alle aktiven Pläne</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Sonstiges" data-doc="1" data-impl="1" data-text="ms-02 aktive schichtpläne als wochenübersicht ansehen (read-only) shiftplanning.tsx ruft get /plans, filtert auf active_today, lädt für jeden aktiven plan get /plans/{id} (detail mit slots+assignments). weekgrid rendert wochentage×slots mit arbeitsplatz/zeit/zugewiesenen personen + unterbesetzungs-warnung. _build_plan_detail liefert die qualified/unqualified-flags nur für admins (is_admin), für ma werden kompetenzlücken der kollegen ausgeblendet. get /api/shift-planning/plans, get /api/shift-planning/plans/{plan_id}">
+          <div class="uc-head">
+            <code class="uc-id">MS-02</code>
+            <span class="uc-title">Aktive Schichtpläne als Wochenübersicht ansehen (read-only)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Mitarbeiter klickt Menüpunkt &#x27;Schichtplan&#x27; (nur sichtbar wenn Feature aktiv)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">ShiftPlanning.tsx ruft GET /plans, filtert auf active_today, lädt für jeden aktiven Plan GET /plans/{id} (Detail mit Slots+Assignments). WeekGrid rendert Wochentage×Slots mit Arbeitsplatz/Zeit/zugewiesenen Personen + Unterbesetzungs-Warnung. _build_plan_detail liefert die qualified/unqualified-Flags NUR für Admins (is_admin), für MA werden Kompetenzlücken der Kollegen ausgeblendet.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/shift-planning/plans, GET /api/shift-planning/plans/{plan_id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/ShiftPlanning.tsx + components/shiftplanning/WeekGrid.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">DocViewer.tsx Abschnitt 11; HANDBUCH-MITARBEITER.md Z.547ff; CHEATSHEET-MITARBEITER.md Z.179</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Feature-Flag-Gate (404 wenn aus); F-026 tenant-scoped; DSGVO/HR-sensible &#x27;qualified&#x27;-Flags admin-only (kein Leak für MA: a.get(&#x27;qualified&#x27;, True) → unqualified immer False für MA, unqualified_slot_ids nur is_admin); read-only (keine Write-Endpoints für MA)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Sonstiges" data-doc="1" data-impl="1" data-text="ms-03 eigene arbeitsplatz-einweisungen ansehen myqualificationscard prüft feature-flag → get /api/shift-planning/me/qualifications. endpoint joint workstation×workstationqualification gefiltert auf eigene user_id + tenant_id, gibt die arbeitsplätze (name/farbe/standort) zurück. bei leerer liste hinweistext, sonst chips. get /api/shift-planning/me/qualifications">
+          <div class="uc-head">
+            <code class="uc-id">MS-03</code>
+            <span class="uc-title">Eigene Arbeitsplatz-Einweisungen ansehen</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Mitarbeiter öffnet Profil; Karte &#x27;Meine Einweisungen&#x27; lädt (nur wenn Feature aktiv)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">MyQualificationsCard prüft Feature-Flag → GET /api/shift-planning/me/qualifications. Endpoint joint Workstation×WorkstationQualification gefiltert auf eigene user_id + tenant_id, gibt die Arbeitsplätze (Name/Farbe/Standort) zurück. Bei leerer Liste Hinweistext, sonst Chips.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/shift-planning/me/qualifications</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/components/MyQualificationsCard.tsx (in Profile.tsx)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">DocViewer.tsx Abschnitt 11 Z.379; HANDBUCH-MITARBEITER.md Z.554</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Feature-Flag-Gate; F-026 (user_id==current_user.id + tenant_id beidseitig); Eigenansicht (jeder authentifizierte MA, keine Admin-Rolle nötig)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Sonstiges" data-doc="1" data-impl="1" data-text="ms-04 in-app-hilfe / handbuch &amp; kurzanleitung ansehen und herunterladen help.tsx wählt rollenabhängig (admin vs. ma) cheatsheet- bzw. handbuch-inhalte aus docviewer (hardcoded handbuchmitarbeitersections / cheatsheetmitarbeiter), tabs kurzanleitung/handbuch, accordion-abschnitte, plus download-link auf /help/*.md (statische markdown-kopien). keine (statische /help/*.md assets, in-app-inhalt hardcoded)">
+          <div class="uc-head">
+            <code class="uc-id">MS-04</code>
+            <span class="uc-title">In-App-Hilfe / Handbuch &amp; Kurzanleitung ansehen und herunterladen</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Mitarbeiter öffnet &#x27;Hilfe &amp; Dokumentation&#x27;</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Help.tsx wählt rollenabhängig (admin vs. MA) Cheatsheet- bzw. Handbuch-Inhalte aus DocViewer (hardcoded handbuchMitarbeiterSections / CheatsheetMitarbeiter), Tabs Kurzanleitung/Handbuch, Accordion-Abschnitte, plus Download-Link auf /help/*.md (statische Markdown-Kopien).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>keine (statische /help/*.md Assets, In-App-Inhalt hardcoded)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/Help.tsx + components/DocViewer.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">Self-dokumentierend (DocViewer.tsx); docs/handbuch/HANDBUCH-MITARBEITER.md + CHEATSHEET-MITARBEITER.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Rollen-Switch admin/MA; In-App-Hilfe ist hardcoded und muss synchron zu docs/handbuch/*.md gepflegt werden (CLAUDE.md-Regel)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Interessent" data-area="Mitarbeiter-Sonstiges" data-doc="1" data-impl="1" data-text="ms-05 datenschutzerklärung ansehen (öffentlich, vor login) privacy.tsx (öffentliche route, kein protectedroute) rendert statische dsgvo-erklärung: verantwortlicher, zwecke/rechtsgrundlagen (art.6/9), datenkategorien inkl. art.9-gesundheitsdaten, aufbewahrungsfristen (arbzg §16, ao §147), empfänger, betroffenenrechte (art.15-21) inkl. verweis auf self-export, datensicherheit, kontakt. keine (statische seite)">
+          <div class="uc-head">
+            <code class="uc-id">MS-05</code>
+            <span class="uc-title">Datenschutzerklärung ansehen (öffentlich, vor Login)</span>
+            <span class="actor actor-interessent">Interessent</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Nutzer ruft /privacy auf (Link von der Login-Seite)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Privacy.tsx (öffentliche Route, kein ProtectedRoute) rendert statische DSGVO-Erklärung: Verantwortlicher, Zwecke/Rechtsgrundlagen (Art.6/9), Datenkategorien inkl. Art.9-Gesundheitsdaten, Aufbewahrungsfristen (ArbZG §16, AO §147), Empfänger, Betroffenenrechte (Art.15-21) inkl. Verweis auf Self-Export, Datensicherheit, Kontakt.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>keine (statische Seite)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/Privacy.tsx (Route /privacy)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">Self-dokumentierend (Privacy.tsx)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Öffentlich/pre-login zugänglich (Art.13 Informationspflicht); nennt Art.9-Maskierung in Exporten; Stand Juni 2026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Sonstiges" data-doc="1" data-impl="1" data-text="ms-06 dsgvo self-service-datenexport (art.15 auskunft + art.20 portabilität) get /api/me/data-export (rate-limit 5/tag/ip). lifecycle_service.build_self_export_payload sammelt eigene timeentries, absences, vacationrequests, changerequests, audit-logs (als subjekt oder akteur), reichert reviewer-uuids zu klartext-namen an (user_directory, tenant-gefiltert), ergänzt art15_meta (pflichtangaben a–h). schreibt einen audit-log-eintrag (action/source=&#x27;self_data_export&#x27;). liefert json-download mit rfc-5987-codiertem dateinamen. get /api/me/data-export">
+          <div class="uc-head">
+            <code class="uc-id">MS-06</code>
+            <span class="uc-title">DSGVO Self-Service-Datenexport (Art.15 Auskunft + Art.20 Portabilität)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Mitarbeiter klickt im Profil &#x27;Meine Daten exportieren → JSON herunterladen&#x27;</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/me/data-export (Rate-Limit 5/Tag/IP). lifecycle_service.build_self_export_payload sammelt eigene TimeEntries, Absences, VacationRequests, ChangeRequests, Audit-Logs (als Subjekt ODER Akteur), reichert Reviewer-UUIDs zu Klartext-Namen an (user_directory, tenant-gefiltert), ergänzt art15_meta (Pflichtangaben a–h). Schreibt einen Audit-Log-Eintrag (action/source=&#x27;self_data_export&#x27;). Liefert JSON-Download mit RFC-5987-codiertem Dateinamen.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/me/data-export</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/Profile.tsx (&#x27;Meine Daten exportieren&#x27;, Z.723)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">Privacy.tsx Abschnitt 6 (Verweis &#x27;Profil → Weitere Einstellungen&#x27;); Profile.tsx Tooltip — FEHLT in HANDBUCH-MITARBEITER.md / CHEATSHEET / DocViewer</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026 (user_id + tenant_id auf allen Queries); nur eigene Daten (keine Maskierung nötig = eigene Auskunft); Rate-Limit 5/Tag; Audit-Log (action/source &lt;40 Zeichen, Migration 037); RFC-5987-Dateiname</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Mitarbeiter-Sonstiges" data-doc="0" data-impl="1" data-text="ms-07 eigene effektive typ-farben laden (kalender-rendering) get /api/me/type-colors → type_colors_service.get_type_colors für den eigenen tenant_id; für jeden authentifizierten nutzer (nicht nur admin) verfügbar. get /api/me/type-colors">
+          <div class="uc-head">
+            <code class="uc-id">MS-07</code>
+            <span class="uc-title">Eigene effektive Typ-Farben laden (Kalender-Rendering)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Kalender-/Dialog-Komponenten laden die Tenant-Typfarben des eigenen Mandanten</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/me/type-colors → type_colors_service.get_type_colors für den eigenen tenant_id; für jeden authentifizierten Nutzer (nicht nur Admin) verfügbar.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/me/type-colors</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Kalender-/Dialog-Komponenten (utils/specialDays / Farb-Rendering)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (rein technischer Hilfs-Endpoint, nicht nutzersichtbar dokumentiert)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Tenant-scoped; jeder MA berechtigt (Lese-Hilfsdaten)</span></div>
+          </div>
+        </div>
+    </section><section class="area" data-area="Admin-Benutzerverwaltung">
+      <h2>Admin-Benutzerverwaltung <span class="count">22</span></h2>
+      <div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-01 benutzer anlegen userform sammelt stammdaten + flags; post /api/admin/users; username-eindeutigkeit pro tenant geprueft, lizenz-/seat-limit geprueft (check_employee_limit + check_seat_limit), passwort gehasht; user mit tenant_id angelegt; danach auto-enrollment in laufende/kuenftige betriebsferien (#290); optional anfangssaldo-carryover (#158) per separatem put. post /api/admin/users">
+          <div class="uc-head">
+            <code class="uc-id">ABV-01</code>
+            <span class="uc-title">Benutzer anlegen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt &#x27;Neue:r Mitarbeiter:in&#x27; und speichert das Formular</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">UserForm sammelt Stammdaten + Flags; POST /api/admin/users; Username-Eindeutigkeit pro Tenant geprueft, Lizenz-/Seat-Limit geprueft (check_employee_limit + check_seat_limit), Passwort gehasht; User mit tenant_id angelegt; danach Auto-Enrollment in laufende/kuenftige Betriebsferien (#290); optional Anfangssaldo-Carryover (#158) per separatem PUT.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/users</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/admin/users/UserForm.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/handbuch/HANDBUCH-ADMIN.md (Abschnitt &#x27;Neuen Benutzer anlegen&#x27;, Z.154ff) + DocViewer.tsx (Benutzerverwaltung)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026 Tenant-Scope der Username-Probe; Lizenz/Seat-Limit; Passwort-Komplexitaet (10 Zeichen, Gross/Klein/Ziffer); first&lt;last_work_day + Soll-Fenster-Reihenfolge via validator</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-02 benutzer bearbeiten put /api/admin/users/{id}; nur gesetzte felder (exclude_unset); is_active wird ausgefiltert (eigener endpoint); bei rollenwechsel token_version++ (vuln-010); bei neu aktivierter betriebsferien-teilnahme auto-enrollment. put /api/admin/users/{user_id}">
+          <div class="uc-head">
+            <code class="uc-id">ABV-02</code>
+            <span class="uc-title">Benutzer bearbeiten</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt Bearbeiten-Icon</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">PUT /api/admin/users/{id}; nur gesetzte Felder (exclude_unset); is_active wird ausgefiltert (eigener Endpoint); bei Rollenwechsel token_version++ (VULN-010); bei neu aktivierter Betriebsferien-Teilnahme Auto-Enrollment.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/admin/users/{user_id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">UserForm.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md Z.164ff + DocViewer.tsx Z.402-407</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026; is_active pop verhindert Bypass des Deactivate-Endpoints; Rollenwechsel invalidiert JWTs</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-03 passwort setzen (admin) post /api/admin/users/{id}/set-password; neues passwort gehasht, token_version++ (alle sessions invalidiert). post /api/admin/users/{user_id}/set-password">
+          <div class="uc-head">
+            <code class="uc-id">ABV-03</code>
+            <span class="uc-title">Passwort setzen (Admin)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt Schluessel-Icon</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/admin/users/{id}/set-password; neues Passwort gehasht, token_version++ (alle Sessions invalidiert).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/users/{user_id}/set-password</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">SetPasswordModal.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md (Benutzerverwaltung) / DocViewer Benutzerverwaltung</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Passwort-Komplexitaet; Session-Invalidierung</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-04 benutzer deaktivieren (soft-delete) delete /api/admin/users/{id}; selbst-deaktivierung blockiert; is_active=false, deactivated_at gesetzt (grace-period-start), token_version++. delete /api/admin/users/{user_id}">
+          <div class="uc-head">
+            <code class="uc-id">ABV-04</code>
+            <span class="uc-title">Benutzer deaktivieren (Soft-Delete)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt Deaktivieren-Icon</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">DELETE /api/admin/users/{id}; Selbst-Deaktivierung blockiert; is_active=False, deactivated_at gesetzt (Grace-Period-Start), token_version++.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>DELETE /api/admin/users/{user_id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Users.tsx handleDeactivate</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md Z.240 + CHEATSHEET-ADMIN.md Z.56 + DocViewer Z.402</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§16 ArbZG: nicht loeschen, deaktivieren; Selbst-Deaktivierung verhindert Lockout</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="0" data-impl="1" data-text="abv-05 benutzer reaktivieren post /api/admin/users/{id}/reactivate; seat-limit geprueft (reaktivierung = seat-add); is_active=true, deactivated_at=none. post /api/admin/users/{user_id}/reactivate">
+          <div class="uc-head">
+            <code class="uc-id">ABV-05</code>
+            <span class="uc-title">Benutzer reaktivieren</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt Reaktivieren-Icon bei inaktivem User</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/admin/users/{id}/reactivate; Seat-Limit geprueft (Reaktivierung = Seat-Add); is_active=True, deactivated_at=None.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/users/{user_id}/reactivate</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Users.tsx handleReactivate</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (Deaktivierung dokumentiert, Reaktivierung nicht explizit)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Seat-Limit; F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="0" data-impl="1" data-text="abv-06 benutzer aus-/einblenden (toggle-hidden) post /api/admin/users/{id}/toggle-hidden; is_hidden umgeschaltet; login bleibt moeglich, nur aus listen/berichten ausgeblendet. post /api/admin/users/{user_id}/toggle-hidden">
+          <div class="uc-head">
+            <code class="uc-id">ABV-06</code>
+            <span class="uc-title">Benutzer aus-/einblenden (toggle-hidden)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt Auge-Icon</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/admin/users/{id}/toggle-hidden; is_hidden umgeschaltet; Login bleibt moeglich, nur aus Listen/Berichten ausgeblendet.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/users/{user_id}/toggle-hidden</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Users.tsx handleToggleHidden</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (kein Handbuch-/Cheatsheet-/In-App-Eintrag fuer Ausblenden)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026; Sichtbarkeit getrennt von Aktiv-Status</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="0" data-impl="1" data-text="abv-07 dsgvo-anonymisierung (art.17) post /api/admin/users/{id}/anonymize; pruefen: inaktiv + nicht bereits anonymisiert + 14-tage-grace abgelaufen; name/username/email/profilbild/totp/department geleert, token_version++; absences geloescht; zeiteintraege bleiben (§16); audit-log. post /api/admin/users/{user_id}/anonymize">
+          <div class="uc-head">
+            <code class="uc-id">ABV-07</code>
+            <span class="uc-title">DSGVO-Anonymisierung (Art.17)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt Anonymisieren-Icon (nur inaktiv, nach Sperrfrist)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/admin/users/{id}/anonymize; pruefen: inaktiv + nicht bereits anonymisiert + 14-Tage-Grace abgelaufen; Name/Username/Email/Profilbild/TOTP/Department geleert, token_version++; Absences geloescht; Zeiteintraege bleiben (§16); Audit-Log.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/users/{user_id}/anonymize</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Users.tsx handleAnonymize</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT in HANDBUCH-ADMIN/CHEATSHEET/DocViewer (nur in docs/specs/dsgvo)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Art.17 DSGVO; §16 ArbZG (TimeEntry-Retention); 14-Tage-Sperrfrist; Art.4/9 (Biometrie/TOTP loeschen); F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="0" data-impl="1" data-text="abv-08 dsgvo endgueltige loeschung (purge, art.17) delete /api/admin/users/{id}/purge; inaktiv noetig; juengste timeentry- und absence-datum muss &gt;=730 tage zurueck (409 sonst); fk-abhaengigkeiten aufgeloest (audit-logs umgehaengt/geloescht, vacationrequest/changerequest/workinghourschange/shiftplan/qualifications/companyclosure/signuptoken bereinigt), dann db.delete(user). delete /api/admin/users/{user_id}/purge">
+          <div class="uc-head">
+            <code class="uc-id">ABV-08</code>
+            <span class="uc-title">DSGVO endgueltige Loeschung (Purge, Art.17)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt Endgueltig-Loeschen-Icon (nur bei anonymisiertem User)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">DELETE /api/admin/users/{id}/purge; inaktiv noetig; juengste TimeEntry- UND Absence-Datum muss &gt;=730 Tage zurueck (409 sonst); FK-Abhaengigkeiten aufgeloest (Audit-Logs umgehaengt/geloescht, VacationRequest/ChangeRequest/WorkingHoursChange/ShiftPlan/Qualifications/CompanyClosure/SignupToken bereinigt), dann db.delete(user).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>DELETE /api/admin/users/{user_id}/purge</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Users.tsx handlePurge</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT in Handbuch/Cheatsheet/DocViewer</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Art.17; §16 730-Tage-Aufbewahrung (TimeEntry+Absence); FK-Cleanup wegen Postgres NOT-NULL/no-ondelete; F-026; kein Klarname im Audit-Log</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="0" data-impl="1" data-text="abv-09 loeschkandidaten-liste get /api/admin/users/deletion-candidates; bulk-group-by letztes timeentry-datum (f-055); grace-period + can_anonymize/can_purge berechnet. get /api/admin/users/deletion-candidates">
+          <div class="uc-head">
+            <code class="uc-id">ABV-09</code>
+            <span class="uc-title">Loeschkandidaten-Liste</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Anzeige inaktiver User mit Anonymisierungs-/Purge-Eligibilitaet</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/admin/users/deletion-candidates; Bulk-GROUP-BY letztes TimeEntry-Datum (F-055); Grace-Period + can_anonymize/can_purge berechnet.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/users/deletion-candidates</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Users.tsx (Grace-Badge inline) — kein dedizierter Screen</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026; today_local; 14d Grace / 730d Retention</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-10 benutzerliste get /api/admin/users; default nur aktiv+sichtbar; include_inactive/include_hidden filter; pagination skip/limit&lt;=500. get /api/admin/users">
+          <div class="uc-head">
+            <code class="uc-id">ABV-10</code>
+            <span class="uc-title">Benutzerliste</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Aufruf Benutzerverwaltung</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/admin/users; default nur aktiv+sichtbar; include_inactive/include_hidden Filter; Pagination skip/limit&lt;=500.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/users</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Users.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md (Benutzeruebersicht)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026 expliziter Tenant-Filter; UserListResponse ohne profile_picture-Blob</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-11 benutzeruebersicht (urlaub+jtd-ueberstunden) #194 get /api/admin/users-overview; pro user vacation_account + ytd_summary (mit stichtag im laufenden jahr #313) in einem call (ersetzt n+1). get /api/admin/users-overview">
+          <div class="uc-head">
+            <code class="uc-id">ABV-11</code>
+            <span class="uc-title">Benutzeruebersicht (Urlaub+JTD-Ueberstunden) #194</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Aufruf Benutzerverwaltung (Bulk-Aggregat)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /api/admin/users-overview; pro User vacation_account + ytd_summary (mit Stichtag im laufenden Jahr #313) in einem Call (ersetzt N+1).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/users-overview</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Users.tsx (Urlaubskonto + JTD-Spalte)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md Z.189 + DocViewer Z.404</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026; Urlaub tagebasiert; #313 Stichtag; &#x27;—&#x27; bei track_hours=False</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-12 wochenstunden-historie (anzeigen/anlegen/loeschen) get/post/delete /api/admin/users/{id}/working-hours-changes; duplikat-datum 400; bei effective_from&lt;=heute wird user.weekly_hours auf juengsten eintrag gecacht; calc nutzt get_weekly_hours_for_date (historie). get/post/delete /api/admin/users/{user_id}/working-hours-changes[/{change_id}]">
+          <div class="uc-head">
+            <code class="uc-id">ABV-12</code>
+            <span class="uc-title">Wochenstunden-Historie (anzeigen/anlegen/loeschen)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin oeffnet Stundenverlauf-Modal</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET/POST/DELETE /api/admin/users/{id}/working-hours-changes; Duplikat-Datum 400; bei effective_from&lt;=heute wird user.weekly_hours auf juengsten Eintrag gecacht; Calc nutzt get_weekly_hours_for_date (Historie).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET/POST/DELETE /api/admin/users/{user_id}/working-hours-changes[/{change_id}]</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">WorkingHoursModal.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md Z.232 + DocViewer Z.195/403</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026; historisch korrekte Soll-Berechnung; nie user.weekly_hours direkt lesen</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-13 vorjahresuebernahme (carryover) je user get /carryovers, put /carryovers/{year}; jahr 2000-2100 validiert; upsert overtime_hours + vacation_days. get /api/admin/users/{id}/carryovers, put /api/admin/users/{id}/carryovers/{year}">
+          <div class="uc-head">
+            <code class="uc-id">ABV-13</code>
+            <span class="uc-title">Vorjahresuebernahme (Carryover) je User</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin oeffnet Vorjahresuebernahme-Modal</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /carryovers, PUT /carryovers/{year}; Jahr 2000-2100 validiert; Upsert overtime_hours + vacation_days.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/users/{id}/carryovers, PUT /api/admin/users/{id}/carryovers/{year}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">CarryoverModal.tsx + UserForm (Anfangssaldo)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md (Vorjahresuebernahme/Anfangssaldo Z.180) + CHEATSHEET Z.249</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026; Ueberstunden in Stunden, Urlaub in Tagen</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="0" data-text="abv-14 jahresabschluss erstellen post /api/admin/year-closing/{year}; pg_advisory_xact_lock pro (tenant,year); 409 bei offenen changerequests des jahres; berechnet ueberstundensaldo + resturlaub per 31.12. fuer aktive user mit track_hours==true; upsert yearcarryover fuer year+1. post /api/admin/year-closing/{year}">
+          <div class="uc-head">
+            <code class="uc-id">ABV-14</code>
+            <span class="uc-title">Jahresabschluss erstellen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt &#x27;Jahresabschluss&#x27; im Admin-Dashboard</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /api/admin/year-closing/{year}; pg_advisory_xact_lock pro (tenant,year); 409 bei offenen ChangeRequests des Jahres; berechnet Ueberstundensaldo + Resturlaub per 31.12. fuer aktive User mit track_hours==True; Upsert YearCarryover fuer year+1.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/year-closing/{year}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AdminDashboard.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md Z.104-119 + CHEATSHEET Z.249-257</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-029 Serialisierung; 409 bei Pending-CRs; Carryover Stunden+Tage; #191: untracked MA ausgenommen</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-15 jahresabschluss loeschen delete /api/admin/year-closing/{year}; loescht alle yearcarryover fuer year+1 (auch manuelle); 404 wenn keine. delete /api/admin/year-closing/{year}">
+          <div class="uc-head">
+            <code class="uc-id">ABV-15</code>
+            <span class="uc-title">Jahresabschluss loeschen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt &#x27;Abschluss loeschen&#x27;</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">DELETE /api/admin/year-closing/{year}; loescht ALLE YearCarryover fuer year+1 (auch manuelle); 404 wenn keine.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>DELETE /api/admin/year-closing/{year}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AdminDashboard.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md Z.121-130 + CHEATSHEET Z.254</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026; loescht auch manuelle Uebernahmen (dokumentierte Warnung)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-16 stundenzaehlung-flag (track_hours) #191 track_hours steuert soll/ist/ueberstunden; bei false kein tagessoll, aber urlaub/krank tagebasiert gefuehrt; getrennt von §18 exempt_from_arbzg. post/put /api/admin/users">
+          <div class="uc-head">
+            <code class="uc-id">ABV-16</code>
+            <span class="uc-title">Stundenzaehlung-Flag (track_hours) #191</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Checkbox &#x27;Stundenzaehlung aktiv&#x27; im UserForm</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">track_hours steuert Soll/Ist/Ueberstunden; bei False kein Tagessoll, aber Urlaub/Krank tagebasiert gefuehrt; getrennt von §18 exempt_from_arbzg.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST/PUT /api/admin/users</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">UserForm.tsx (track_hours Checkbox)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md Z.195-208 + CHEATSHEET Z.37 + DocViewer Z.187/359</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#191; Urlaub tagebasiert auch bei daily_target==0; Trennung von §18</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-17 beschaeftigungsfenster first/last_work_day #193 soll- und ist-berechnung nur innerhalb des fensters (_within_employment_window); urlaubsanspruch pro-rata; betriebsferien-buchung respektiert fenster (#298). post/put /api/admin/users">
+          <div class="uc-head">
+            <code class="uc-id">ABV-17</code>
+            <span class="uc-title">Beschaeftigungsfenster first/last_work_day #193</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Felder Erster/Letzter Arbeitstag im UserForm</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Soll- und Ist-Berechnung nur innerhalb des Fensters (_within_employment_window); Urlaubsanspruch pro-rata; Betriebsferien-Buchung respektiert Fenster (#298).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST/PUT /api/admin/users</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">UserForm.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md Z.177 + DocViewer Z.404</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#193/#195/#298; first&lt;last (Validator); pro-rata Urlaub</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-18 arbeitszeit-fenster (scheduled_start/end je wochentag) #201 optionale soll-beginn/-ende mo-fr; clamp() kappt stempel auf [soll-beginn-puffer, soll-ende+puffer]; rohwerte erhalten (§16); opt-in. post/put /api/admin/users">
+          <div class="uc-head">
+            <code class="uc-id">ABV-18</code>
+            <span class="uc-title">Arbeitszeit-Fenster (scheduled_start/end je Wochentag) #201</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Bereich &#x27;Soll-Arbeitszeiten je Wochentag&#x27; im UserForm</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Optionale Soll-Beginn/-Ende Mo-Fr; clamp() kappt Stempel auf [Soll-Beginn-Puffer, Soll-Ende+Puffer]; Rohwerte erhalten (§16); opt-in.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST/PUT /api/admin/users</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">UserForm.tsx (Soll-Arbeitszeiten)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md Z.210-219 + DocViewer Z.406</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#201; Soll-Beginn&lt;Soll-Ende (Validator); §16 Rohstempel; uebersprungen bei track_hours=False</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-19 kalenderfarbe je ma setzen (admin) #297 calendar_color (pattern #rrggbb) im user-payload; ueberschreibt/ergaenzt profil-selbstwahl. post/put /api/admin/users">
+          <div class="uc-head">
+            <code class="uc-id">ABV-19</code>
+            <span class="uc-title">Kalenderfarbe je MA setzen (Admin) #297</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Farbpalette im UserForm</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">calendar_color (Pattern #RRGGBB) im User-Payload; ueberschreibt/ergaenzt Profil-Selbstwahl.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST/PUT /api/admin/users</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">UserForm.tsx PASTEL_COLORS</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md Z.252 + DocViewer Z.407</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Pattern-Validierung #RRGGBB</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-20 betriebsferien-teilnahme (receives_company_closures) #189/#290 flag (default true) steuert betriebsferien-buchung rollenunabhaengig; aktivieren beim bearbeiten/anlegen triggert auto-enrollment in laufende/kuenftige closures (#290, best-effort, loescht keine arbeitszeit). post/put /api/admin/users (auto-enroll via company_closures helpers)">
+          <div class="uc-head">
+            <code class="uc-id">ABV-20</code>
+            <span class="uc-title">Betriebsferien-Teilnahme (receives_company_closures) #189/#290</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Checkbox &#x27;Nimmt an Betriebsferien teil&#x27;</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Flag (Default True) steuert Betriebsferien-Buchung rollenunabhaengig; Aktivieren beim Bearbeiten/Anlegen triggert Auto-Enrollment in laufende/kuenftige Closures (#290, best-effort, loescht keine Arbeitszeit).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST/PUT /api/admin/users (Auto-Enroll via company_closures helpers)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">UserForm.tsx receives_company_closures</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md Z.176/445 + DocViewer Z.236/435</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#189 rollenunabhaengig; #290 Auto-Enroll best-effort; #298 nur im Beschaeftigungsfenster; F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-21 anfangssaldo ueberstunden beim anlegen/bearbeiten #158 nach user-save separater put carryovers/{startyear}; bewahrt vorhandenen urlaubs-vortrag des zieljahres (frischer fetch), schreibt nur bei !=0 oder vorhandenem carryover. put /api/admin/users/{id}/carryovers/{year}">
+          <div class="uc-head">
+            <code class="uc-id">ABV-21</code>
+            <span class="uc-title">Anfangssaldo Ueberstunden beim Anlegen/Bearbeiten #158</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Feld &#x27;Anfangssaldo Ueberstunden&#x27; (nur track_hours)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Nach User-Save separater PUT carryovers/{startYear}; bewahrt vorhandenen Urlaubs-Vortrag des Zieljahres (frischer Fetch), schreibt nur bei !=0 oder vorhandenem Carryover.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/admin/users/{id}/carryovers/{year}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">UserForm.tsx (overtime_carryover)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md Z.180</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#158; Startjahr = first_work_day-Jahr oder aktuelles Jahr; Urlaubs-Vortrag erhalten</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Benutzerverwaltung" data-doc="1" data-impl="1" data-text="abv-22 monatsjournal je mitarbeiter (admin-ansicht) navigation zu /admin/users/{id}/journal; laedt user-name via get /admin/users/{id}; rendert monthlyjournal isadminview. get /api/admin/users/{user_id} (+journal-endpoints der komponente)">
+          <div class="uc-head">
+            <code class="uc-id">ABV-22</code>
+            <span class="uc-title">Monatsjournal je Mitarbeiter (Admin-Ansicht)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt Journal-Icon</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Navigation zu /admin/users/{id}/journal; laedt User-Name via GET /admin/users/{id}; rendert MonthlyJournal isAdminView.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/users/{user_id} (+Journal-Endpoints der Komponente)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">UserJournal.tsx + MonthlyJournal</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md (Monatsjournal) / Users.tsx Tooltip</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026 via _get_user_in_tenant</span></div>
+          </div>
+        </div>
+    </section><section class="area" data-area="Admin-Berichte &amp; Datenaustausch">
+      <h2>Admin-Berichte &amp; Datenaustausch <span class="count">19</span></h2>
+      <div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="0" data-impl="1" data-text="imp-01 xls-import vorschau (timerec) datei &lt;=5mb, magic-byte-guard (nur ole2/biff .xls; .xlsx/zip + fremdformat abgelehnt 400), parse_xls (sheet &#x27;zeiterfassung&#x27;), soll-fenster-kappung (#201, raw_* erhalten), arbzg-warnungen (§3/§4 tagesaggregation, §5 inkl. db-vorlauf, §6, §18-bypass), konflikt-erkennung. kein schreiben. post /api/admin/import/preview (multipart: file, user_id)">
+          <div class="uc-head">
+            <code class="uc-id">IMP-01</code>
+            <span class="uc-title">XLS-Import Vorschau (TimeRec)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Import → Datei analysieren</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Datei &lt;=5MB, Magic-Byte-Guard (nur OLE2/BIFF .xls; .xlsx/ZIP + Fremdformat abgelehnt 400), parse_xls (Sheet &#x27;Zeiterfassung&#x27;), Soll-Fenster-Kappung (#201, raw_* erhalten), ArbZG-Warnungen (§3/§4 Tagesaggregation, §5 inkl. DB-Vorlauf, §6, §18-bypass), Konflikt-Erkennung. KEIN Schreiben.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/import/preview (multipart: file, user_id)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">ImportXls.tsx (Wizard Schritt 1→2)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT in In-App-Hilfe; HANDBUCH-ADMIN.md §12 vorhanden aber FALSCH (s. Finding)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">ArbZG §3/§4/§5/§6/§18; #201 work_window; F-026 (User tenant-scoped im Router); 5MB-Limit</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="0" data-impl="1" data-text="imp-02 xls-import ausführen execute_import: pro eintrag end&gt;start-guard (sonst skip+warnung, kein phantom-0h-eintrag, §3-bypass verhindert), konflikt-recheck (nicht client-flag vertrauen), overwrite→audit update / neu→audit create, raw_* übernommen (§16). f-042 voller try/except mit rollback + separater fehler-audit. summary-audit. audit source/action &lt;40 zeichen. post /api/admin/import/confirm">
+          <div class="uc-head">
+            <code class="uc-id">IMP-02</code>
+            <span class="uc-title">XLS-Import Ausführen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Import → Import bestätigen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">execute_import: pro Eintrag end&gt;start-Guard (sonst skip+Warnung, kein Phantom-0h-Eintrag, §3-Bypass verhindert), Konflikt-Recheck (nicht Client-Flag vertrauen), overwrite→Audit update / neu→Audit create, raw_* übernommen (§16). F-042 voller try/except mit Rollback + separater Fehler-Audit. Summary-Audit. Audit source/action &lt;40 Zeichen.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/import/confirm</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">ImportXls.tsx (Wizard Schritt 3)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT/FALSCH (HANDBUCH-ADMIN.md §12)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§16 Roh-Stempel; Race (Konflikt-Recheck vor Schreiben); F-042 Atomarität; F-026 tenant_id auf TimeEntry/User</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="1" data-impl="1" data-text="jnl-01 monatsjournal eines ma (admin-zugriff, §16-beleg) journal_service.get_journal: tagesgenaue zeilen (soll/ist/saldo, einträge, abwesenheiten, feiertage/sondertage/beschäftigungsfenster via _eff_daily_target) + monatssumme + jahres-überstunden. voll-monat (kein cutoff → §16). get /api/admin/users/{user_id}/journal">
+          <div class="uc-head">
+            <code class="uc-id">JNL-01</code>
+            <span class="uc-title">Monatsjournal eines MA (Admin-Zugriff, §16-Beleg)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Benutzerübersicht → Buch-Symbol</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">journal_service.get_journal: tagesgenaue Zeilen (Soll/Ist/Saldo, Einträge, Abwesenheiten, Feiertage/Sondertage/Beschäftigungsfenster via _eff_daily_target) + Monatssumme + Jahres-Überstunden. Voll-Monat (kein cutoff → §16).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/users/{user_id}/journal</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">UserJournal.tsx / MonthlyJournal.tsx (#311 Name in Überschrift)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">DocViewer.tsx Z.408, HANDBUCH-ADMIN.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§16 voll-Monat; F-026 (explizite tenant_id-Filter + User-Lookup tenant-scoped); #146/#193/#198 Per-Tag-Fenster; OVERTIME nicht soll-mindernd</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="1" data-impl="1" data-text="jnl-02 eigenes monatsjournal (mitarbeiter) journal_service.get_journal für current_user; identische logik, eigene daten (kein maskierungsbedarf). get /api/journal/me">
+          <div class="uc-head">
+            <code class="uc-id">JNL-02</code>
+            <span class="uc-title">Eigenes Monatsjournal (Mitarbeiter)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Zeiterfassung → Tab Journal</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">journal_service.get_journal für current_user; identische Logik, eigene Daten (kein Maskierungsbedarf).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/journal/me</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">TimeTracking.tsx (Journal-Tab) / MonthlyJournal.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">DocViewer.tsx (MA-Hilfe), HANDBUCH-MITARBEITER.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Eigene Daten; §16-Konsistenz zum Admin-Journal</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="1" data-impl="1" data-text="rpt-01 monatsbericht (team-tabelle aller ma) pro aktivem, nicht-verborgenem ma soll/ist/saldo/überstunden + urlaub/krank (stunden &amp; tage) für den monat. soll-mindernde abwesenheiten berücksichtigt; weekly_hours historisch zum monatsanfang; urlaub/krank tagebasiert via absence_days (tagesprinzip). get /api/admin/reports/monthly?month=yyyy-mm&amp;soll_basis=&amp;include_health_data=">
+          <div class="uc-head">
+            <code class="uc-id">RPT-01</code>
+            <span class="uc-title">Monatsbericht (Team-Tabelle aller MA)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin-Dashboard öffnen / Monatsansicht</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Pro aktivem, nicht-verborgenem MA Soll/Ist/Saldo/Überstunden + Urlaub/Krank (Stunden &amp; Tage) für den Monat. Soll-mindernde Abwesenheiten berücksichtigt; weekly_hours historisch zum Monatsanfang; Urlaub/Krank tagebasiert via absence_days (Tagesprinzip).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/reports/monthly?month=YYYY-MM&amp;soll_basis=&amp;include_health_data=</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AdminDashboard.tsx (Team-Tabelle), nicht Reports.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/handbuch/HANDBUCH-ADMIN.md (Admin-Dashboard), DocViewer.tsx Abschnitt 2</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Calc: Soll/Ist; Tagesprinzip für Urlaub/Krank-Tage; F-026 (explizite Absence.tenant_id-Filter); DSGVO Art.9 (sick nur bei include_health_data)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="1" data-impl="1" data-text="rpt-02 wochenbericht (#329) week_start auf montag normalisiert (mo–so), darf monats-/jahresgrenze überschreiten. gleiches schema wie /monthly über get_range_target/actual; überstunden = kumulativer saldo zum wochenende (ggf. am bis_heute-cutoff gekappt). urlaub/krank-absences bei cutoff zusätzlich auf &lt;=cutoff gefiltert. get /api/admin/reports/weekly?week_start=yyyy-mm-dd&amp;soll_basis=&amp;include_health_data=">
+          <div class="uc-head">
+            <code class="uc-id">RPT-02</code>
+            <span class="uc-title">Wochenbericht (#329)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin-Dashboard Umschalter Monat/Woche</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">week_start auf Montag normalisiert (Mo–So), darf Monats-/Jahresgrenze überschreiten. Gleiches Schema wie /monthly über get_range_target/actual; Überstunden = kumulativer Saldo zum Wochenende (ggf. am bis_heute-Cutoff gekappt). Urlaub/Krank-Absences bei Cutoff zusätzlich auf &lt;=cutoff gefiltert.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/reports/weekly?week_start=YYYY-MM-DD&amp;soll_basis=&amp;include_health_data=</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AdminDashboard.tsx (viewMode=week)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/handbuch/HANDBUCH-ADMIN.md Z.91 (#329), DocViewer.tsx Z.392</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Calc Wochenfenster; Tagesprinzip; DSGVO Art.9; F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="1" data-impl="1" data-text="rpt-03 soll-basis bis_heute / monatsende|volle woche (#313) soll_basis=bis_heute (default): per-user get_soll_cutoff_date kappt soll/ist auf letzten abgeschlossenen arbeitstag (kein monatsanfangs-minus). monatsende: cutoff=none (voller zeitraum). validierung auf die zwei erlaubten werte (400 sonst). query-param auf /monthly + /weekly">
+          <div class="uc-head">
+            <code class="uc-id">RPT-03</code>
+            <span class="uc-title">Soll-Basis bis_heute / monatsende|volle Woche (#313)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Dropdown &#x27;Soll: bis heute / Monatsende&#x27;</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">soll_basis=bis_heute (Default): per-User get_soll_cutoff_date kappt Soll/Ist auf letzten abgeschlossenen Arbeitstag (kein Monatsanfangs-Minus). monatsende: cutoff=None (voller Zeitraum). Validierung auf die zwei erlaubten Werte (400 sonst).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>Query-Param auf /monthly + /weekly</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AdminDashboard.tsx Dropdown</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/handbuch/HANDBUCH-ADMIN.md Z.93-96, DocViewer.tsx Z.393, docs/GLOSSAR.md §5</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#313 Stichtag-Semantik; Datei-Exporte/§16 bleiben bewusst voll-Monat (kein cutoff)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="1" data-impl="1" data-text="rpt-04 jahres-abwesenheitsübersicht pro ma urlaub/krank/fortbildung/überstd.-ausgleich/sonstiges/bez.freistellung in tagen + resturlaub + ytd-überstunden. urlaub &amp; resturlaub tagebasiert aus get_vacation_account (konsistent: budget-genommen=rest). übrige typen via hours/daily_target-näherung (im code dokumentiert). get /api/admin/reports/yearly-absences?year=&amp;include_health_data=">
+          <div class="uc-head">
+            <code class="uc-id">RPT-04</code>
+            <span class="uc-title">Jahres-Abwesenheitsübersicht</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin-Dashboard Jahresübersicht</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Pro MA Urlaub/Krank/Fortbildung/Überstd.-Ausgleich/Sonstiges/bez.Freistellung in Tagen + Resturlaub + YTD-Überstunden. Urlaub &amp; Resturlaub tagebasiert aus get_vacation_account (konsistent: budget-genommen=Rest). Übrige Typen via hours/daily_target-Näherung (im Code dokumentiert).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/reports/yearly-absences?year=&amp;include_health_data=</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AdminDashboard.tsx (Jahresübersicht)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/handbuch/HANDBUCH-ADMIN.md, DocViewer.tsx</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Tagesprinzip (Urlaub day-based korrekt); DSGVO Art.9 (sick gegated); übrige Tage = Näherung</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="1" data-impl="1" data-text="rpt-05 monatsreport excel (.xlsx) export export_service.generate_monthly_report: ein sheet je ma mit tages-breakdown + monatszusammenfassung. voll-monat (kein cutoff = §16-rechtsbeleg). db.close() vor streaming (f-053). rate-limit 20/min. get /api/admin/reports/export?month=&amp;include_health_data=">
+          <div class="uc-head">
+            <code class="uc-id">RPT-05</code>
+            <span class="uc-title">Monatsreport Excel (.xlsx) Export</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Berichte → Monatsreport → Excel</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">export_service.generate_monthly_report: ein Sheet je MA mit Tages-Breakdown + Monatszusammenfassung. Voll-Monat (kein cutoff = §16-Rechtsbeleg). db.close() vor Streaming (F-053). Rate-Limit 20/min.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/reports/export?month=&amp;include_health_data=</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Reports.tsx handleMonthlyExport</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/handbuch/HANDBUCH-ADMIN.md Abschnitt 3, DocViewer.tsx Z.413-417</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§16 voll-Monat; DSGVO Art.9 (sick maskiert als &#x27;Abwesenheit&#x27; ohne Flag, Audit health_export); F-026 tenant_id</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="0" data-impl="1" data-text="rpt-06 monatsreport ods export ods_export_service.generate_monthly_report, analog excel. get /api/admin/reports/export-ods">
+          <div class="uc-head">
+            <code class="uc-id">RPT-06</code>
+            <span class="uc-title">Monatsreport ODS Export</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Berichte → Monatsreport → ODS</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">ods_export_service.generate_monthly_report, analog Excel.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/reports/export-ods</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Reports.tsx handleMonthlyExportOds</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (DocViewer/Handbuch nennen ODS nicht; nur Excel/CSV)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§16 voll-Monat; DSGVO Art.9; F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="0" data-impl="1" data-text="rpt-07 monatsreport pdf export export_service.generate_monthly_report_pdf (querformat a4, eine seite je ma). get /api/admin/reports/export-pdf">
+          <div class="uc-head">
+            <code class="uc-id">RPT-07</code>
+            <span class="uc-title">Monatsreport PDF Export</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Berichte → Monatsreport → PDF</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">export_service.generate_monthly_report_pdf (Querformat A4, eine Seite je MA).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/reports/export-pdf</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Reports.tsx handleMonthlyExportPdf</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (PDF nicht im Handbuch/DocViewer)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§16 voll-Monat; DSGVO Art.9 (Audit); F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="1" data-impl="1" data-text="rpt-08 jahresreport excel (detailliert + classic) generate_yearly_report (übersicht+abwesenheiten+365-tage/ma) bzw. generate_yearly_report_classic (12 monate als spalten). voll-jahr. get /export-yearly, /export-yearly-classic">
+          <div class="uc-head">
+            <code class="uc-id">RPT-08</code>
+            <span class="uc-title">Jahresreport Excel (Detailliert + Classic)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Berichte → Jahresreport → Excel</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">generate_yearly_report (Übersicht+Abwesenheiten+365-Tage/MA) bzw. generate_yearly_report_classic (12 Monate als Spalten). Voll-Jahr.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /export-yearly, /export-yearly-classic</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Reports.tsx handleYearlyExport / handleYearlyClassicExport</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/handbuch/HANDBUCH-ADMIN.md Abschnitt 3, DocViewer.tsx Z.215-216</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§16; DSGVO Art.9 (sick + is_night_worker gegated); F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="0" data-impl="1" data-text="rpt-09 jahresreport ods (detailliert + classic) ods_export_service.generate_yearly_report / _classic. get /export-yearly-ods, /export-yearly-classic-ods">
+          <div class="uc-head">
+            <code class="uc-id">RPT-09</code>
+            <span class="uc-title">Jahresreport ODS (Detailliert + Classic)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Berichte → Jahresreport → ODS</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">ods_export_service.generate_yearly_report / _classic.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /export-yearly-ods, /export-yearly-classic-ods</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Reports.tsx handleYearlyExportOds / handleYearlyClassicExportOds</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (ODS nicht genannt)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§16; DSGVO Art.9; F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="1" data-impl="1" data-text="rpt-10 dsgvo art.9 gesundheitsdaten-gate + audit ohne flag: sick_hours/sick_days=0 in json-reports, sick als &#x27;abwesenheit&#x27; in exporten maskiert, is_night_worker &#x27;–&#x27;. mit flag: reports loggen action=health_data_read (flush→commit erst nach erfolgreichem aufbau, l-2); exporte loggen health_export (commit vor build). include_health_data= auf allen report-/export-endpoints">
+          <div class="uc-head">
+            <code class="uc-id">RPT-10</code>
+            <span class="uc-title">DSGVO Art.9 Gesundheitsdaten-Gate + Audit</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Checkbox &#x27;Krankheitsdaten einschließen&#x27;</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Ohne Flag: sick_hours/sick_days=0 in JSON-Reports, sick als &#x27;Abwesenheit&#x27; in Exporten maskiert, is_night_worker &#x27;–&#x27;. Mit Flag: Reports loggen action=health_data_read (flush→commit erst nach erfolgreichem Aufbau, L-2); Exporte loggen health_export (commit vor Build).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>include_health_data= auf allen Report-/Export-Endpoints</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Reports.tsx + AdminDashboard.tsx (showHealthData)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">Reports.tsx UI-Hinweis (amber), docs/specs/dsgvo/*</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO Art.9 + F-020 Audit-Trail; saubere flush/commit-Reihenfolge</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="1" data-impl="1" data-text="rpt-11 §5 arbzg ruhezeitprüfung rest_time_service.check_all_users_violations für jahr/optional monat; &lt;11h zwischen schichten. §18-exempt ma werden ausgeschlossen (h-1). get /api/admin/reports/rest-time-violations">
+          <div class="uc-head">
+            <code class="uc-id">RPT-11</code>
+            <span class="uc-title">§5 ArbZG Ruhezeitprüfung</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Berichte → Ruhezeitprüfung</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">rest_time_service.check_all_users_violations für Jahr/optional Monat; &lt;11h zwischen Schichten. §18-exempt MA werden ausgeschlossen (H-1).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/reports/rest-time-violations</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Reports.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">DocViewer.tsx Z.473, HANDBUCH-ADMIN.md ArbZG-Abschnitt</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§5 ArbZG; §18 exempt korrekt ausgeschlossen; tenant_id-Filter im Service</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="1" data-impl="0" data-text="rpt-12 §11 arbzg sonntagsarbeit-auswertung zählt gearbeitete vs. freie sonntage pro ma, mindestziel 15 freie/jahr. get /api/admin/reports/sunday-summary">
+          <div class="uc-head">
+            <code class="uc-id">RPT-12</code>
+            <span class="uc-title">§11 ArbZG Sonntagsarbeit-Auswertung</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Berichte → Sonntagsarbeit</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Zählt gearbeitete vs. freie Sonntage pro MA, Mindestziel 15 freie/Jahr.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/reports/sunday-summary</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Reports.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">DocViewer.tsx Z.473/254</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§11 ArbZG; ABER §18-exempt MA werden NICHT ausgeschlossen (Inkonsistenz, s. Finding)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="1" data-impl="0" data-text="rpt-13 §6 arbzg nachtarbeit-auswertung is_night_work(start,end) je eintrag; nachtarbeitnehmer ab 48 nachttagen/jahr. get /api/admin/reports/night-work-summary">
+          <div class="uc-head">
+            <code class="uc-id">RPT-13</code>
+            <span class="uc-title">§6 ArbZG Nachtarbeit-Auswertung</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Berichte → Nachtarbeit</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">is_night_work(start,end) je Eintrag; Nachtarbeitnehmer ab 48 Nachttagen/Jahr.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/reports/night-work-summary</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Reports.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">DocViewer.tsx Z.473, Reports.tsx Info-Boxen</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§6 ArbZG; §18-exempt MA NICHT ausgeschlossen (s. Finding)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="1" data-impl="0" data-text="rpt-14 §11 arbzg ersatzruhetage nach so-arbeit 1 freier tag in 2 wochen, nach feiertag in 8 wochen; feiertage tenant-scoped einmal vorgeladen (l-7). get /api/admin/reports/compensatory-rest">
+          <div class="uc-head">
+            <code class="uc-id">RPT-14</code>
+            <span class="uc-title">§11 ArbZG Ersatzruhetage</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Berichte → Ersatzruhetage</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Nach So-Arbeit 1 freier Tag in 2 Wochen, nach Feiertag in 8 Wochen; Feiertage tenant-scoped einmal vorgeladen (L-7).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/reports/compensatory-rest</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Reports.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">DocViewer.tsx Z.473</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§11 ArbZG; PublicHoliday tenant_id korrekt; §18-exempt NICHT ausgeschlossen (s. Finding)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Berichte &amp; Datenaustausch" data-doc="0" data-impl="1" data-text="rpt-15 §3 arbzg 24-wochen-durchschnitt summiert netto-std im 24-wochen-fenster, vergleicht gegen 8h × tatsächliche soll-arbeitstage (m-arb2, weekday-plan+historie+feiertage+abwesenheiten). end_date default today_local (europe/berlin). §18-exempt übersprungen. get /api/admin/reports/24-week-average">
+          <div class="uc-head">
+            <code class="uc-id">RPT-15</code>
+            <span class="uc-title">§3 ArbZG 24-Wochen-Durchschnitt</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">API-Aufruf (kein UI)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Summiert Netto-Std im 24-Wochen-Fenster, vergleicht gegen 8h × tatsächliche Soll-Arbeitstage (M-ARB2, weekday-Plan+Historie+Feiertage+Abwesenheiten). end_date default today_local (Europe/Berlin). §18-exempt übersprungen.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/reports/24-week-average</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">—(kein Frontend-Consumer)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§3 ArbZG Ausgleichszeitraum; exempt korrekt übersprungen; Berlin-TZ-Stichtag</span></div>
+          </div>
+        </div>
+    </section><section class="area" data-area="Admin-Genehmigungen &amp; Kalender">
+      <h2>Admin-Genehmigungen &amp; Kalender <span class="count">19</span></h2>
+      <div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-01 korrekturantrag (änderungsantrag) genehmigen row mit with_for_update sperren (f-028) → status==pending prüfen → 4-augen-checks (eigene pflicht-pause-ausnahme nie selbst; eigener cr nur wenn weiterer aktiver admin existiert) → preconditions vor statuswechsel: duplikat-/existenz-check, §3-10h-hardcap + §4-pause auf geclampter zeit re-validieren (waiver excused §4, nie §3) → status=approved → timeentry/absence materialisieren (soll-window-clamp, audit-log) → commit → §6/§3-warnungen post-commit post /api/admin/change-requests/{id}/review (action=approve)">
+          <div class="uc-head">
+            <code class="uc-id">AC-01</code>
+            <span class="uc-title">Korrekturantrag (Änderungsantrag) genehmigen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt &#x27;Genehmigen&#x27; auf einem offenen Änderungsantrag</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Row mit with_for_update sperren (F-028) → Status==PENDING prüfen → 4-Augen-Checks (eigene Pflicht-Pause-Ausnahme nie selbst; eigener CR nur wenn weiterer aktiver Admin existiert) → Preconditions VOR Statuswechsel: Duplikat-/Existenz-Check, §3-10h-Hardcap + §4-Pause auf geclampter Zeit re-validieren (Waiver excused §4, nie §3) → Status=APPROVED → TimeEntry/Absence materialisieren (Soll-Window-Clamp, Audit-Log) → commit → §6/§3-Warnungen post-commit</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/change-requests/{id}/review (action=approve)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/admin/ChangeRequests.tsx (Genehmigen-Button, actionLock gegen Doppelklick)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/handbuch/HANDBUCH-ADMIN.md §Korrekturanträge genehmigen; DocViewer.tsx &#x27;4. Korrekturanträge genehmigen&#x27;</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§3/§4 ArbZG re-validate gegen aktuellen DB-Stand; #201 Soll-Window-Clamp; #144 break_waiver Audit-Source; Tagesprinzip (Voll-Tag-Absence = Tagessoll, nur OVERTIME behält Stunden); F-026 Tenant-Scope; F-028 Race-Lock; 4-Augen</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-02 korrekturantrag ablehnen row sperren → pending prüfen → status=rejected, reviewed_by/at + rejection_reason → commit post /api/admin/change-requests/{id}/review (action=reject)">
+          <div class="uc-head">
+            <code class="uc-id">AC-02</code>
+            <span class="uc-title">Korrekturantrag ablehnen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt &#x27;Ablehnen&#x27; (optionaler Grund)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Row sperren → PENDING prüfen → status=REJECTED, reviewed_by/at + rejection_reason → commit</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/change-requests/{id}/review (action=reject)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/ChangeRequests.tsx (Ablehnen + Textarea)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md; DocViewer.tsx</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Eigenen CR ablehnen erlaubt (kein 4-Augen nötig); F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="0" data-impl="1" data-text="ac-03 korrekturanträge in sammelbearbeitung genehmigen/ablehnen pro request_id review_change_request aufrufen; jeder erfolg committet einzeln; bei fehler rollback nur des betroffenen items + fehlertext, rest läuft weiter; aggregiertes ergebnis (succeeded/failed/items) post /api/admin/change-requests/bulk-review">
+          <div class="uc-head">
+            <code class="uc-id">AC-03</code>
+            <span class="uc-title">Korrekturanträge in Sammelbearbeitung genehmigen/ablehnen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin wählt mehrere offene Anträge + &#x27;genehmigen/ablehnen&#x27;</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Pro request_id review_change_request aufrufen; jeder Erfolg committet einzeln; bei Fehler rollback nur des betroffenen Items + Fehlertext, Rest läuft weiter; aggregiertes Ergebnis (succeeded/failed/items)</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/change-requests/bulk-review</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/ChangeRequests.tsx (Bulk-Action-Bar, Checkboxen, bulkProcessing-Guard)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (nur Einzel-Genehmigung dokumentiert)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Per-Item-Preconditions identisch zum Einzelpfad; partielle Persistenz korrekt</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-04 korrekturanträge auflisten/filtern + pending-badge tenant-scoped query mit status/user/datum-filter, order by created_at desc, enrich; pending-count separat get /api/admin/change-requests, /change-requests/pending-count, /change-requests/{id}">
+          <div class="uc-head">
+            <code class="uc-id">AC-04</code>
+            <span class="uc-title">Korrekturanträge auflisten/filtern + Pending-Badge</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Aufruf der Seite Änderungsanträge / Badge</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Tenant-scoped Query mit Status/User/Datum-Filter, order by created_at desc, enrich; pending-count separat</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/change-requests, /change-requests/pending-count, /change-requests/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/ChangeRequests.tsx (Status-/User-/Zeitraum-Filter)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md (Filter-Tabs)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026 explizit vor optionalen Filtern; limit&lt;=500; 404 cross-tenant</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-05 urlaubs-/abwesenheitsantrag genehmigen vr + user mit with_for_update sperren (bug-3) → pending → 4-augen (eigener vr nur wenn weiterer admin) → beschäftigungsfenster-check → arbeitstage (mo-fr, ohne feiertage) → bestehende fremd-absence blockt (409, jeder typ) → urlaubsbudget tagebasiert pro jahr → bestehende timeentries löschen (audit) → absence je arbeitstag mit tagessoll (nur overtime explizite stunden, halbtag 0,5×), half_day persistiert → reviewed_*/approved → commit post /api/admin/vacation-requests/{id}/review (approve)">
+          <div class="uc-head">
+            <code class="uc-id">AC-05</code>
+            <span class="uc-title">Urlaubs-/Abwesenheitsantrag genehmigen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt &#x27;Genehmigen&#x27; auf offenem Antrag</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">VR + User mit with_for_update sperren (BUG-3) → PENDING → 4-Augen (eigener VR nur wenn weiterer Admin) → Beschäftigungsfenster-Check → Arbeitstage (Mo-Fr, ohne Feiertage) → bestehende Fremd-Absence blockt (409, jeder Typ) → Urlaubsbudget tagebasiert pro Jahr → bestehende TimeEntries löschen (Audit) → Absence je Arbeitstag mit Tagessoll (nur OVERTIME explizite Stunden, Halbtag 0,5×), half_day persistiert → reviewed_*/APPROVED → commit</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/vacation-requests/{id}/review (approve)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/admin/VacationApprovals.tsx (Genehmigen, per-Antrag pendingIds-Lock)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §7; DocViewer.tsx &#x27;5. Urlaubsanträge &amp; Betriebsferien&#x27;</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§3 BUrlG Tagesprinzip (Tage statt Stunden, OVERTIME-Ausnahme in beiden Pfaden); #156/#167/#205 half_day; #193 Beschäftigungsfenster; F-026/F-028; Budget-Check VOR Statuswechsel</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-06 urlaubsantrag ablehnen vr sperren → pending → reviewed_*/rejected + rejection_reason → commit post /api/admin/vacation-requests/{id}/review (reject)">
+          <div class="uc-head">
+            <code class="uc-id">AC-06</code>
+            <span class="uc-title">Urlaubsantrag ablehnen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">&#x27;Ablehnen&#x27; (optionaler Grund)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">VR sperren → PENDING → reviewed_*/REJECTED + rejection_reason → commit</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/vacation-requests/{id}/review (reject)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/VacationApprovals.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §7 &#x27;Antrag ablehnen&#x27;</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Ablehnen ist keine Selbst-Genehmigung; F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="0" data-impl="1" data-text="ac-07 offenen urlaubsantrag im namen des ma bearbeiten vr sperren → nur pending editierbar → validierung gegen target_user (arbeitstag-fenster + budget) via gemeinsamem apply_vacation_request_patch patch /api/admin/vacation-requests/{id}">
+          <div class="uc-head">
+            <code class="uc-id">AC-07</code>
+            <span class="uc-title">Offenen Urlaubsantrag im Namen des MA bearbeiten</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt &#x27;Bearbeiten&#x27; auf offenem Antrag</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">VR sperren → nur PENDING editierbar → Validierung gegen target_user (Arbeitstag-Fenster + Budget) via gemeinsamem apply_vacation_request_patch</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PATCH /api/admin/vacation-requests/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/VacationApprovals.tsx + components/VacationRequestEditModal.tsx (mode=admin)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (Bearbeiten-Funktion im Handbuch nicht erwähnt)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Tenant-Scope 404 statt 403; Validierung gegen MA, nicht Admin; rate-limit 60/min</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="0" data-impl="1" data-text="ac-08 genehmigten zukünftigen urlaub stornieren / antrag löschen vr sperren → pending: row löschen; rejected: row löschen (keine seiteneffekte); approved &amp; start in zukunft: absencen löschen + withdrawn; approved &amp; bereits begonnen → 400 delete /api/admin/vacation-requests/{id}">
+          <div class="uc-head">
+            <code class="uc-id">AC-08</code>
+            <span class="uc-title">Genehmigten zukünftigen Urlaub stornieren / Antrag löschen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin klickt &#x27;Urlaub stornieren&#x27; (zukünftig) bzw. löscht offenen/abgelehnten Antrag</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">VR sperren → PENDING: Row löschen; REJECTED: Row löschen (keine Seiteneffekte); APPROVED &amp; Start in Zukunft: Absencen löschen + WITHDRAWN; APPROVED &amp; bereits begonnen → 400</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>DELETE /api/admin/vacation-requests/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/VacationApprovals.tsx (&#x27;Urlaub stornieren&#x27; nur wenn date&gt;today)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FALSCH dokumentiert: HANDBUCH-ADMIN.md §7 sagt &#x27;Genehmigung ist unwiderruflich, Abwesenheiten manuell löschen&#x27;</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Vergangenheits-Schutz (date&lt;=today_local blockt); Audit beim Absencen-Löschen; F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-09 genehmigungspflicht für abwesenheitsanträge umschalten get /admin/settings liest vacation_approval_required; toggle put setzt true/false get /api/admin/settings, put /api/admin/settings/vacation_approval_required">
+          <div class="uc-head">
+            <code class="uc-id">AC-09</code>
+            <span class="uc-title">Genehmigungspflicht für Abwesenheitsanträge umschalten</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Toggle auf der Anträge-Seite</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /admin/settings liest vacation_approval_required; Toggle PUT setzt true/false</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/settings, PUT /api/admin/settings/vacation_approval_required</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/VacationApprovals.tsx (Toggle-Switch oben)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §7 &#x27;Genehmigungspflicht konfigurieren&#x27;; DocViewer.tsx</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Aus = MA buchen direkt; Krankmeldungen immer ausgenommen</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-10 urlaubsanträge auflisten + pending-badge tenant-scoped query status/user-filter, enrich mit tagen; pending-count separat get /api/admin/vacation-requests, /vacation-requests/pending-count">
+          <div class="uc-head">
+            <code class="uc-id">AC-10</code>
+            <span class="uc-title">Urlaubsanträge auflisten + Pending-Badge</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Aufruf Anträge-Seite</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Tenant-scoped Query Status/User-Filter, enrich mit Tagen; pending-count separat</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/vacation-requests, /vacation-requests/pending-count</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/VacationApprovals.tsx (Filter-Tabs, Last-Write-Wins-Seq)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §7</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026; Anzeige in Tagen (vr.days), nicht Stunden</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="0" data-text="ac-11 betriebsferien anlegen (auto-buchung abwesenheiten) end&gt;=start prüfen → closure anlegen → arbeitstage (mo-fr ohne feiertage) → alle aktiven receives_company_closures-ma → _create_closure_absences: pro ma/tag beschäftigungsfenster-check (#298), use_daily_schedule-0h-tag überspringen, fremd-absence überspringen, timeentry löschen (audit), absence type vacation/paid_leave mit tagessoll → affected = distinct ma post /api/company-closures">
+          <div class="uc-head">
+            <code class="uc-id">AC-11</code>
+            <span class="uc-title">Betriebsferien anlegen (Auto-Buchung Abwesenheiten)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin legt Betriebsferien (Name, Von-Bis, Verrechnung) an</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">end&gt;=start prüfen → Closure anlegen → Arbeitstage (Mo-Fr ohne Feiertage) → alle aktiven receives_company_closures-MA → _create_closure_absences: pro MA/Tag Beschäftigungsfenster-Check (#298), use_daily_schedule-0h-Tag überspringen, Fremd-Absence überspringen, TimeEntry löschen (Audit), Absence type VACATION/PAID_LEAVE mit Tagessoll → affected = distinct MA</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/company-closures</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/admin/AdminAbsences.tsx (Tab Betriebsferien, submitting-Guard)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §11; DocViewer.tsx &#x27;Betriebsferien&#x27;</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#145 counts_as_vacation→VACATION/PAID_LEAVE; #189 receives_company_closures statt Rolle; #298 Beschäftigungsfenster; #191 untracked tagebasiert; F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="0" data-text="ac-12 betriebsferien bearbeiten (re-sync der abwesenheiten) attribute setzen → neue arbeitstage → linked absencen: nicht mehr abgedeckte löschen, rest note/end_date/typ syncen; bei aktivem #314-split alle in-range linked löschen + per helper (delete_time_entries=false) neu buchen → flush vor helper (l-3) → affected via count(distinct) put /api/company-closures/{id}">
+          <div class="uc-head">
+            <code class="uc-id">AC-12</code>
+            <span class="uc-title">Betriebsferien bearbeiten (Re-Sync der Abwesenheiten)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin ändert Name/Zeitraum/Verrechnung</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Attribute setzen → neue Arbeitstage → linked Absencen: nicht mehr abgedeckte löschen, Rest Note/end_date/Typ syncen; bei aktivem #314-Split alle in-range linked löschen + per Helper (delete_time_entries=False) neu buchen → flush vor Helper (L-3) → affected via COUNT(DISTINCT)</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/company-closures/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/AdminAbsences.tsx (Bearbeiten)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §11; AdminAbsences.tsx Hinweistext</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#145 Typ-Switch; closure_id-FK-Matching statt Note-String; #290 delete_time_entries=False schützt geloggte Arbeit; Unique-Constraint via flush</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-13 betriebsferien löschen tenant-scoped lookup → alle via closure_id verknüpften absencen löschen (synchronize_session=false + tenant) → closure löschen delete /api/company-closures/{id}">
+          <div class="uc-head">
+            <code class="uc-id">AC-13</code>
+            <span class="uc-title">Betriebsferien löschen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin löscht Betriebsferien</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Tenant-scoped Lookup → alle via closure_id verknüpften Absencen löschen (synchronize_session=False + tenant) → Closure löschen</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>DELETE /api/company-closures/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/AdminAbsences.tsx (Trash + Confirm)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §11 &#x27;Betriebsferien löschen&#x27;</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">FK-Matching robust gegen Rename; F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-14 betriebsferien auflisten (mit betroffenen ma) tenant-scoped liste; affected_employees pro closure als count(distinct user_id) der verknüpften absencen (eine group-by-query, kein n+1) get /api/company-closures">
+          <div class="uc-head">
+            <code class="uc-id">AC-14</code>
+            <span class="uc-title">Betriebsferien auflisten (mit betroffenen MA)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Aufruf Tab Betriebsferien</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Tenant-scoped Liste; affected_employees pro Closure als COUNT(DISTINCT user_id) der verknüpften Absencen (eine GROUP-BY-Query, kein N+1)</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/company-closures</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/AdminAbsences.tsx (Tabelle)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §11</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">list via get_current_user (alle auth lesbar); F-026</span></div>
+          </div>
+        </div><div class="uc" data-actor="System" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-15 überzählige betriebsferien als überstundenabbau (#314) pro ma chronologisch: solange resturlaub-budget&gt;=1 tag vacation buchen (snapshot pro jahr lazy), danach overtime (konto darf ins minus); untracked ma behalten vacation (kein überstundenkonto); übersprungene tage verbrauchen kein budget post/put /api/company-closures (verhalten in _create_closure_absences)">
+          <div class="uc-head">
+            <code class="uc-id">AC-15</code>
+            <span class="uc-title">Überzählige Betriebsferien als Überstundenabbau (#314)</span>
+            <span class="actor actor-system">System</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Setting closure_overtime_after_vacation aktiv + Betriebsferien als Urlaub angelegt/neu gespeichert</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Pro MA chronologisch: solange Resturlaub-Budget&gt;=1 Tag VACATION buchen (Snapshot pro Jahr lazy), danach OVERTIME (Konto darf ins Minus); untracked MA behalten VACATION (kein Überstundenkonto); übersprungene Tage verbrauchen kein Budget</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST/PUT /api/company-closures (Verhalten in _create_closure_absences)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/AdminAbsences.tsx + Settings.tsx (Toggle)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §11 (Tipp #314); DocViewer.tsx &#x27;5.&#x27;</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Tagesprinzip Budget in Tagen; NIE Minus-Urlaub; Snapshot ohne eigene Closure-Tage; emp_split nur track_hours</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-16 eigene feiertage anlegen/bearbeiten/löschen create: duplikat-check (tenant+datum) → is_custom=true, source=admin, year aus datum → cache invalidieren; update/delete nur custom (gesetzliche → 403), duplikat-check bei datumswechsel, cache (alt+neu jahr) invalidieren post/put/delete /api/holidays/{id}">
+          <div class="uc-head">
+            <code class="uc-id">AC-16</code>
+            <span class="uc-title">Eigene Feiertage anlegen/bearbeiten/löschen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin pflegt lokale/regionale Feiertage in Einstellungen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Create: Duplikat-Check (Tenant+Datum) → is_custom=True, source=admin, year aus Datum → Cache invalidieren; Update/Delete nur custom (gesetzliche → 403), Duplikat-Check bei Datumswechsel, Cache (alt+neu Jahr) invalidieren</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST/PUT/DELETE /api/holidays/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/admin/Settings.tsx (Feiertage-Bereich)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §13 &#x27;Feiertage / Eigene Feiertage&#x27;; DocViewer.tsx</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">REQ-2 nur custom editierbar; F-026; F-034 Cache-Invalidierung; PublicHoliday immer tenant-scoped</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-17 feiertage + bundesländer auflisten get_holidays(year, tenant) → gesetzliche (workalendar) + custom; /states liefert unterstützte bundesländer + aktuelles get /api/holidays, /api/holidays/states">
+          <div class="uc-head">
+            <code class="uc-id">AC-17</code>
+            <span class="uc-title">Feiertage + Bundesländer auflisten</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Kalender/Einstellungen-Aufruf</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">get_holidays(year, tenant) → gesetzliche (workalendar) + custom; /states liefert unterstützte Bundesländer + aktuelles</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/holidays, /api/holidays/states</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Settings.tsx, Kalender</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §13 (Bundesland)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Allen auth Usern lesbar; tenant-scoped</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-18 sondertage 24./31.12. konfigurieren pro tag modus working_day/half_day/free; bei free zusätzlich counts_as_vacation; gespeichert in system_settings (kein neues table); soll-faktor + urlaubsabzug non-invasiv in calculation_service get /api/admin/settings/special-days, put /api/admin/settings/{key}">
+          <div class="uc-head">
+            <code class="uc-id">AC-18</code>
+            <span class="uc-title">Sondertage 24./31.12. konfigurieren</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin stellt Modus/Verrechnung für 24.12. und 31.12. ein</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Pro Tag Modus working_day/half_day/free; bei free zusätzlich counts_as_vacation; gespeichert in system_settings (kein neues Table); Soll-Faktor + Urlaubsabzug non-invasiv in calculation_service</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/settings/special-days, PUT /api/admin/settings/{key}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/Settings.tsx (&#x27;Sondertage (24./31.12.)&#x27;)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §13 &#x27;Sondertage 24./31.12.&#x27;; DocViewer.tsx &#x27;6. Sondertage&#x27;</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#146/#188; free+counts_as_vacation = 1 Urlaubstag (dedup gegen reale VACATION-Absence); /api/settings (public) liefert special_days für MA-Kalender</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Genehmigungen &amp; Kalender" data-doc="1" data-impl="1" data-text="ac-19 mitarbeiter-abwesenheit direkt eintragen/löschen (admin) mitarbeiter wählen → typ/datum/zeitraum/halbtag/eigener grund → post /absences (backend setzt typ aus reason_id, bucht tagessoll, tagesprinzip); liste je ma/monat; löschen via confirm post /api/absences, delete /api/absences/{id}, get /api/absences">
+          <div class="uc-head">
+            <code class="uc-id">AC-19</code>
+            <span class="uc-title">Mitarbeiter-Abwesenheit direkt eintragen/löschen (Admin)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Admin trägt Abwesenheit für MA ein oder löscht sie</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Mitarbeiter wählen → Typ/Datum/Zeitraum/Halbtag/eigener Grund → POST /absences (Backend setzt Typ aus reason_id, bucht Tagessoll, Tagesprinzip); Liste je MA/Monat; Löschen via Confirm</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/absences, DELETE /api/absences/{id}, GET /api/absences</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">admin/AdminAbsences.tsx (Tab Mitarbeiter-Abwesenheiten)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md (Abwesenheiten verwalten); DocViewer.tsx</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#312 reason_id Etikett, type treibt Calc; #167 half_day nicht bei sick/overtime; Tagessoll-Buchung in beiden Pfaden</span></div>
+          </div>
+        </div>
+    </section><section class="area" data-area="Admin-Schichtplanung">
+      <h2>Admin-Schichtplanung <span class="count">17</span></h2>
+      <div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-01 standorte verwalten (crud) admin legt standorte als optionale gruppierung fuer arbeitsplaetze an. loeschen nur, wenn kein arbeitsplatz daran haengt (sonst 409). namens-eindeutigkeit pro tenant. get/post /api/shift-planning/locations, put/delete /api/shift-planning/locations/{id}">
+          <div class="uc-head">
+            <code class="uc-id">SP-01</code>
+            <span class="uc-title">Standorte verwalten (CRUD)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Reiter Stammdaten -&gt; Standort anlegen/umbenennen/loeschen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Admin legt Standorte als optionale Gruppierung fuer Arbeitsplaetze an. Loeschen nur, wenn kein Arbeitsplatz daran haengt (sonst 409). Namens-Eindeutigkeit pro Tenant.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET/POST /api/shift-planning/locations, PUT/DELETE /api/shift-planning/locations/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/admin/ShiftPlanning.tsx (Tab Stammdaten), components/shiftplanning/LocationManager.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md (Stammdaten), HANDBUCH-ADMIN.md, DocViewer.tsx §12</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026 tenant-scoped + RLS; 409 bei In-Use/Namens-Kollision; _commit_or_conflict gegen Race</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-02 arbeitsplaetze verwalten (crud, farbe, standort) admin legt arbeitsplaetze (optional standort + hex-farbe #rrggbb) an. loeschen nur, wenn in keinem slot verwendet (409). farbe edge-validiert (string(7)). get/post /api/shift-planning/workstations, put/delete /api/shift-planning/workstations/{id}">
+          <div class="uc-head">
+            <code class="uc-id">SP-02</code>
+            <span class="uc-title">Arbeitsplaetze verwalten (CRUD, Farbe, Standort)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Reiter Stammdaten -&gt; Arbeitsplatz anlegen/bearbeiten/loeschen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Admin legt Arbeitsplaetze (optional Standort + Hex-Farbe #RRGGBB) an. Loeschen nur, wenn in keinem Slot verwendet (409). Farbe edge-validiert (String(7)).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET/POST /api/shift-planning/workstations, PUT/DELETE /api/shift-planning/workstations/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">components/shiftplanning/WorkstationManager.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md, HANDBUCH-ADMIN.md §Schichtplanung</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Hex-Farb-Validierung (Postgres String(7), SQLite-Test ignoriert Laenge); F-026; In-Use-Guard via ShiftSlot</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-03 schichtplaene anlegen/bearbeiten/loeschen benannte wochenpläne; loeschen cascadet slots+zuweisungen (orm + db). namens-eindeutigkeit. is_valid = keine unterbesetzten slots. get /plans, get /plans/{id}, post /plans, put /plans/{id}, delete /plans/{id}">
+          <div class="uc-head">
+            <code class="uc-id">SP-03</code>
+            <span class="uc-title">Schichtplaene anlegen/bearbeiten/loeschen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Reiter Schichtplaene -&gt; neuer Plan / Bearbeiten / Loeschen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Benannte Wochenpläne; Loeschen cascadet Slots+Zuweisungen (ORM + DB). Namens-Eindeutigkeit. is_valid = keine unterbesetzten Slots.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /plans, GET /plans/{id}, POST /plans, PUT /plans/{id}, DELETE /plans/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">ShiftPlanning.tsx (Plan-Liste + Editor)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md, HANDBUCH-ADMIN.md, DocViewer.tsx §12</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026; Cascade ohne passive_deletes (SQLite-FK-aus); 409 Namens-Kollision</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="0" data-impl="1" data-text="sp-04 schichtplan duplizieren (#338) kopiert plan inkl. slots + zuweisungen als inaktiven entwurf ohne aktiv-datumsfenster. arbeitsplaetze/einweisungen werden nicht kopiert (nicht plan-gebunden). post /api/shift-planning/plans/{id}/duplicate">
+          <div class="uc-head">
+            <code class="uc-id">SP-04</code>
+            <span class="uc-title">Schichtplan duplizieren (#338)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Button Duplizieren im Plan-Editor</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Kopiert Plan inkl. Slots + Zuweisungen als INAKTIVEN Entwurf OHNE Aktiv-Datumsfenster. Arbeitsplaetze/Einweisungen werden nicht kopiert (nicht plan-gebunden).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/shift-planning/plans/{id}/duplicate</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">ShiftPlanning.tsx Duplizier-Dialog (Name der Kopie)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (weder HANDBUCH-ADMIN.md, CHEATSHEET-ADMIN.md, DocViewer §12 noch docs/SCHICHTPLANUNG.md)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Kopie is_active=False, kein Datumsfenster (verhindert versehentliches Parallel-Aktiv); F-026; flush vor Slot/Assignment-Kopie</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-05 plan aktiv/inaktiv schalten setzt is_active. mehrere plaene koennen gleichzeitig aktiv sein. aktivierung ohne validierung (unterbesetzt bleibt erlaubt = weiche warnung). post /plans/{id}/activate, post /plans/{id}/deactivate">
+          <div class="uc-head">
+            <code class="uc-id">SP-05</code>
+            <span class="uc-title">Plan aktiv/inaktiv schalten</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Button Aktiv schalten / Deaktivieren</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Setzt is_active. Mehrere Plaene koennen gleichzeitig aktiv sein. Aktivierung ohne Validierung (unterbesetzt bleibt erlaubt = weiche Warnung).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /plans/{id}/activate, POST /plans/{id}/deactivate</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">ShiftPlanning.tsx toggleActive</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md §Aktivschaltung, HANDBUCH-ADMIN.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Mehrfach-Aktiv bewusst; keine ArbZG-Validierung (entkoppelt)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-06 kw-/jahresplanung: aktiv-datumsfenster (#305 m2) plan gilt zusaetzlich als aktiv, wenn heute im [from,until]-fenster liegt (offene grenze erlaubt). active_today via is_plan_active_on/plan_active_filter. put /plans/{id} (active_from_date/until), get /plans (active_today)">
+          <div class="uc-head">
+            <code class="uc-id">SP-06</code>
+            <span class="uc-title">KW-/Jahresplanung: Aktiv-Datumsfenster (#305 M2)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Bearbeiten -&gt; aktiv von/bis setzen; Jahres-Zeitstrahl</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Plan gilt zusaetzlich als aktiv, wenn heute im [from,until]-Fenster liegt (offene Grenze erlaubt). active_today via is_plan_active_on/plan_active_filter.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /plans/{id} (active_from_date/until), GET /plans (active_today)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">components/shiftplanning/PlanSettingsDialog.tsx, YearTimeline.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md §KW-/Ganzjahres-Planung, HANDBUCH-ADMIN.md, DocViewer §12</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">_validate_window (from&lt;=until, sonst 400); Python is_plan_active_on == SQL plan_active_filter (Konsistenz)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-07 slots anlegen/bearbeiten/loeschen + drag-verschieben slot = arbeitsplatz x wochentag x zeitfenster x mindestbesetzung. drag verschiebt wochentag/uhrzeit (15-min-raster, im grid geclamped). end&gt;start erzwungen. post /plans/{id}/slots, put /slots/{id}, delete /slots/{id}">
+          <div class="uc-head">
+            <code class="uc-id">SP-07</code>
+            <span class="uc-title">Slots anlegen/bearbeiten/loeschen + Drag-Verschieben</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">+ Slot / Klick auf Rasterflaeche / Drag-Block im Wochenraster</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Slot = Arbeitsplatz x Wochentag x Zeitfenster x Mindestbesetzung. Drag verschiebt Wochentag/Uhrzeit (15-Min-Raster, im Grid geclamped). end&gt;start erzwungen.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /plans/{id}/slots, PUT /slots/{id}, DELETE /slots/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">components/shiftplanning/WeekGrid.tsx, SlotDialog.tsx, weekGridUtils.ts; @dnd-kit</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md §Wochen-Editor, HANDBUCH-ADMIN.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">weekday 0-6 validiert; end&lt;=start -&gt; 400; workstation tenant-validiert; min_staff&gt;=0; Slot-Delete cascadet Assignments</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-08 slot auf wochentage kopieren (#322) erzeugt denselben slot (arbeitsplatz/zeit/mindestbesetzung + zuweisungen) auf gewaehlten weiteren wochentagen. rein client-seitig: schleife createslot + setassignments pro tag. (nutzt post /plans/{id}/slots + put /slots/{id}/assignments je tag)">
+          <div class="uc-head">
+            <code class="uc-id">SP-08</code>
+            <span class="uc-title">Slot auf Wochentage kopieren (#322)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Slot bearbeiten -&gt; Auf Wochentage kopieren</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Erzeugt denselben Slot (Arbeitsplatz/Zeit/Mindestbesetzung + Zuweisungen) auf gewaehlten weiteren Wochentagen. Rein client-seitig: Schleife createSlot + setAssignments pro Tag.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>(nutzt POST /plans/{id}/slots + PUT /slots/{id}/assignments je Tag)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">SlotDialog.tsx (copyDays, Quell-Wochentag ausgeschlossen Z.237), ShiftPlanning.tsx copySlot</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md §Schicht kopieren, CHEATSHEET-ADMIN.md, DocViewer §12</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Quell-Wochentag aus Zielliste ausgeschlossen (kein Self-Duplikat); kein dedizierter Backend-Endpoint; Teilfehler bei Schleifenabbruch moeglich (nicht-transaktional)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-09 mitarbeiter einem slot zuweisen (set-semantik) ersetzt die zuweisungen eines slots idempotent (delete+insert). ma tenant-validiert, dedup. qualified-flag relativ zum arbeitsplatz. put /slots/{id}/assignments">
+          <div class="uc-head">
+            <code class="uc-id">SP-09</code>
+            <span class="uc-title">Mitarbeiter einem Slot zuweisen (Set-Semantik)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA aus Liste auf Slot ziehen / im SlotDialog auswaehlen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Ersetzt die Zuweisungen eines Slots idempotent (delete+insert). MA tenant-validiert, dedup. qualified-Flag relativ zum Arbeitsplatz.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /slots/{id}/assignments</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">ShiftPlanning.tsx onDragEnd/submitSlot, SlotDialog.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md §Zuweisung</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026 (User.tenant_id==tid); dedup; _commit_or_conflict gegen uq_tenant_slot_user-Race -&gt; 409 statt 500</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-10 auto-generierung zuweisungen (#305 m2) greedy-fuellung der slots; harte constraints: eingewiesen + nicht ganztaegig abwesend + im beschaeftigungsfenster + keine doppelbelegung ueberlappender slots. weiche reihenfolge nach minuten/auslastung/ueberstunden/user_id. schreibt nur assignments, aktiviert plan nicht. post /plans/{id}/generate">
+          <div class="uc-head">
+            <code class="uc-id">SP-10</code>
+            <span class="uc-title">Auto-Generierung Zuweisungen (#305 M2)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Automatisch fuellen -&gt; Zielwoche + Modus (replace/fill_gaps)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Greedy-Fuellung der Slots; harte Constraints: eingewiesen + nicht ganztaegig abwesend + im Beschaeftigungsfenster + keine Doppelbelegung ueberlappender Slots. Weiche Reihenfolge nach Minuten/Auslastung/Ueberstunden/user_id. Schreibt nur Assignments, aktiviert Plan NICHT.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /plans/{id}/generate</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">components/shiftplanning/GenerateDialog.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md §Auto-Generierung, HANDBUCH-ADMIN.md, DocViewer §12</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">ENTKOPPELT: liest nur Absence(ganztaegig, half_day nicht), weekly_hours, get_overtime_account, _within_employment_window; target_monday auf Montag normalisiert; Halbtags-Absence blockiert nicht; Ueberstunden-Lesefehler -&gt; Decimal(0) (kein Generation-Fail)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-11 einweisungs-/skill-matrix verwalten (m2d) matrix aktiver ma x arbeitsplaetze; put ersetzt die einweisungen eines ma idempotent. treibt weiche nicht-eingewiesen-warnung; blockiert nie. get /qualifications, put /qualifications/{user_id}">
+          <div class="uc-head">
+            <code class="uc-id">SP-11</code>
+            <span class="uc-title">Einweisungs-/Skill-Matrix verwalten (M2d)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Reiter Einweisungen -&gt; Haekchen MA x Arbeitsplatz</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Matrix aktiver MA x Arbeitsplaetze; PUT ersetzt die Einweisungen eines MA idempotent. Treibt weiche nicht-eingewiesen-Warnung; blockiert nie.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /qualifications, PUT /qualifications/{user_id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">components/shiftplanning/QualificationMatrix.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md §Einweisungen, HANDBUCH-ADMIN.md, DocViewer §12</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026; base_behavior nur aktive/nicht-versteckte MA; qualified-Flag/unqualified_slot_ids ADMIN-ONLY in _build_plan_detail (HR-sensibel)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-12 eigene einweisungen ansehen ma sieht eigene arbeitsplatz-qualifikationen (read-only). get /me/qualifications">
+          <div class="uc-head">
+            <code class="uc-id">SP-12</code>
+            <span class="uc-title">Eigene Einweisungen ansehen</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Profil -&gt; Meine Einweisungen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">MA sieht eigene Arbeitsplatz-Qualifikationen (read-only).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /me/qualifications</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">components/shiftplanning/MyQualificationsCard.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md, HANDBUCH-MITARBEITER (DocViewer §11)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Nur eigene (user_id==current_user.id), tenant-scoped</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-13 tages-/wochenansicht-umschalter (#321) tag-modus zeigt nur einen wochentag (dropdown) in voller breite. reine ui-filterung des weekgrid (singleday). (keine; client-seitig)">
+          <div class="uc-head">
+            <code class="uc-id">SP-13</code>
+            <span class="uc-title">Tages-/Wochenansicht-Umschalter (#321)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Woche/Tag-Umschalter im Editor</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Tag-Modus zeigt nur einen Wochentag (Dropdown) in voller Breite. Reine UI-Filterung des WeekGrid (singleDay).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>(keine; client-seitig)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">ShiftPlanning.tsx shiftView/dayWeekday, WeekGrid singleDay</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md §Tagesansicht, CHEATSHEET-ADMIN.md, DocViewer §12</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">rein clientseitig, keine Datenwirkung</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-14 auslastungsanzeige je ma (#330) zeigt zugewiesene schichtstunden dieses plans / wochenarbeitszeit (z.b. 15,25 / 17 h) mit ampelfarbe (gruen +/-30min, gelb +/-1h, sonst rot; neutral ohne wochenstunden). (keine; aus plandetail berechnet)">
+          <div class="uc-head">
+            <code class="uc-id">SP-14</code>
+            <span class="uc-title">Auslastungsanzeige je MA (#330)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Mitarbeiterliste im Plan-Editor</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Zeigt zugewiesene Schichtstunden dieses Plans / Wochenarbeitszeit (z.B. 15,25 / 17 h) mit Ampelfarbe (gruen +/-30min, gelb +/-1h, sonst rot; neutral ohne Wochenstunden).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>(keine; aus planDetail berechnet)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">components/shiftplanning/employeeLoad.ts, ShiftPlanning.tsx DraggableEmployee</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md §Auslastungsanzeige, CHEATSHEET-ADMIN.md, DocViewer §12</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">ENTKOPPELT: rein planbasierte Summe (kein Soll/Ist); overnight (dur&lt;=0) -&gt; 0; nur aktueller Plan</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-15 feature aktivieren/deaktivieren (flag) tenant-setting shift_planning_enabled (default aus). aus = router liefert 404 (feature existiert nicht). menue + dashboard-widget per systemstore. put /admin/settings (shift_planning_enabled), get /api/system/info">
+          <div class="uc-head">
+            <code class="uc-id">SP-15</code>
+            <span class="uc-title">Feature aktivieren/deaktivieren (Flag)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Einstellungen -&gt; Schichtplanung -&gt; Schalter</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Tenant-Setting shift_planning_enabled (Default aus). Aus = Router liefert 404 (Feature existiert nicht). Menue + Dashboard-Widget per systemStore.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /admin/settings (shift_planning_enabled), GET /api/system/info</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/admin/Settings.tsx, systemStore.ts isShiftPlanningEnabled</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md §Aktivieren, HANDBUCH-ADMIN.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">3 Sync-Stellen: admin_settings(_ALLOWED/_BOOL), main.py system_info (Default-Tenant, nie 500), systemStore; Router-Gate per-Tenant korrekt</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Admin-Schichtplanung" data-doc="1" data-impl="0" data-text="sp-16 schichtplan ansehen (read-only) ma sieht aktive wochenplaene als uebersicht. frontend filtert client-seitig auf active_today; api liefert jedoch alle plaene. get /plans, get /plans/{id} (get_current_user)">
+          <div class="uc-head">
+            <code class="uc-id">SP-16</code>
+            <span class="uc-title">Schichtplan ansehen (read-only)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Menue Schichtplan</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">MA sieht aktive Wochenplaene als Uebersicht. Frontend filtert client-seitig auf active_today; API liefert jedoch ALLE Plaene.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /plans, GET /plans/{id} (get_current_user)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/pages/ShiftPlanning.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md §Bedienung (Mitarbeitende), DocViewer §11</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Read-Endpoints fuer alle Auth-User (Router-Docstring); KEINE serverseitige Beschraenkung auf aktive Plaene fuer Nicht-Admins</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Admin-Schichtplanung" data-doc="1" data-impl="1" data-text="sp-17 dashboard deine einteilung heute union der eigenen zuweisungen ueber alle heute aktiven plaene fuer den heutigen wochentag (europe/berlin). get /my-today">
+          <div class="uc-head">
+            <code class="uc-id">SP-17</code>
+            <span class="uc-title">Dashboard Deine Einteilung heute</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Dashboard-Karte</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Union der eigenen Zuweisungen ueber alle heute aktiven Plaene fuer den heutigen Wochentag (Europe/Berlin).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /my-today</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">components/ShiftTodayCard.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/SCHICHTPLANUNG.md, DocViewer §11</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">today_local (Europe/Berlin); plan_active_filter; nur eigene user_id; tenant-scoped</span></div>
+          </div>
+        </div>
+    </section><section class="area" data-area="Admin-Betrieb">
+      <h2>Admin-Betrieb <span class="count">24</span></h2>
+      <div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-01 systemeinstellungen auflisten get /admin/settings liefert alle systemsetting-rows tenant-scoped; frontend mappt einzelne keys auf toggles/felder get /api/admin/settings">
+          <div class="uc-head">
+            <code class="uc-id">ADM-01</code>
+            <span class="uc-title">Systemeinstellungen auflisten</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Öffnen der Seite Einstellungen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /admin/settings liefert alle SystemSetting-Rows tenant-scoped; Frontend mappt einzelne Keys auf Toggles/Felder</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/settings</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Settings.tsx (loadSettings)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §13 Einstellungen; DocViewer Admin-Abschnitt</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026: Filter SystemSetting.tenant_id == current_user.tenant_id vorhanden</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-02 generische einstellung ändern (put key) put /admin/settings/{key}: whitelist-check (_allowed_settings), typ-spezifische validierung (bool/int/mode), upsert tenant-scoped, commit put /api/admin/settings/{key}">
+          <div class="uc-head">
+            <code class="uc-id">ADM-02</code>
+            <span class="uc-title">Generische Einstellung ändern (PUT key)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Speichern eines Settings-Blocks</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">PUT /admin/settings/{key}: Whitelist-Check (_ALLOWED_SETTINGS), typ-spezifische Validierung (bool/int/mode), upsert tenant-scoped, commit</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/admin/settings/{key}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Settings.tsx (diverse save*-Funktionen)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §13</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Bool-Normalisierung true/false; unbekannter Key → 400; work_window_grace_minutes int&gt;=0</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-03 bundesland setzen + feiertage neu generieren put holiday_state: validiert gegen supported_states, löscht workalendar-feiertage (custom bleiben), sync_current_and_next_year in einer transaktion put /api/admin/settings/holiday_state">
+          <div class="uc-head">
+            <code class="uc-id">ADM-03</code>
+            <span class="uc-title">Bundesland setzen + Feiertage neu generieren</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Speichern Bundesland</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">PUT holiday_state: validiert gegen SUPPORTED_STATES, löscht workalendar-Feiertage (Custom bleiben), sync_current_and_next_year in einer Transaktion</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/admin/settings/holiday_state</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Settings.tsx saveHolidayState; Feiertage-Block</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §13 (Feiertage)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Tenant-scoped Holiday-Sync; #143 admin-Custom-Feiertage überleben Resync; atomar mit Rollback</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-04 sondertage 24./31.12. konfigurieren vier puts (mode + counts_as_vacation je tag); backend validiert modus gegen valid_modes und bool put /api/admin/settings/special_day_dec24_mode|_counts_as_vacation|dec31_*">
+          <div class="uc-head">
+            <code class="uc-id">ADM-04</code>
+            <span class="uc-title">Sondertage 24./31.12. konfigurieren</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Speichern Sondertage</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Vier PUTs (mode + counts_as_vacation je Tag); Backend validiert Modus gegen VALID_MODES und bool</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/admin/settings/special_day_dec24_mode|_counts_as_vacation|dec31_*</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Settings.tsx saveSpecialDays; GET /admin/settings/special-days</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §13 Sondertage 24./31.12.</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">4 PUTs nicht atomar → Frontend re-synct bei Fehler; wirkt auf Soll/Urlaub/Kalender</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-05 typ-farben konfigurieren get/put type-colors via type_colors_service; route vor generischer {key}-route registriert; sofort app-weit übernommen get/put /api/admin/settings/type-colors">
+          <div class="uc-head">
+            <code class="uc-id">ADM-05</code>
+            <span class="uc-title">Typ-Farben konfigurieren</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Farben speichern</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET/PUT type-colors via type_colors_service; Route VOR generischer {key}-Route registriert; sofort app-weit übernommen</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET/PUT /api/admin/settings/type-colors</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Settings.tsx saveTypeColors, typeColorsStore</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §13 Farben</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">ValueError → 400; tenant-scoped Defaults-Merge</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-06 feature-flag schichtplanung (#305) put shift_planning_enabled (bool); frontend ruft systemstore.fetch() für sofortige nav-aktualisierung put /api/admin/settings/shift_planning_enabled">
+          <div class="uc-head">
+            <code class="uc-id">ADM-06</code>
+            <span class="uc-title">Feature-Flag Schichtplanung (#305)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Toggle Schichtplanung aktivieren</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">PUT shift_planning_enabled (bool); Frontend ruft systemStore.fetch() für sofortige Nav-Aktualisierung</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/admin/settings/shift_planning_enabled</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Settings.tsx saveShiftPlanning</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md Schichtplanung-Abschnitt; CHEATSHEET; docs/SCHICHTPLANUNG.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">3-Stellen-Sync verifiziert: admin_settings _ALLOWED+_BOOL, main.py system_info (Default false, nie 500), systemStore isShiftPlanningEnabled (===true)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-07 feature-flag onboarding-tour put onboarding_enabled (bool); systemstore.fetch() danach put /api/admin/settings/onboarding_enabled">
+          <div class="uc-head">
+            <code class="uc-id">ADM-07</code>
+            <span class="uc-title">Feature-Flag Onboarding-Tour</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Toggle Willkommens-Tour</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">PUT onboarding_enabled (bool); systemStore.fetch() danach</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/admin/settings/onboarding_enabled</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Settings.tsx saveOnboarding</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §13 Onboarding</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Default an (nur explizit &#x27;false&#x27; deaktiviert); 3-Stellen-Sync verifiziert</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-08 closure-overtime-flag (#314) put closure_overtime_after_vacation (bool); reines backend-verhalten, kein system_info put /api/admin/settings/closure_overtime_after_vacation">
+          <div class="uc-head">
+            <code class="uc-id">ADM-08</code>
+            <span class="uc-title">Closure-Overtime-Flag (#314)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Toggle Überzählige Betriebsferien als Überstundenabbau</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">PUT closure_overtime_after_vacation (bool); reines Backend-Verhalten, KEIN system_info</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/admin/settings/closure_overtime_after_vacation</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Settings.tsx saveClosureOvertime</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §11/§13; DocViewer Betriebsferien</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Korrekt NICHT in system_info (CLAUDE.md); UI weist auf erneutes Speichern bestehender Closures hin</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-09 admin legt zeiteintrag für ma an work_window clamp → §4 pause (mit waiver) → §3 10h hard-cap (422) → warnungen 8h/48h/nacht → timeentry + audit create post /api/admin/users/{user_id}/time-entries">
+          <div class="uc-head">
+            <code class="uc-id">ADM-09</code>
+            <span class="uc-title">Admin legt Zeiteintrag für MA an</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Zeiteintrag anlegen im Admin-Dashboard</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">work_window clamp → §4 Pause (mit Waiver) → §3 10h Hard-Cap (422) → Warnungen 8h/48h/Nacht → TimeEntry + Audit create</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/users/{user_id}/time-entries</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AdminDashboard.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md (Zeiteinträge/ArbZG-Abschnitte)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#201 clamp auf affected_user; exempt_from_arbzg überspringt Checks aber wird geclampt; F-026; raw_start/end persistiert; Audit source manual/break_waiver</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-10 admin ändert zeiteintrag with_for_update lock → clamp → arbzg-checks → audit update (old+new) vor apply → nur gesetzte felder schreiben put /api/admin/time-entries/{entry_id}">
+          <div class="uc-head">
+            <code class="uc-id">ADM-10</code>
+            <span class="uc-title">Admin ändert Zeiteintrag</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Zeiteintrag bearbeiten</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">with_for_update lock → clamp → ArbZG-Checks → Audit update (old+new) VOR Apply → nur gesetzte Felder schreiben</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/admin/time-entries/{entry_id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AdminDashboard.tsx handleAdminEditEntry</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §9 (Audit) / ArbZG</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-028 Lock gegen Race; F-026 Tenant-Filter; clamp via affected_user; raw_* reset wenn ungekappt</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-11 admin löscht zeiteintrag with_for_update lock → audit delete (old) → db.delete → 204 delete /api/admin/time-entries/{entry_id}">
+          <div class="uc-head">
+            <code class="uc-id">ADM-11</code>
+            <span class="uc-title">Admin löscht Zeiteintrag</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Zeiteintrag löschen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">with_for_update lock → Audit delete (old) → db.delete → 204</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>DELETE /api/admin/time-entries/{entry_id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AdminDashboard.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §9</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026 Tenant-Scope (fremde UUID → 404); F-028 Lock; Audit vor Delete</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="0" data-text="adm-12 compliance-änderungsprotokoll ansehen get /admin/audit-log mit month + optional user_id; volle sicht (changes_only=false) inkl. zugriffs-/systemereignisse get /api/admin/audit-log">
+          <div class="uc-head">
+            <code class="uc-id">ADM-12</code>
+            <span class="uc-title">Compliance-Änderungsprotokoll ansehen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Seite Änderungsprotokoll öffnen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /admin/audit-log mit month + optional user_id; volle Sicht (changes_only=false) inkl. Zugriffs-/Systemereignisse</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/audit-log</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AuditLog.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §9; CHEATSHEET; DocViewer §9; helpContent /admin/audit-log</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026 Tenant-Scope; §16 ArbZG unveränderliche Aufzeichnung; ABER kein Pagination-UI (limit 100) → siehe Finding</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-13 per-mitarbeiter-änderungsprotokoll (#284) get /admin/audit-log?user_id=&amp;month=&amp;changes_only=true → nur create/update/delete, keine phantom-gelöscht durch zugriffsmarker get /api/admin/audit-log?changes_only=true">
+          <div class="uc-head">
+            <code class="uc-id">ADM-13</code>
+            <span class="uc-title">Per-Mitarbeiter-Änderungsprotokoll (#284)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">MA im Admin-Dashboard öffnen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /admin/audit-log?user_id=&amp;month=&amp;changes_only=true → nur create/update/delete, keine Phantom-Gelöscht durch Zugriffsmarker</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/audit-log?changes_only=true</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">AdminDashboard.tsx fetchAuditForUser</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §9 (Audit)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#284 _CHANGE_ACTIONS-Filter im Backend korrekt; AuditLog.tsx (compliance) bewusst ohne Filter</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="0" data-impl="1" data-text="adm-14 audit-integritätsprüfung (#121) get verify-integrity berechnet hmac pro row neu, vergleicht row_hash; liefert checked/ok/tampered/legacy_unhashed/intact get /api/admin/audit/verify-integrity">
+          <div class="uc-head">
+            <code class="uc-id">ADM-14</code>
+            <span class="uc-title">Audit-Integritätsprüfung (#121)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Manuell (nur API)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET verify-integrity berechnet HMAC pro Row neu, vergleicht row_hash; liefert checked/ok/tampered/legacy_unhashed/intact</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/audit/verify-integrity</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">FEHLT (keine UI)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026 Tenant-Scope + yield_per; legacy ohne Hash nicht als Manipulation gewertet — Logik korrekt, aber unauffindbar/undokumentiert</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-15 fehler-monitoring: liste &amp; summary get /admin/errors (+status-filter) + /summary; onprem tid=none (single-tenant), saas tenant-scoped get /api/admin/errors/, get /api/admin/errors/summary">
+          <div class="uc-head">
+            <code class="uc-id">ADM-15</code>
+            <span class="uc-title">Fehler-Monitoring: Liste &amp; Summary</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Seite Fehler-Monitoring öffnen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /admin/errors (+status-Filter) + /summary; onprem tid=None (single-tenant), saas tenant-scoped</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/errors/, GET /api/admin/errors/summary</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">ErrorMonitoring.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §10; CHEATSHEET; DocViewer §9</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO PII-Scrubbing (UUID/Email) bei Speicherung; Traceback-Cap 2000; #127 SaaS-Scope</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-16 fehler-status ändern / löschen / github-url patch status (open/ignored/resolved), delete, patch github-url (regex-validiert); ui sanitisiert link gegen xss patch /api/admin/errors/{id}/status; delete /{id}; patch /{id}/github-url">
+          <div class="uc-head">
+            <code class="uc-id">ADM-16</code>
+            <span class="uc-title">Fehler-Status ändern / löschen / GitHub-URL</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Aktion an Fehler-Zeile</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">PATCH status (open/ignored/resolved), DELETE, PATCH github-url (regex-validiert); UI sanitisiert Link gegen XSS</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PATCH /api/admin/errors/{id}/status; DELETE /{id}; PATCH /{id}/github-url</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">ErrorMonitoring.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §10</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-049 sanitizeGithubUrl (nur https github.com); Backend-Pattern-Validierung; DSGVO Art.28-Warnung bei GitHub-Übertragung</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-17 backup-übersicht (liste + config) get /admin/backups liefert backupconfig + sortierte dateiliste (praxiszeit_*.sql.gz) get /api/admin/backups">
+          <div class="uc-head">
+            <code class="uc-id">ADM-17</code>
+            <span class="uc-title">Backup-Übersicht (Liste + Config)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Seite Datensicherung öffnen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /admin/backups liefert BackupConfig + sortierte Dateiliste (praxiszeit_*.sql.gz)</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/backups</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Backups.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §19; DocViewer §11; docs/BACKUP.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">#213; Config global unter Default-Tenant; FILENAME_RE gefiltert</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-18 backup sofort erstellen post /admin/backups: pg_dump --clean --if-exists | gzip via superuser-url, atomar 0o600, danach prune post /api/admin/backups">
+          <div class="uc-head">
+            <code class="uc-id">ADM-18</code>
+            <span class="uc-title">Backup sofort erstellen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Jetzt sichern</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /admin/backups: pg_dump --clean --if-exists | gzip via Superuser-URL, atomar 0o600, danach prune</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/backups</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Backups.tsx handleCreate</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §19; docs/BACKUP.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Plain-SQL kein -Fc (1.8.12-Bug); PGPASSWORD nicht in argv; truncated/leer → BackupError; DSGVO Art.32 Owner-only</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-19 backup-konfiguration speichern put /config: enabled/hour(0-23)/retention(1-3650)/location mit schreibprobe (kein mkdir -p) put /api/admin/backups/config">
+          <div class="uc-head">
+            <code class="uc-id">ADM-19</code>
+            <span class="uc-title">Backup-Konfiguration speichern</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Einstellungen speichern (Zeitplan/Retention/Pfad)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">PUT /config: enabled/hour(0-23)/retention(1-3650)/location mit Schreibprobe (kein mkdir -p)</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>PUT /api/admin/backups/config</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Backups.tsx handleSaveConfig</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §19</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Pfad-Schreibprobe lehnt nicht beschreibbare/fehlende Parent-Verzeichnisse ab (Privilege-Surface-Schutz nativ)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-20 backup herunterladen get /{filename}/download: resolve_backup_path (path-traversal-sicher) → fileresponse get /api/admin/backups/{filename}/download">
+          <div class="uc-head">
+            <code class="uc-id">ADM-20</code>
+            <span class="uc-title">Backup herunterladen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Download-Button</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /{filename}/download: resolve_backup_path (path-traversal-sicher) → FileResponse</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/backups/{filename}/download</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Backups.tsx handleDownload</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §19; docs/BACKUP.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">FILENAME_RE + resolve-Parent-Check; Backup enthält ALLE Tenants → SaaS-Gate-TODO im Code dokumentiert</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-21 backup löschen delete /{filename} → resolve + unlink → 204 delete /api/admin/backups/{filename}">
+          <div class="uc-head">
+            <code class="uc-id">ADM-21</code>
+            <span class="uc-title">Backup löschen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Löschen + Bestätigung</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">DELETE /{filename} → resolve + unlink → 204</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>DELETE /api/admin/backups/{filename}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Backups.tsx handleDelete</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §19</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Path-traversal-sicher; ConfirmDialog im UI</span></div>
+          </div>
+        </div><div class="uc" data-actor="System" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-22 geplantes automatisches backup _run_scheduled_backup prüft europe/berlin-stunde==cfg.hour &amp; enabled; native (serve_frontend) übersprungen (os-timer); sonst create+prune (intern, scheduler_service)">
+          <div class="uc-head">
+            <code class="uc-id">ADM-22</code>
+            <span class="uc-title">Geplantes automatisches Backup</span>
+            <span class="actor actor-system">System</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">APScheduler stündlich :30</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">_run_scheduled_backup prüft Europe/Berlin-Stunde==cfg.hour &amp; enabled; native (SERVE_FRONTEND) übersprungen (OS-Timer); sonst create+prune</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>(intern, scheduler_service)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Backups.tsx Zeitplan-Block (Doku-Hinweis HH:30)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">HANDBUCH-ADMIN.md §19 (Native: OS-Timer); docs/BACKUP.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Tz-explizit zoneinfo; native skip gegen Doppel-Backup; pytest-Mode disabled</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-23 update-prüfung (manuell/banner) post /admin/updates/check gegen update_server_url mit license_id; signiertes manifest; banner mit download-link post /api/admin/updates/check">
+          <div class="uc-head">
+            <code class="uc-id">ADM-23</code>
+            <span class="uc-title">Update-Prüfung (manuell/Banner)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Dashboard-Aufruf (1x/Session) bzw. Banner</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">POST /admin/updates/check gegen UPDATE_SERVER_URL mit license_id; signiertes Manifest; Banner mit Download-Link</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/updates/check</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">UpdateBanner.tsx, AdminDashboard.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/UPDATE.md (Installation manuell via Installer)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">404 wenn kein Update-Server (Docker/Dev); safeHttpUrl auf download_page; sessionStorage-Cache; keine In-App-Installation (by design)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Admin-Betrieb" data-doc="1" data-impl="1" data-text="adm-24 update-status abfragen get /admin/updates/status liefert version + download_page get /api/admin/updates/status">
+          <div class="uc-head">
+            <code class="uc-id">ADM-24</code>
+            <span class="uc-title">Update-Status abfragen</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Status-Abfrage</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET /admin/updates/status liefert Version + download_page</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/updates/status</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">(Backend; via Banner/Status)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/UPDATE.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">get_update_status aus updater.py; APP_VERSION SoT</span></div>
+          </div>
+        </div>
+    </section><section class="area" data-area="Querschnitt &amp; System">
+      <h2>Querschnitt &amp; System <span class="count">17</span></h2>
+      <div class="uc" data-actor="Mitarbeiter" data-area="Querschnitt &amp; System" data-doc="1" data-impl="1" data-text="cs-01 §4 arbzg pausenprüfung in echtzeit (stempeln + manueller eintrag) validate_daily_break gruppiert alle tageseinträge, summiert brutto-zeit, zieht nur &gt;=15min-pausenabschnitte + lücken ab; &gt;6h netto erfordert 30min, &gt;9h 45min pause. verstoß blockiert nicht hart, sondern erlaubt dokumentierte ausnahme (break_waiver). post /api/time-entries/clock-out, post /api/time-entries, put /api/time-entries/{id}">
+          <div class="uc-head">
+            <code class="uc-id">CS-01</code>
+            <span class="uc-title">§4 ArbZG Pausenprüfung in Echtzeit (Stempeln + manueller Eintrag)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Ausstempeln / Erfassen / Korrigieren eines Zeiteintrags</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">validate_daily_break gruppiert alle Tageseinträge, summiert Brutto-Zeit, zieht nur &gt;=15min-Pausenabschnitte + Lücken ab; &gt;6h netto erfordert 30min, &gt;9h 45min Pause. Verstoß blockiert nicht hart, sondern erlaubt dokumentierte Ausnahme (break_waiver).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/time-entries/clock-out, POST /api/time-entries, PUT /api/time-entries/{id}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Stempel-Widget / Zeiteintrag-Dialog (Pause-Feld + gelber Hinweis + Begründung)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/handbuch/HANDBUCH-MITARBEITER.md (Pause §4) + HANDBUCH-ADMIN.md Abschnitt §4/Pflicht-Pause-Ausnahme</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§4 ArbZG: Pause auf Netto-Arbeitszeit bezogen, Pausenabschnitte &gt;=15min (§4 S.2)</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Querschnitt &amp; System" data-doc="1" data-impl="0" data-text="cs-02 §5 arbzg ruhezeit-echtzeitwarnung beim einstempeln sucht letzten beendeten eintrag, berechnet tz-aware (europe/berlin, dst-sicher) die ruhezeit seit letztem arbeitsende; &lt;11h -&gt; nicht-blockierende rest_time_warning. exempt_from_arbzg übersprungen. post /api/time-entries/clock-in">
+          <div class="uc-head">
+            <code class="uc-id">CS-02</code>
+            <span class="uc-title">§5 ArbZG Ruhezeit-Echtzeitwarnung beim Einstempeln</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Einstempeln (clock-in)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Sucht letzten beendeten Eintrag, berechnet TZ-aware (Europe/Berlin, DST-sicher) die Ruhezeit seit letztem Arbeitsende; &lt;11h -&gt; nicht-blockierende REST_TIME_WARNING. exempt_from_arbzg übersprungen.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/time-entries/clock-in</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Stempel-Widget (Toast-Warnung)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/handbuch/HANDBUCH-ADMIN.md §5 (Report); Echtzeit-Warnung in MA-Handbuch nicht explizit</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§5 ArbZG 11h Ruhezeit; F-030 DST-Korrektur; F-026 tenant-scope</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Querschnitt &amp; System" data-doc="1" data-impl="1" data-text="cs-03 §3/§6 arbzg tageshöchst- + nachtarbeit-warnung daily_net_hours geprüft: &gt;10h harte sperre an pfaden mit frei wählbarer zeit, beim ausstempeln nur warnung (zeit bereits geleistet, kein 422). nachtarbeiter (is_night_worker) + is_night_work + &gt;8h -&gt; §6-warnung. post /api/time-entries/clock-out, post/put /api/time-entries">
+          <div class="uc-head">
+            <code class="uc-id">CS-03</code>
+            <span class="uc-title">§3/§6 ArbZG Tageshöchst- + Nachtarbeit-Warnung</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Ausstempeln / Erfassen / Korrigieren</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">daily_net_hours geprüft: &gt;10h harte Sperre an Pfaden mit frei wählbarer Zeit, beim Ausstempeln nur Warnung (Zeit bereits geleistet, kein 422). Nachtarbeiter (is_night_worker) + is_night_work + &gt;8h -&gt; §6-Warnung.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/time-entries/clock-out, POST/PUT /api/time-entries</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Stempel-Widget / Eintrag-Dialog</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/handbuch/HANDBUCH-ADMIN.md (§6 Nachtarbeit, 10h-Grenze)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§3 ArbZG 8/10h; §6 Nachtarbeitnehmer 8h; §2 Abs.4 Nachtzeit 23-6, &gt;2h</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Querschnitt &amp; System" data-doc="1" data-impl="1" data-text="cs-04 sonn-/feiertagsarbeit-kennzeichnung (warnung + §10 begründung) weekday==6 -&gt; sunday_work, is_holiday -&gt; holiday_work warnung; sunday_exception_reason wird gespeichert (§10 begründung, im export). post /api/time-entries/clock-out, post/put /api/time-entries">
+          <div class="uc-head">
+            <code class="uc-id">CS-04</code>
+            <span class="uc-title">Sonn-/Feiertagsarbeit-Kennzeichnung (Warnung + §10 Begründung)</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Stempeln/Eintrag an Sonntag oder Feiertag</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">weekday==6 -&gt; SUNDAY_WORK, is_holiday -&gt; HOLIDAY_WORK Warnung; sunday_exception_reason wird gespeichert (§10 Begründung, im Export).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/time-entries/clock-out, POST/PUT /api/time-entries</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Stempel-Widget / Eintrag-Dialog</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/handbuch/HANDBUCH-ADMIN.md (§11 Sonntagsruhe, Feiertage)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§9-11 ArbZG Sonn-/Feiertagsruhe; is_holiday tenant_id-Pflicht</span></div>
+          </div>
+        </div><div class="uc" data-actor="System" data-area="Querschnitt &amp; System" data-doc="1" data-impl="1" data-text="cs-05 lizenzprüfung beim start + beta_mode beta_mode=true -&gt; lizenzcheck komplett aus (volle funktion). sonst: license.key validieren (ed25519, mehrere public keys), abgelaufen/ungültig -&gt; read-only (kein sys.exit), demo-mode via license_demo_expires_at. (startup, kein endpoint) + /api/system/info liefert beta/license">
+          <div class="uc-head">
+            <code class="uc-id">CS-05</code>
+            <span class="uc-title">Lizenzprüfung beim Start + BETA_MODE</span>
+            <span class="actor actor-system">System</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Backend-Startup</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">BETA_MODE=True -&gt; Lizenzcheck komplett aus (volle Funktion). Sonst: license.key validieren (Ed25519, mehrere Public Keys), abgelaufen/ungültig -&gt; Read-Only (kein sys.exit), Demo-Mode via LICENSE_DEMO_EXPIRES_AT.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>(Startup, kein Endpoint) + /api/system/info liefert beta/license</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">BetaBadge / Footer; Login-Screen</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/handbuch/CHEATSHEET-ADMIN.md (Beta, Lizenzprüfung deaktiviert); docs/INSTALL-NATIVE.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Lizenz-Fehler nie Totalausfall; mehrere Public Keys; BETA_MODE vor Paid-Release auf False</span></div>
+          </div>
+        </div><div class="uc" data-actor="System" data-area="Querschnitt &amp; System" data-doc="0" data-impl="1" data-text="cs-06 read-only-enforcement (abgelaufene lizenz onprem / suspended saas) licensereadonlymiddleware blockt schreibmethoden mit 403, wenn onprem read_only oder saas-tenant suspended; auth- und dsgvo-betroffenenrechts-endpoints (anonymize/purge/request-deletion/profile) + stripe-webhook ausgenommen. middleware über alle routen">
+          <div class="uc-head">
+            <code class="uc-id">CS-06</code>
+            <span class="uc-title">Read-Only-Enforcement (abgelaufene Lizenz onprem / suspended SaaS)</span>
+            <span class="actor actor-system">System</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Schreibender Request (POST/PUT/PATCH/DELETE)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">LicenseReadOnlyMiddleware blockt Schreibmethoden mit 403, wenn onprem read_only ODER SaaS-Tenant suspended; Auth- und DSGVO-Betroffenenrechts-Endpoints (anonymize/purge/request-deletion/profile) + Stripe-Webhook ausgenommen.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>Middleware über alle Routen</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Toast/Fehlermeldung im Frontend</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (Endnutzer-Doku); Begründung im Code</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§16 Lese/Export bleibt; DSGVO Art.12/16/17 dürfen nicht blockiert werden</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Querschnitt &amp; System" data-doc="0" data-impl="1" data-text="cs-07 mitarbeiter-limit-prüfung check_employee_limit: bei aktiver lizenz block (403), wenn current_count &gt;= max_employees. in beta (license=none) no-op. post /api/admin/users">
+          <div class="uc-head">
+            <code class="uc-id">CS-07</code>
+            <span class="uc-title">Mitarbeiter-Limit-Prüfung</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Neuen Benutzer anlegen</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">check_employee_limit: bei aktiver Lizenz Block (403), wenn current_count &gt;= max_employees. In BETA (license=None) No-op.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/admin/users</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Benutzerverwaltung</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (Beta inaktiv)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Limit aus Lizenz; Beta: deaktiviert</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Querschnitt &amp; System" data-doc="0" data-impl="1" data-text="cs-08 stripe checkout / customer-portal (self-service billing) checkout/portal erstellen stripe-session-urls (require_admin, eigener tenant). _require_stripe -&gt; 503 wenn stripe_secret_key fehlt. post /api/billing/checkout, post /api/billing/portal">
+          <div class="uc-head">
+            <code class="uc-id">CS-08</code>
+            <span class="uc-title">Stripe Checkout / Customer-Portal (Self-Service Billing)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Plan buchen / Zahlungsdaten verwalten</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">checkout/portal erstellen Stripe-Session-URLs (require_admin, eigener Tenant). _require_stripe -&gt; 503 wenn STRIPE_SECRET_KEY fehlt.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/billing/checkout, POST /api/billing/portal</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Billing-UI (SaaS)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (SaaS Phase 4, in Beta/onprem nicht aktiv)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Multi-Tenant: nur eigener Tenant; Plan/seat webhook-owned</span></div>
+          </div>
+        </div><div class="uc" data-actor="System" data-area="Querschnitt &amp; System" data-doc="0" data-impl="1" data-text="cs-09 stripe-webhook (subscription-lifecycle) signatur verifiziert, idempotent via stripe_events (unique), pii-freier whitelist-excerpt; aktualisiert plan/subscription_status (active/past_due/canceled), invoices upsert, past_due/suspended-&gt;active bei zahlung. post /api/webhooks/stripe (unauth, superadmin-context)">
+          <div class="uc-head">
+            <code class="uc-id">CS-09</code>
+            <span class="uc-title">Stripe-Webhook (Subscription-Lifecycle)</span>
+            <span class="actor actor-system">System</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Stripe sendet signiertes Event</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Signatur verifiziert, idempotent via stripe_events (UNIQUE), PII-freier whitelist-Excerpt; aktualisiert plan/subscription_status (active/past_due/canceled), Invoices upsert, past_due/suspended-&gt;active bei Zahlung.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/webhooks/stripe (unauth, superadmin-context)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">-</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/specs (Phase 4)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Idempotenz; DSGVO #129 kein customer_email/PII in DB</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Querschnitt &amp; System" data-doc="0" data-impl="1" data-text="cs-10 tenant-billing self-service (status/adresse/invoices/usage) get billing/usage/invoices (f-026 explizite tenant-filter), patch billing nur adress-submenge (plan/stripe_* gesperrt), country-&gt;upper. get /api/tenant/billing|usage|invoices, patch /api/tenant/billing">
+          <div class="uc-head">
+            <code class="uc-id">CS-10</code>
+            <span class="uc-title">Tenant-Billing Self-Service (Status/Adresse/Invoices/Usage)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Billing-Seite öffnen / Adresse ändern</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">GET billing/usage/invoices (F-026 explizite tenant-Filter), PATCH billing nur Adress-Submenge (plan/stripe_* gesperrt), country-&gt;upper.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/tenant/billing|usage|invoices, PATCH /api/tenant/billing</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Billing-UI (SaaS)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (SaaS)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">F-026; plan/seat_limit/stripe nicht admin-änderbar</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Querschnitt &amp; System" data-doc="0" data-impl="1" data-text="cs-11 tenant-lifecycle self-service (suspend/löschung/transfer/export/avv) suspend (7d grace), request-deletion (30d grace -&gt; anonymisierung), transfer-ownership (billing_email), export (json, arbzg-konform), avv-pdf (draft). post /api/tenant/{suspend,cancel-suspend,request-deletion,cancel-deletion,transfer-ownership}, get /api/tenant/{export,avv}">
+          <div class="uc-head">
+            <code class="uc-id">CS-11</code>
+            <span class="uc-title">Tenant-Lifecycle Self-Service (Suspend/Löschung/Transfer/Export/AVV)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Konto pausieren/löschen, Eigentümer wechseln, Daten exportieren</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">suspend (7d Grace), request-deletion (30d Grace -&gt; Anonymisierung), transfer-ownership (billing_email), export (JSON, ArbZG-konform), AVV-PDF (Draft).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/tenant/{suspend,cancel-suspend,request-deletion,cancel-deletion,transfer-ownership}, GET /api/tenant/{export,avv}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Tenant-Verwaltung (SaaS)</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (SaaS Phase 6)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">ArbZG §16 2-Jahre-Aufbewahrung -&gt; Anonymisierung statt Hard-Delete; DSGVO Art.17 Abs.3</span></div>
+          </div>
+        </div><div class="uc" data-actor="Superadmin" data-area="Querschnitt &amp; System" data-doc="0" data-impl="0" data-text="cs-12 superadmin §16-notfall-export deaktivierter tenants require_superadmin (tenant_id null), set_superadmin_context, exportiert users/timeentries/absences/auditlogs eines tenants als json auch bei is_active=false; export selbst wird im audit-log markiert (best-effort). get /api/superadmin/tenants/{id}/arbzg-export, get /api/superadmin/tenants">
+          <div class="uc-head">
+            <code class="uc-id">CS-12</code>
+            <span class="uc-title">Superadmin §16-Notfall-Export deaktivierter Tenants</span>
+            <span class="actor actor-superadmin">Superadmin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge warn">Abweichung</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Arbeitsschutzbehörde fordert Aufzeichnungen eines archivierten Kunden</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">require_superadmin (tenant_id NULL), set_superadmin_context, exportiert Users/TimeEntries/Absences/AuditLogs eines Tenants als JSON auch bei is_active=False; Export selbst wird im Audit-Log markiert (best-effort).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/superadmin/tenants/{id}/arbzg-export, GET /api/superadmin/tenants</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Superadmin-Dashboard</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/ARC42.md / specs (kein Admin-Handbuch — operator-intern)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">§16 Aufzeichnungspflicht; Export muss vollständige Roh-Aufzeichnung enthalten</span></div>
+          </div>
+        </div><div class="uc" data-actor="Superadmin" data-area="Querschnitt &amp; System" data-doc="0" data-impl="1" data-text="cs-13 superadmin tenant-übersicht / mrr / cron-trigger tenants-overview (paginiert, seats, trial-tage, mrr), metrics/mrr, cron/metrics-refresh, cron/trial-check (suspend abgelaufener trials + canceled-after-grace + scheduled suspends/deletions + audit purge). get /api/superadmin/tenants-overview|metrics/mrr, post /api/superadmin/cron/{metrics-refresh,trial-check}">
+          <div class="uc-head">
+            <code class="uc-id">CS-13</code>
+            <span class="uc-title">Superadmin Tenant-Übersicht / MRR / Cron-Trigger</span>
+            <span class="actor actor-superadmin">Superadmin</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Dashboard öffnen / Wartungsjob manuell</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">tenants-overview (paginiert, Seats, Trial-Tage, MRR), metrics/mrr, cron/metrics-refresh, cron/trial-check (suspend abgelaufener Trials + canceled-after-grace + scheduled suspends/deletions + audit purge).</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/superadmin/tenants-overview|metrics/mrr, POST /api/superadmin/cron/{metrics-refresh,trial-check}</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Superadmin-Dashboard</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/specs (Phase 7)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">superadmin-only; tz-aware Vergleiche</span></div>
+          </div>
+        </div><div class="uc" data-actor="Mitarbeiter" data-area="Querschnitt &amp; System" data-doc="0" data-impl="1" data-text="cs-14 in-app bug-/feedback-report backend-proxy ergänzt license_id (oder &#x27;beta&#x27;), app-version, os und leitet multipart an pzweb /v1/bugs weiter; host gegen allowlist + https geprüft; status-mapping 200/400/409/429/502, app bleibt stabil. post /api/feedback/report (rate-limit 10/h)">
+          <div class="uc-head">
+            <code class="uc-id">CS-14</code>
+            <span class="uc-title">In-App Bug-/Feedback-Report</span>
+            <span class="actor actor-mitarbeiter">Mitarbeiter</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Nutzer meldet Fehler aus der App</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Backend-Proxy ergänzt license_id (oder &#x27;beta&#x27;), App-Version, OS und leitet multipart an pzweb /v1/bugs weiter; Host gegen Allowlist + HTTPS geprüft; Status-Mapping 200/400/409/429/502, App bleibt stabil.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>POST /api/feedback/report (rate-limit 10/h)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">frontend/src/components/FeedbackDialog.tsx</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">FEHLT (keine Erwähnung in Handbüchern/CHEATSHEETs/DocViewer)</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Host-Allowlist; BETA erlaubt Reports ohne Lizenz</span></div>
+          </div>
+        </div><div class="uc" data-actor="System" data-area="Querschnitt &amp; System" data-doc="0" data-impl="1" data-text="cs-15 multi-tenant-bootstrap (onprem vs saas) onprem: default-tenant (uuid …001) + admin-user (track_hours=false) + feiertags-sync; saas: übersprungen (tenants via signup). weak-password-guard in production. (startup)">
+          <div class="uc-head">
+            <code class="uc-id">CS-15</code>
+            <span class="uc-title">Multi-Tenant-Bootstrap (onprem vs saas)</span>
+            <span class="actor actor-system">System</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Backend-Startup</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">onprem: Default-Tenant (UUID …001) + Admin-User (track_hours=False) + Feiertags-Sync; saas: übersprungen (Tenants via Signup). Weak-Password-Guard in production.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>(Startup)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">-</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/INSTALLATION.md / ARC42 (Default-Tenant); Modus-Schalter in CLAUDE.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DEPLOYMENT_MODE onprem/saas; RLS superadmin-context beim Bootstrap</span></div>
+          </div>
+        </div><div class="uc" data-actor="System" data-area="Querschnitt &amp; System" data-doc="0" data-impl="1" data-text="cs-16 lifecycle-/dsgvo-scheduler (täglich 03:00 + stündl. backup) täglich 03:00: vacation-audit-purge (730d), apply_scheduled_suspends/deletions, error-log-cleanup (90d). stündlich :30: backup zur konfigurierten stunde (nur docker; native via systemd-timer). pytest-no-op. intern + post /api/superadmin/cron/trial-check (manueller trigger)">
+          <div class="uc-head">
+            <code class="uc-id">CS-16</code>
+            <span class="uc-title">Lifecycle-/DSGVO-Scheduler (täglich 03:00 + stündl. Backup)</span>
+            <span class="actor actor-system">System</span>
+            <span class="badge warn">nicht dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">APScheduler (Europe/Berlin)</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">Täglich 03:00: vacation-audit-purge (730d), apply_scheduled_suspends/deletions, error-log-cleanup (90d). Stündlich :30: Backup zur konfigurierten Stunde (nur Docker; native via systemd-Timer). pytest-No-op.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>intern + POST /api/superadmin/cron/trial-check (manueller Trigger)</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">-</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/specs (#126); Backup docs/BACKUP.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">DSGVO Art.5(1)(e) Speicherbegrenzung; §16 Time-Entry-Audits NICHT gepurged</span></div>
+          </div>
+        </div><div class="uc" data-actor="Admin" data-area="Querschnitt &amp; System" data-doc="1" data-impl="1" data-text="cs-17 update-check (native, admin) check_for_updates ruft signiertes manifest vom update-server (allowlist-host), ed25519-signatur verifiziert, version-vergleich; liefert update_available + download-seite. get /api/admin/updates/status, post /api/admin/updates/check">
+          <div class="uc-head">
+            <code class="uc-id">CS-17</code>
+            <span class="uc-title">Update-Check (Native, Admin)</span>
+            <span class="actor actor-admin">Admin</span>
+            <span class="badge ok">dokumentiert</span> <span class="badge ok">korrekt</span>
+          </div>
+          <div class="uc-body">
+            <div class="row"><span class="k">Auslöser</span><span class="v">Manueller Update-Check / Status</span></div>
+            <div class="row"><span class="k">Ablauf</span><span class="v">check_for_updates ruft signiertes Manifest vom Update-Server (Allowlist-Host), Ed25519-Signatur verifiziert, Version-Vergleich; liefert update_available + Download-Seite.</span></div>
+            <div class="row"><span class="k">Endpoints</span><span class="v"><code>GET /api/admin/updates/status, POST /api/admin/updates/check</code></span></div>
+            <div class="row"><span class="k">UI</span><span class="v">Admin -&gt; Updates</span></div>
+            <div class="row"><span class="k">Doku</span><span class="v">docs/UPDATE.md</span></div>
+            <div class="row"><span class="k">Regeln</span><span class="v">Manifest-Signatur (Ed25519); _ALLOWED_UPDATE_HOSTS; native-only</span></div>
+          </div>
+        </div>
+    </section>
+</div>
+<footer>PraxisZeit UC-Inventar · 177 Use-Cases · generiert aus dem UC-Review-Workflow</footer>
+<script>
+const q=document.getElementById('q'),fa=document.getElementById('fActor'),far=document.getElementById('fArea'),fu=document.getElementById('fUndoc'),fi=document.getElementById('fImpl');
+function apply(){
+  const t=q.value.trim().toLowerCase(),a=fa.value,ar=far.value,u=fu.checked,im=fi.checked;
+  document.querySelectorAll('.uc').forEach(c=>{
+    let ok=true;
+    if(t&&!c.dataset.text.includes(t))ok=false;
+    if(a&&c.dataset.actor!==a)ok=false;
+    if(ar&&c.dataset.area!==ar)ok=false;
+    if(u&&c.dataset.doc!=='0')ok=false;
+    if(im&&c.dataset.impl!=='0')ok=false;
+    c.classList.toggle('hidden',!ok);
+    if(ok&&(t||u||im))c.classList.add('open');
+  });
+  document.querySelectorAll('section.area').forEach(s=>{
+    const vis=[...s.querySelectorAll('.uc')].some(c=>!c.classList.contains('hidden'));
+    s.classList.toggle('hidden',!vis);
+  });
+}
+[q,fa,far,fu,fi].forEach(el=>el.addEventListener('input',apply));
+document.querySelectorAll('.uc-head').forEach(h=>h.addEventListener('click',()=>h.parentNode.classList.toggle('open')));
+</script>
+</body></html>


### PR DESCRIPTION
Aus dem UC-Review-Workflow generiertes, durchsuchbares **Use-Case-Verzeichnis**.

`docs/uc/index.html` (standalone) listet alle **177** inventarisierten Use-Cases mit Akteur, Auslöser, Hauptablauf, Endpoints, Frontend-Seite, relevanten ArbZG/BUrlG/DSGVO-Regeln sowie **Doku-Status** (132 dokumentiert / 45 offen) und **Implementierungs-Status** (17 Abweichungen). Oben die offenen Findings (≥ medium). Volltextsuche + Filter (Akteur/Bereich/undokumentiert/Impl-Abweichung), aufklappbare Karten.

Enthält außerdem `README.md` + `_generate.py` (Regenerierung aus dem Review-JSON) und einen Link in der CLAUDE.md-Doku-Tabelle.

Die offenen Findings (≥ medium) werden in Folge-PRs behoben.
