### PR TITLE
fix(uc-review): 7 Backend-Findings (ArbZG/DSGVO/Auth/Urlaub)

### DIFF
--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -12,7 +12,7 @@ from app.models import (
 )
 from app.middleware.auth import get_current_user
 from app.schemas.absence import AbsenceCreate, AbsenceResponse, AbsenceCalendarEntry, TeamAbsenceEntry, NextVacationResponse
-from app.services import calculation_service
+from app.services import calculation_service, settings_service
 from app.routers.admin_helpers import _create_audit_log
 
 router = APIRouter(prefix="/api/absences", tags=["absences"])
@@ -316,6 +316,19 @@ def create_absence(
             absence_data.type = BEHAVIOR_TO_ABSENCE_TYPE[AbsenceReasonBehavior(reason.base_behavior)]
         except (KeyError, ValueError):
             raise HTTPException(status_code=400, detail="Ungültiges Basis-Verhalten des Abwesenheitsgrundes")
+
+    # MA-ABS-01: Bei aktivierter Genehmigungspflicht dürfen NICHT-Admins Urlaub
+    # nicht direkt buchen (sonst Approval-Bypass über die API) — sie müssen einen
+    # Urlaubsantrag stellen. Admins (auch für sich) buchen weiterhin direkt. Greift
+    # auch für eigene Gründe, die auf VACATION mappen (Auflösung steht oben).
+    if (absence_data.type == AbsenceType.VACATION
+            and current_user.role != UserRole.ADMIN
+            and settings_service.get_bool_setting(
+                db, "vacation_approval_required", current_user.tenant_id, False)):
+        raise HTTPException(
+            status_code=400,
+            detail="Urlaub ist genehmigungspflichtig — bitte einen Urlaubsantrag stellen.",
+        )
 
     # Determine date range
     start_date = absence_data.date

--- a/backend/app/routers/admin_carryovers.py
+++ b/backend/app/routers/admin_carryovers.py
@@ -134,9 +134,12 @@ def create_year_closing(
             ),
         )
 
+    # ABV-14: auch MA OHNE Stundenzählung (#191) einbeziehen — sie führen
+    # tagebasiert Urlaub (Pro-rata + Vortrag). create_year_closing liefert für sie
+    # Überstunden = 0 und den korrekten Resturlaub-Vortrag; ohne sie ginge ihr
+    # Resturlaub beim Jahreswechsel verloren.
     users = db.query(User).filter(
         User.is_active == True,
-        User.track_hours == True,
         User.tenant_id == current_user.tenant_id,
     ).all()
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -368,6 +368,7 @@ def get_me(current_user: User = Depends(get_current_user)):
 @limiter.limit("3/minute")
 def change_password(
     request: Request,
+    response: Response,
     password_data: ChangePasswordRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
@@ -399,6 +400,14 @@ def change_password(
     new_access_token = auth_service.create_access_token(
         str(current_user.id), current_user.role.value, current_user.token_version, tenant_id_str
     )
+    # AUTH-05: Auch ein frisches Refresh- + CSRF-Cookie setzen. Sonst trägt das
+    # Refresh-Cookie weiter die ALTE token_version → der nächste /refresh nach
+    # Ablauf des Access-Tokens scheitert am token_version-Check (stiller Logout).
+    new_refresh_token = auth_service.create_refresh_token(
+        str(current_user.id), current_user.token_version, tenant_id_str
+    )
+    _set_refresh_cookie(response, new_refresh_token)
+    _set_csrf_cookie(response)
     return {"message": "Passwort erfolgreich geändert", "access_token": new_access_token}
 
 

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -711,6 +711,8 @@ def get_sunday_summary(
     result = []
 
     for user in users:
+        if user.exempt_from_arbzg:
+            continue  # RPT-12: §18-Leitende konsistent ausnehmen (wie rest-time/24-week)
         # Get all entries on Sundays in this year
         entries = (
             db.query(TimeEntry)
@@ -761,6 +763,8 @@ def get_night_work_summary(
     threshold = 48  # §6 ArbZG: Nachtarbeitnehmer if >= 48 days/year
 
     for user in users:
+        if user.exempt_from_arbzg:
+            continue  # RPT-12: §18-Leitende konsistent ausnehmen
         entries = (
             db.query(TimeEntry)
             .filter(
@@ -830,6 +834,8 @@ def get_compensatory_rest(
     }
 
     for user in users:
+        if user.exempt_from_arbzg:
+            continue  # RPT-12: §18-Leitende konsistent ausnehmen
         entries = (
             db.query(TimeEntry)
             .filter(

--- a/backend/app/routers/superadmin.py
+++ b/backend/app/routers/superadmin.py
@@ -72,6 +72,11 @@ def _time_entry_dict(te: TimeEntry) -> dict:
         "date": _iso(te.date),
         "start_time": _iso(te.start_time),
         "end_time": _iso(te.end_time),
+        # CS-12: Rohstempel (#201 work-window) gehören in den §16-Notfall-Export —
+        # die gekappten start/end_time sind die angerechneten, raw_* die tatsächlich
+        # gestempelten Zeiten (Aufzeichnungspflicht).
+        "raw_start_time": _iso(te.raw_start_time),
+        "raw_end_time": _iso(te.raw_end_time),
         "break_minutes": te.break_minutes,
         "note": te.note,
         "sunday_exception_reason": te.sunday_exception_reason,

--- a/backend/app/routers/time_entries.py
+++ b/backend/app/routers/time_entries.py
@@ -300,7 +300,12 @@ def clock_in(
             TimeEntry.user_id == current_user.id,
             TimeEntry.tenant_id == current_user.tenant_id,  # F-026
             TimeEntry.end_time.isnot(None),
-            TimeEntry.date <= now.date(),
+            # MZ-01: nur Einträge VOR HEUTE — §5 ist die Ruhezeit ZWISCHEN
+            # Arbeitstagen. Ein früherer ausgestempelter Eintrag am selben Tag
+            # (geteilte Sprechzeit: vormittags aus, nachmittags wieder ein) ist
+            # eine Pause innerhalb des Arbeitstags (§4), keine §5-Ruhezeit — sonst
+            # feuert die Warnung beim 2. Einstempeln fälschlich.
+            TimeEntry.date < now.date(),
         ).order_by(TimeEntry.date.desc(), TimeEntry.end_time.desc()).first()
 
         if last_entry:

--- a/backend/app/services/lifecycle_service.py
+++ b/backend/app/services/lifecycle_service.py
@@ -471,6 +471,39 @@ def build_self_export_payload(db: Session, user: User) -> dict[str, Any]:
         for u in reviewers
     }
 
+    # MS-06: Schichtplanungs-Daten des MA (DSGVO Art. 15) — eigene Einteilungen +
+    # Einweisungen sind personenbezogen. Nur wenn das Feature aktiv ist.
+    from app.services import settings_service
+    own_shift_assignments_data: list[dict[str, Any]] = []
+    own_qualifications_data: list[dict[str, Any]] = []
+    if settings_service.get_bool_setting(db, "shift_planning_enabled", tid, False):
+        from app.models.shift_planning import (
+            ShiftAssignment, ShiftSlot, ShiftPlan, Workstation, WorkstationQualification,
+        )
+        _WD = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"]
+        for a, sl, pl, ws in (
+            db.query(ShiftAssignment, ShiftSlot, ShiftPlan, Workstation)
+            .join(ShiftSlot, ShiftAssignment.shift_slot_id == ShiftSlot.id)
+            .join(ShiftPlan, ShiftSlot.shift_plan_id == ShiftPlan.id)
+            .outerjoin(Workstation, ShiftSlot.workstation_id == Workstation.id)
+            .filter(ShiftAssignment.user_id == user.id, ShiftAssignment.tenant_id == tid)
+            .all()
+        ):
+            own_shift_assignments_data.append({
+                "plan": pl.name,
+                "weekday": _WD[sl.weekday] if 0 <= sl.weekday < 7 else sl.weekday,
+                "start_time": sl.start_time.strftime("%H:%M") if sl.start_time else None,
+                "end_time": sl.end_time.strftime("%H:%M") if sl.end_time else None,
+                "workstation": ws.name if ws else None,
+            })
+        for q, ws in (
+            db.query(WorkstationQualification, Workstation)
+            .outerjoin(Workstation, WorkstationQualification.workstation_id == Workstation.id)
+            .filter(WorkstationQualification.user_id == user.id, WorkstationQualification.tenant_id == tid)
+            .all()
+        ):
+            own_qualifications_data.append({"workstation": ws.name if ws else str(q.workstation_id)})
+
     return {
         "export_generated_at": datetime.now(timezone.utc).isoformat(),
         "export_type": "self_service_dsgvo_art15",
@@ -484,6 +517,9 @@ def build_self_export_payload(db: Session, user: User) -> dict[str, Any]:
         "vacation_requests": [_vacation_request_dict(v) for v in own_vacation_requests],
         "change_requests": [_change_request_dict(c) for c in own_change_requests],
         "audit_logs": [_audit_log_dict(a) for a in own_audit_logs],
+        # MS-06: eigene Schichteinteilungen + Einweisungen (leer, wenn Feature aus).
+        "shift_assignments": own_shift_assignments_data,
+        "qualifications": own_qualifications_data,
         # Klartext-Aufloesung fuer reviewed_by / last_modified_by / changed_by
         # (siehe Kommentar oben). Schluessel = UUID-String, Wert = "First Last".
         "user_directory": user_directory,
@@ -493,6 +529,8 @@ def build_self_export_payload(db: Session, user: User) -> dict[str, Any]:
             "vacation_requests": len(own_vacation_requests),
             "change_requests": len(own_change_requests),
             "audit_logs": len(own_audit_logs),
+            "shift_assignments": len(own_shift_assignments_data),
+            "qualifications": len(own_qualifications_data),
         },
     }
 
@@ -513,6 +551,7 @@ def _build_art15_meta() -> dict[str, Any]:
             "Aenderungs- und Urlaubsantraege inkl. Begruendungen",
             "Audit-Log (Wer hat wann was geaendert)",
             "Authentifizierung (Passwort-Hash, ggf. TOTP-Status)",
+            "Schichtplanung (Einteilungen, Einweisungen) — sofern aktiviert",
         ],
         "c_empfaenger": (
             "Praxis-Administrator (zur Genehmigung/Korrektur), ggf. Lohnbuchhaltung "

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -870,6 +870,24 @@ class TestClockEndpoints:
         })
         assert resp.status_code == 400
 
+    def test_clock_in_no_rest_warning_for_same_day_split_shift(self, employee_client, _db_session, employee_user):
+        """MZ-01: Ein früherer AUSGESTEMPELTER Eintrag AM SELBEN TAG (geteilte
+        Sprechzeit: vormittags aus, nachmittags wieder ein) darf KEINE §5-
+        Ruhezeitwarnung auslösen — das ist eine Pause innerhalb des Arbeitstags."""
+        from datetime import timedelta
+        from app.services.timezone_service import now_local
+        now = now_local()
+        _db_session.add(TimeEntry(
+            user_id=employee_user.id, tenant_id=DEFAULT_TENANT_ID, date=now.date(),
+            start_time=(now - timedelta(hours=4)).time(),
+            end_time=(now - timedelta(minutes=1)).time(),  # endete eben → ohne Fix < 11h
+        ))
+        _db_session.commit()
+        resp = employee_client.post("/api/time-entries/clock-in", json={})
+        assert resp.status_code == 201, resp.text
+        warnings = resp.json().get("warnings", [])
+        assert not any("REST_TIME_WARNING" in w for w in warnings), warnings
+
     def test_clock_out_stale_entry_gets_closed(self, employee_client, _db_session, employee_user):
         """B-H1: ein offener Eintrag von einem früheren Tag wird beim Ausstempeln
         automatisch geschlossen UND committed (nicht durch das 400-Raise verworfen),


### PR DESCRIPTION
Behebt die Backend-Findings (≥ medium) aus dem UC-Review:

- **MZ-01** §5-Ruhezeitwarnung feuerte beim 2. Einstempeln am selben Tag (geteilte Sprechzeit) → nur Einträge vor heute (+ Regressionstest).
- **MA-ABS-01** `vacation_approval_required` wurde auf `POST /absences` nicht erzwungen (Approval-Bypass via API) → Nicht-Admins müssen den Urlaubsantrag stellen.
- **RPT-12** §18-Leitende in Sonntags-/Nacht-/Ersatzruhe-Auswertung inkonsistent → an allen 3 Stellen ausgenommen (wie rest-time/24-week).
- **AUTH-05** `change_password` rotierte das Refresh-Cookie nicht → stiller Logout. Jetzt frisches Refresh-/CSRF-Cookie.
- **ABV-14** Jahresabschluss übersprang MA ohne Stundenzählung (#191) → Resturlaub-Vortrag ging verloren; `track_hours`-Filter entfernt (Überstunden=0, Urlaub korrekt).
- **CS-12** Superadmin-§16-Notfall-Export ohne Rohstempel (`raw_start/end_time`, #201) → ergänzt.
- **MS-06** DSGVO-Art.15-Selbstexport ohne Schichtdaten → eigene Einteilungen + Einweisungen aufgenommen (gated, tenant-scoped).

Verifiziert: betroffene Suites grün (clock/reports/superadmin/absences/auth/year_closing/calc/self-export/lifecycle = 105+78+47 + neue Tests).

Offen (Folge-PRs): AC-11 (Sondertage in Closure/Urlaubsgenehmigung), ADM-12 (Audit-Pagination), MA-ABS-03 + ABV-12 (Frontend), 5 Doku-Findings.
