### PR TITLE
fix(uc-review AC-11): free-Sondertage in Betriebsferien + Urlaubsgenehmigung ausschließen

### DIFF
--- a/backend/app/routers/admin_vacations.py
+++ b/backend/app/routers/admin_vacations.py
@@ -10,7 +10,7 @@ from app.models import User, Absence, PublicHoliday, AbsenceType, TimeEntry, Tim
 from app.models.vacation_request import VacationRequest, VacationRequestStatus
 from app.middleware.auth import require_admin
 from app.schemas.vacation_request import VacationRequestResponse, VacationRequestReview, VacationRequestUpdate
-from app.services import calculation_service
+from app.services import calculation_service, special_days_service
 from app.services.timezone_service import today_local
 from app.routers.admin_helpers import (
     _create_audit_log,
@@ -177,6 +177,13 @@ def review_vacation_request(
         ).all()
         for h in rows:
             holidays.add(h.date)
+
+    # AC-11: 'free'-Sondertage (24./31.12.) sind soll-frei → wie Feiertage
+    # ausschließen, sonst kostet ein Urlaubsantrag über einen freien Tag fälschlich
+    # einen Urlaubstag (free+counts_as_vacation wird separat im Konto gezählt).
+    holidays |= special_days_service.free_special_days_in_range(
+        db, current_user.tenant_id, start_date, end_date
+    )
 
     # Determine working days
     dates_to_create = []

--- a/backend/app/routers/company_closures.py
+++ b/backend/app/routers/company_closures.py
@@ -10,7 +10,7 @@ from app.database import get_db
 from app.middleware.auth import get_current_user, require_admin
 from app.models import User, Absence, AbsenceType, PublicHoliday, CompanyClosure, TimeEntry, WorkingHoursChange
 from app.schemas.absence import AbsenceResponse
-from app.services import calculation_service, settings_service
+from app.services import calculation_service, settings_service, special_days_service
 from app.routers.admin_helpers import _create_audit_log
 
 router = APIRouter(prefix="/api/company-closures", tags=["company-closures"])
@@ -330,6 +330,12 @@ def create_closure(
     holidays = _get_holidays_for_range(
         db, data.start_date, data.end_date, current_user.tenant_id
     )
+    # AC-11: als 'free' konfigurierte Sondertage (24./31.12.) sind soll-frei und
+    # dürfen keine Betriebsferien-Absence bekommen (sonst kostet ein freier Tag
+    # fälschlich einen Urlaubstag) — wie Feiertage ausschließen.
+    holidays |= special_days_service.free_special_days_in_range(
+        db, current_user.tenant_id, data.start_date, data.end_date
+    )
     workdays = _get_workdays(data.start_date, data.end_date, holidays)
 
     if not workdays:
@@ -415,6 +421,12 @@ def update_closure(
     # Target workdays of the (new) range.
     holidays = _get_holidays_for_range(
         db, data.start_date, data.end_date, current_user.tenant_id
+    )
+    # AC-11: als 'free' konfigurierte Sondertage (24./31.12.) sind soll-frei und
+    # dürfen keine Betriebsferien-Absence bekommen (sonst kostet ein freier Tag
+    # fälschlich einen Urlaubstag) — wie Feiertage ausschließen.
+    holidays |= special_days_service.free_special_days_in_range(
+        db, current_user.tenant_id, data.start_date, data.end_date
     )
     workdays = _get_workdays(data.start_date, data.end_date, holidays)
 

--- a/backend/app/services/special_days_service.py
+++ b/backend/app/services/special_days_service.py
@@ -204,3 +204,23 @@ def vacation_deduction_dates_for_year(
             continue
         result.add(d)
     return result
+
+
+def free_special_days_in_range(db: Session, tenant_id, start: date, end: date) -> set:
+    """Alle als ``free`` konfigurierten Sondertage (24./31.12.) im Bereich [start, end].
+
+    AC-11: Diese Tage sind soll-frei (Tagessoll 0) → sie sind KEINE Arbeitstage und
+    dürfen daher keine Betriebsferien-/Urlaubs-Absence bekommen (sonst kostete ein
+    ohnehin freier Tag fälschlich einen Urlaubstag und reduzierte das Soll doppelt).
+    ``free`` + ``counts_as_vacation``-Tage werden separat in get_vacation_account
+    gezählt (vacation_deduction_dates) → der Ausschluss hier bleibt budget-neutral.
+    (``half_day``-Sondertage werden derzeit als voller Tag behandelt — seltener Fall,
+    separater Tech-Debt.)
+    """
+    result = set()
+    for year in range(start.year, end.year + 1):
+        config = get_special_day_config(db, tenant_id, year)
+        for d, entry in config.items():
+            if entry["mode"] == MODE_FREE and start <= d <= end:
+                result.add(d)
+    return result

--- a/backend/tests/test_closure_overtime_split.py
+++ b/backend/tests/test_closure_overtime_split.py
@@ -336,3 +336,23 @@ class TestClosureOvertimeSplitBudgetAndOffday:
         assert _types(db, emp, c["id"]) == [
             AbsenceType.VACATION, AbsenceType.VACATION, AbsenceType.OVERTIME, AbsenceType.OVERTIME,
         ]
+
+
+class TestClosureSpecialDays:
+    """AC-11: als 'free' konfigurierte Sondertage (24./31.12.) sind soll-frei und
+    bekommen KEINE Betriebsferien-Absence (sonst kostet ein freier Tag fälschlich
+    einen Urlaubstag)."""
+
+    def test_closure_skips_free_special_day(self, db, default_tenant, admin_client):
+        from app.models.system_setting import SystemSetting
+        emp = _make_user(db, "e_xmas", vacation_days=30)
+        db.add(SystemSetting(key="special_day_dec24_mode", tenant_id=DEFAULT_TENANT_ID, value="free"))
+        db.commit()
+        r = admin_client.post("/api/company-closures/", json={
+            "name": "Weihnachten", "start_date": "2025-12-22", "end_date": "2025-12-26",
+            "counts_as_vacation": True})
+        assert r.status_code == 201, r.text
+        booked = {a.date for a in db.query(Absence).filter(
+            Absence.user_id == emp.id, Absence.closure_id == uuid.UUID(r.json()["id"])).all()}
+        assert date(2025, 12, 24) not in booked, "24.12. (free) darf NICHT gebucht werden"
+        assert date(2025, 12, 22) in booked and date(2025, 12, 26) in booked


### PR DESCRIPTION
**AC-11** (UC-Review): Als `free` konfigurierte Sondertage (24./31.12.) sind soll-frei, wurden in Betriebsferien (`_get_workdays`) und Urlaubsgenehmigung (`review_vacation_request`) aber als Arbeitstage gebucht → ein ohnehin freier Tag kostete fälschlich einen Urlaubstag und reduzierte das Soll doppelt.

Fix: neuer Helper `free_special_days_in_range()`; beide Pfade schließen free-Sondertage wie Feiertage aus. **Budget-neutral** (free+counts_as_vacation wird separat in `get_vacation_account` gezählt). `half_day`-Sondertage vorerst als voller Tag (selten; Tech-Debt-Notiz im Code).

Test: Closure 22.–26.12. mit 24.12.=free → keine Absence am 24.12.; 38+74 Tests grün.
