### PR TITLE
docs(uc-review): 5 Doku-Findings (Import, Reports, DSGVO-Löschung, Urlaubsstorno, 2FA)

### DIFF
--- a/docs/handbuch/CHEATSHEET-ADMIN.md
+++ b/docs/handbuch/CHEATSHEET-ADMIN.md
@@ -57,6 +57,13 @@ Pro MA je Wochentag (Mo–Fr) optionaler **Soll-Beginn / Soll-Ende** (Bereich �
 **Benutzer öffnen** → Status „Inaktiv"
 → Daten 2 Jahre aufbewahren (§16 ArbZG)
 
+### DSGVO: Anonymisierung & endgültige Löschung (Art. 17)
+**Reihenfolge:** Deaktivieren → **14-Tage-Sperrfrist** → Anonymisieren → endgültig löschen
+- **Anonymisieren** (nach 14-Tage-Sperrfrist): entfernt persönliche Daten (Name/E-Mail/Lichtbild/2FA), **Zeiteinträge bleiben** (§16 ArbZG), Abwesenheiten weg
+- **Endgültig löschen (Purge):** vollständige Löschung – erst möglich, wenn die jüngste Aufzeichnung **≥ 730 Tage** alt ist (sonst blockiert)
+- Anonymisierte Nutzer können erst **nach 730 Tagen** endgültig gelöscht werden; alles wird im Änderungsprotokoll vermerkt
+- **Inaktive anzeigen** einblenden → System zeigt Sperrfrist + ob Anonymisierung/Löschung möglich
+
 ---
 
 ## Admin-Dashboard
@@ -80,11 +87,12 @@ Klick auf Pfeil → Detailansicht des Mitarbeiters
 
 | Bericht | Inhalt | Formate |
 |---------|--------|---------|
-| **Monatsreport** | Tägliche Einträge aller MA | Excel + CSV |
-| **Jahresreport Classic** | 12 Monate kompakt | Excel + CSV |
-| **Jahresreport Detailliert** | 365 Tage, ~5s | Excel + CSV |
+| **Monatsreport** | Tägliche Einträge aller MA | Excel (.xlsx) + ODS (.ods) + PDF (.pdf) |
+| **Jahresreport Classic** | 12 Monate kompakt | Excel (.xlsx) + ODS (.ods) |
+| **Jahresreport Detailliert** | 365 Tage, ~5s | Excel (.xlsx) + ODS (.ods) |
 
-**Exportieren:** Berichte → Typ & Zeitraum wählen → Excel oder CSV klicken
+**Exportieren:** Berichte → Typ & Zeitraum wählen → Format klicken (**PDF nur beim Monatsreport**)
+**Krankheitsdaten:** Checkbox „Krankheitsdaten einschließen" (Art. 9 DSGVO) → nimmt Krank-Daten auf, jeder solche Export wird protokolliert
 **Aufbewahrungspflicht: 2 Jahre** (§16 ArbZG)
 
 ---
@@ -99,6 +107,7 @@ Klick auf Pfeil → Detailansicht des Mitarbeiters
 
 **Genehmigen:** Grüner Button → Abwesenheiten werden automatisch eingetragen
 **Ablehnen:** Roter Button → optionalen Ablehnungsgrund eingeben
+**Stornieren:** Filter „Genehmigt" → Antrag → **„Urlaub stornieren"** (nur wenn Zeitraum noch nicht begonnen) → Abwesenheiten werden **automatisch entfernt**, Antrag wird „Zurückgezogen"
 
 ---
 

--- a/docs/handbuch/CHEATSHEET-MITARBEITER.md
+++ b/docs/handbuch/CHEATSHEET-MITARBEITER.md
@@ -153,6 +153,17 @@ Für manche Mitarbeitende führt die Praxis **keine Stundenzählung**:
 
 ---
 
+## Zwei-Faktor-Authentifizierung (2FA)
+
+Zusätzlicher Schutz per Einmal-Code aus einer Authenticator-App (z. B. Google Authenticator, Authy).
+
+**Aktivieren:** Profil → Karte „Zwei-Faktor-Authentifizierung" → **2FA aktivieren** → QR-Code scannen (oder Schlüssel manuell eintragen) → 6-stelligen Code eingeben → **Bestätigen**
+**Login:** Benutzername + Passwort → danach **6-stelligen Code** aus der App
+**Deaktivieren:** **2FA deaktivieren** → aktuelles **Passwort** bestätigen
+> App/Handy verloren? → Administrator kontaktieren
+
+---
+
 ## Häufige Probleme
 
 | Problem | Lösung |

--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -241,6 +241,27 @@ Setzen Sie den Status auf **„Inaktiv"**. Deaktivierte Mitarbeiter können sich
 
 > **Rechtlicher Hinweis (§16 ArbZG):** Arbeitszeitaufzeichnungen müssen **mindestens 2 Jahre** aufbewahrt werden. Löschen Sie daher niemals Mitarbeiterdaten – deaktivieren Sie die Konten.
 
+### DSGVO: Anonymisierung & endgültige Löschung (Art. 17)
+
+Für das **Recht auf Löschung** (Art. 17 DSGVO) gibt es zwei Stufen, die das gesetzliche Spannungsfeld zwischen Löschpflicht und der **Aufbewahrungspflicht** für Arbeitszeitaufzeichnungen (§16 ArbZG) auflösen. Beide setzen voraus, dass das Konto **zuvor deaktiviert** wurde.
+
+**Ablauf in Kürze:**
+
+1. **Deaktivieren** Sie den/die Mitarbeiter:in (Status „Inaktiv"). Damit startet eine **14-tägige Sperrfrist**.
+2. Nach Ablauf der Sperrfrist kann **anonymisiert** werden.
+3. **Endgültig löschen** lässt sich ein Datensatz erst, wenn die **730-tägige (2-Jahre-)Aufbewahrungsfrist** abgelaufen ist.
+
+| Aktion | Was passiert | Voraussetzung |
+|--------|--------------|---------------|
+| **Anonymisieren** | Personenbezogene Daten werden entfernt (Name → „Gelöschter Benutzer", Benutzername/E-Mail, Lichtbild, Abteilung, 2FA-Geheimnis). Die **Zeiteinträge bleiben** erhalten (Pflicht nach §16 ArbZG), Abwesenheiten werden gelöscht. Der Datensatz selbst und die Aufzeichnungen bleiben bestehen. | Konto deaktiviert **und** 14-tägige Sperrfrist abgelaufen |
+| **Endgültig löschen (Purge)** | **Vollständige, unwiderrufliche Löschung** des Benutzers samt aller zugehörigen Daten (Zeiteinträge, Abwesenheiten, Anträge). | Konto deaktiviert **und** die jüngste aufbewahrungspflichtige Aufzeichnung (Zeiteintrag oder Abwesenheit) ist **mindestens 730 Tage** alt |
+
+- Die **Anonymisierung** ist der Regelweg, wenn die Aufbewahrungsfrist noch läuft: Die Person wird anonymisiert, die gesetzlich aufzubewahrenden Aufzeichnungen bleiben aber erhalten.
+- Die **endgültige Löschung** wird vom System blockiert, solange noch aufbewahrungspflichtige Aufzeichnungen jünger als 730 Tage existieren. Ein anonymisierter Benutzer kann also **erst nach Ablauf der 730 Tage** endgültig gelöscht werden.
+- Beide Vorgänge werden im **Änderungsprotokoll** dokumentiert (DSGVO-Rechenschaftspflicht, Art. 5 Abs. 2).
+
+> **Wo?** Blenden Sie über **„Inaktive anzeigen"** die deaktivierten Konten ein. Das System zeigt je Konto die verbleibende Sperrfrist sowie an, ob eine Anonymisierung bzw. endgültige Löschung bereits möglich ist.
+
 ---
 
 ## 5. Abwesenheitskalender
@@ -277,14 +298,14 @@ Betriebsferien werden als gesonderte Einträge angezeigt und betreffen alle akti
 ### Monatsreport
 
 - **Inhalt:** Tägliche Zeiteinträge aller Mitarbeiter im gewählten Monat
-- **Format:** Excel (.xlsx) oder CSV
+- **Format:** Excel (.xlsx), ODS (.ods) oder PDF (.pdf)
 - **Details pro Mitarbeiter:** Datum, Wochentag, Start, Ende, Pause, Ist-Stunden, Soll-Stunden, Abwesenheitstyp, Monatssaldo
 
 **Verwendung:** Gehaltsabrechnung, monatliche Kontrolle, Dokumentation
 
 ### Jahresreport Classic
 
-- **Format:** Excel (.xlsx) oder CSV, ca. 17 KB
+- **Format:** Excel (.xlsx) oder ODS (.ods)
 - **Inhalt:** Pro Mitarbeiter eine Zeile pro Monat
 - **Details:** Soll, Ist, Saldo, Urlaubstage, Krankheitstage, Fortbildungstage
 
@@ -292,18 +313,20 @@ Betriebsferien werden als gesonderte Einträge angezeigt und betreffen alle akti
 
 ### Jahresreport Detailliert
 
-- **Format:** Excel (.xlsx) oder CSV, ca. 108 KB
+- **Format:** Excel (.xlsx) oder ODS (.ods)
 - **Inhalt:** Jeden Tag des Jahres pro Mitarbeiter
 - **Hinweis:** Generierungszeit 3–5 Sekunden
 
 **Verwendung:** Detaillierte Jahresauswertung, Steuerberater, Betriebsprüfung
 
+> **Hinweis:** Das **PDF**-Format gibt es nur für den **Monatsreport**. Die Jahresreports stehen als **Excel** und **ODS** zur Verfügung.
+
 ### Bericht erstellen
 
 1. Wählen Sie den **Berichtstyp**
 2. Wählen Sie **Monat** oder **Jahr**
-3. Optional: **„Krankheiten einstellen"** – legt fest, ab welchem Datum § 3 EntgFG (Kranktage als gearbeitete Zeit) gilt
-4. Klicken Sie auf **Excel** oder **CSV**
+3. Optional: **„Krankheitsdaten einschließen" (Art. 9 DSGVO)** – nimmt Krankheitsstunden bzw. -tage in den Export auf. Krankheitsdaten sind besondere Kategorien personenbezogener Daten (Art. 9 DSGVO); jeder Export mit dieser Option wird im **Änderungsprotokoll** vermerkt.
+4. Klicken Sie auf das gewünschte Format – **Excel (.xlsx)**, **ODS (.ods)** oder (beim Monatsreport) **PDF (.pdf)**
 5. Die Datei wird automatisch heruntergeladen
 
 > **Rechtlicher Hinweis (§16 ArbZG):** Exportieren Sie regelmäßig (mindestens jährlich) und sichern Sie die Dateien sicher für **2 Jahre**.
@@ -331,7 +354,14 @@ Oben auf der Seite befindet sich ein Toggle **„Urlaubsanträge genehmigungspfl
 2. Klicken Sie auf **„Genehmigen"** (grüner Button)
 3. Das System trägt automatisch Abwesenheiten für alle Werktage ein (Wochenenden und Feiertage ausgeschlossen)
 
-> **Achtung:** Eine Genehmigung ist unwiderruflich. Zum Stornieren müssen die erstellten Abwesenheitseinträge manuell gelöscht werden.
+### Genehmigten Antrag stornieren
+
+Eine Genehmigung lässt sich rückgängig machen, solange der Urlaubszeitraum **noch nicht begonnen hat** (Beginn in der Zukunft). Wechseln Sie dazu in den Filter **„Genehmigt"**, öffnen Sie den Antrag und klicken Sie auf **„Urlaub stornieren"**.
+
+- Die durch die Genehmigung erzeugten **Abwesenheitseinträge werden automatisch entfernt** – ein manuelles Löschen ist nicht nötig.
+- Der Antrag wird auf **„Zurückgezogen"** gesetzt und bleibt für die Nachvollziehbarkeit im Änderungsprotokoll erhalten.
+
+> **Hinweis:** Bereits begonnene oder vergangene Urlaube können nicht storniert werden. Offene Anträge können vor der Entscheidung jederzeit storniert werden.
 
 ### Antrag ablehnen
 
@@ -454,11 +484,20 @@ Klicken Sie auf das Löschen-Symbol. Die Abwesenheitseinträge werden bei allen 
 
 ## 12. Import
 
-Unter **Import** können Sie Zeiteinträge oder Abwesenheitsdaten aus externen Quellen (z. B. CSV-Dateien) in das System importieren.
+Unter **Import** übernehmen Sie historische **Zeiteinträge** aus einer **TimeRec-Datei im `.xls`-Format**. Der Bereich ist für die einmalige Datenübernahme bei der Einführung von PraxisZeit gedacht (z. B. Altdaten aus der bisherigen Zeiterfassung).
 
-Dieser Bereich ist für die initiale Datenübernahme oder die Massenbefüllung bei der Einführung von PraxisZeit vorgesehen.
+> **Wichtig:** Importiert werden **ausschließlich Zeiteinträge** (Arbeitszeiten). **Abwesenheiten** (Urlaub, Krank usw.) werden **nicht** importiert. Es gibt **keine** Vorlagendatei zum Herunterladen und es werden **keine** CSV- oder `.xlsx`-Dateien unterstützt – nur das echte `.xls`-Format (BIFF) mit einem Tabellenblatt namens **„Zeiterfassung"**.
 
-**Vorgehensweise:** Laden Sie die Vorlagendatei herunter, befüllen Sie sie gemäß der Vorgaben und laden Sie die Datei wieder hoch.
+**Anforderungen an die Datei:**
+
+- Format **`.xls`** (TimeRec-Export), maximal **5 MB**
+- Tabellenblatt **„Zeiterfassung"** mit den Spalten Datum, Tag, Total, Ein, Aus, Tagesnotiz
+
+**Vorgehensweise (Assistent in drei Schritten):**
+
+1. **Hochladen:** Wählen Sie den/die **Mitarbeiter:in** aus, dem/der die Einträge zugeordnet werden, und laden Sie die `.xls`-Datei hoch (Drag & Drop oder Klick). Klicken Sie auf **„Datei analysieren"**.
+2. **Vorschau:** Das System zeigt alle gefundenen Einträge in einer Tabelle mit Datum, Von/Bis, Pause und Netto-Stunden. **Konflikte** (bereits vorhandene Einträge am selben Tag) werden rot, **ArbZG-Warnungen** (z. B. Ruhezeit, Höchstarbeitszeit) gelb markiert. Über die Option **„Konflikte überschreiben"** entscheiden Sie, ob vorhandene Einträge ersetzt werden – andernfalls werden sie übersprungen. Klicken Sie auf **„Import bestätigen"**.
+3. **Ergebnis:** Sie sehen, wie viele Einträge importiert, überschrieben oder übersprungen wurden sowie die ArbZG-Warnungen. Der Import wird im **Änderungsprotokoll** dokumentiert.
 
 ---
 

--- a/docs/handbuch/HANDBUCH-MITARBEITER.md
+++ b/docs/handbuch/HANDBUCH-MITARBEITER.md
@@ -432,6 +432,22 @@ Klicken Sie in der Karte **Passwort ändern** auf **Ändern**.
 
 > **Sicherheitshinweis:** Nach einer Passwortänderung werden alle anderen aktiven Sitzungen automatisch abgemeldet.
 
+### Zwei-Faktor-Authentifizierung (2FA)
+
+Sie können Ihr Konto zusätzlich mit einem Einmal-Code aus einer **Authenticator-App** (z. B. Google Authenticator, Authy) absichern. Ist 2FA aktiv, benötigen Sie beim Login neben Benutzername und Passwort einen wechselnden 6-stelligen Code.
+
+**2FA aktivieren** (Karte **Zwei-Faktor-Authentifizierung** im Profil):
+
+1. Klicken Sie auf **„2FA aktivieren"**.
+2. **Scannen Sie den angezeigten QR-Code** mit Ihrer Authenticator-App – alternativ tragen Sie den angezeigten Schlüssel manuell ein.
+3. Geben Sie den **6-stelligen Code** aus der App ein und bestätigen Sie mit **„Bestätigen & 2FA aktivieren"**.
+
+**Login mit aktiver 2FA:** Geben Sie wie gewohnt Benutzername und Passwort ein. Anschließend werden Sie nach dem **6-stelligen Code** aus Ihrer Authenticator-App gefragt.
+
+**2FA deaktivieren:** Klicken Sie auf **„2FA deaktivieren"** und bestätigen Sie zur Sicherheit Ihr **aktuelles Passwort**.
+
+> **Tipp:** Bewahren Sie Ihr Smartphone bzw. die Authenticator-App sicher auf. Verlieren Sie den Zugang zur App, wenden Sie sich an Ihren Administrator – er kann Ihr Konto zurücksetzen.
+
 ### Weitere Einstellungen
 
 Unter **Weitere Einstellungen** (aufklappbar) können Sie persönliche Darstellungsoptionen anpassen, z. B. Ihre Kalenderfarbe im Teamkalender.

--- a/frontend/src/components/DocViewer.tsx
+++ b/frontend/src/components/DocViewer.tsx
@@ -366,6 +366,7 @@ export const handbuchMitarbeiterSections: AccordionItem[] = [
     content: (
       <div className="space-y-2">
         <p>Unter <strong>Profil</strong> sehen Sie Ihre persönlichen Daten. Über <strong>Passwort ändern → Ändern</strong> setzen Sie ein neues Passwort (mind. 10 Zeichen, Groß-/Kleinbuchstabe, Ziffer).</p>
+        <p><strong>Zwei-Faktor-Authentifizierung (2FA):</strong> Schützen Sie Ihr Konto zusätzlich mit einem Einmal-Code aus einer Authenticator-App (z. B. Google Authenticator, Authy). <strong>Aktivieren:</strong> Karte „Zwei-Faktor-Authentifizierung" → „2FA aktivieren" → QR-Code scannen (oder Schlüssel manuell eintragen) → 6-stelligen Code bestätigen. <strong>Login:</strong> nach Benutzername + Passwort wird der 6-stellige Code abgefragt. <strong>Deaktivieren:</strong> „2FA deaktivieren" → aktuelles Passwort bestätigen. Bei verlorenem Zugang zur App hilft Ihr Administrator.</p>
         <p>Persönliche Daten wie Name und Wochenstunden können nur vom Administrator geändert werden. Unter <strong>Weitere Einstellungen</strong> finden Sie optionale Darstellungsoptionen.</p>
       </div>
     ),
@@ -406,14 +407,16 @@ export const handbuchAdminSections: AccordionItem[] = [
         <p><strong>Soll-Arbeitszeiten (Arbeitszeit-Fenster):</strong> Im Benutzerformular können Sie pro MA und Wochentag Soll-Beginn und Soll-Ende hinterlegen. Zeiten außerhalb des Fensters (abzüglich Puffer) werden nicht angerechnet; der gestempelte Rohwert bleibt gespeichert (§16). Der systemweite Puffer (Standard 15 Min.) ist unter <strong>Einstellungen → Arbeitszeit-Fenster Puffer</strong> konfigurierbar. Opt-in: ohne Soll-Zeiten kein Eingriff. MA mit deaktivierter Stundenzählung sind ausgenommen.</p>
         <p><strong>Kalenderfarbe:</strong> Im Benutzerformular können Sie die Kalenderfarbe aus einer Palette für jede:n Mitarbeiter:in vorgeben (Badge-Ring im Teamkalender); der/die Mitarbeiter:in kann sie auch selbst im Profil ändern.</p>
         <p><strong>Monatsjournal:</strong> Das Buch-Symbol in der Aktionsspalte öffnet das Monatsjournal des/der Mitarbeitenden. Die Überschrift trägt den Namen – <strong>„Monatsjournal: Vorname Nachname"</strong> –, damit beim Wechsel zwischen Personen sofort klar ist, wessen Journal angezeigt wird.</p>
+        <p><strong>DSGVO: Anonymisierung &amp; endgültige Löschung (Art. 17):</strong> Ablauf <strong>Deaktivieren → 14-Tage-Sperrfrist → Anonymisieren → endgültig löschen</strong>. <strong>Anonymisieren</strong> (nach der Sperrfrist) entfernt persönliche Daten (Name, E-Mail, Lichtbild, 2FA); die <strong>Zeiteinträge bleiben</strong> erhalten (§16 ArbZG), Abwesenheiten werden gelöscht. <strong>Endgültig löschen (Purge)</strong> löscht den Benutzer samt aller Daten unwiderruflich – erst möglich, wenn die jüngste aufbewahrungspflichtige Aufzeichnung <strong>mindestens 730 Tage</strong> alt ist (sonst blockiert das System). Anonymisierte Nutzer können also erst nach Ablauf der 730 Tage endgültig gelöscht werden; beide Vorgänge werden im Änderungsprotokoll vermerkt.</p>
       </div>
     ),
   },
   {
-    title: '3. Berichte & Excel-Exporte',
+    title: '3. Berichte & Exporte',
     content: (
       <div className="space-y-2">
-        <p>Unter <strong>Berichte</strong> stehen drei Export-Typen bereit: <strong>Monatsreport</strong> (Gehaltsabrechnung), <strong>Jahresreport Classic</strong> (12 Monate kompakt) und <strong>Jahresreport Detailliert</strong> (365 Tage, für Steuerberater). Jeder Report ist als Excel oder CSV verfügbar.</p>
+        <p>Unter <strong>Berichte</strong> stehen drei Export-Typen bereit: <strong>Monatsreport</strong> (Gehaltsabrechnung), <strong>Jahresreport Classic</strong> (12 Monate kompakt) und <strong>Jahresreport Detailliert</strong> (365 Tage, für Steuerberater). Jeder Report ist als <strong>Excel (.xlsx)</strong> und <strong>ODS (.ods)</strong> verfügbar; den Monatsreport gibt es zusätzlich als <strong>PDF (.pdf)</strong>.</p>
+        <p>Mit der Checkbox <strong>„Krankheitsdaten einschließen" (Art. 9 DSGVO)</strong> nehmen Sie Krankheitsstunden/-tage mit in den Export auf. Krankheitsdaten sind besondere Kategorien personenbezogener Daten; jeder Export mit dieser Option wird im Änderungsprotokoll vermerkt.</p>
         <p>Aufbewahrungspflicht: <strong>2 Jahre</strong> (§16 ArbZG). Regelmäßig exportieren und sicher archivieren.</p>
       </div>
     ),
@@ -431,7 +434,7 @@ export const handbuchAdminSections: AccordionItem[] = [
     title: '5. Urlaubsanträge & Betriebsferien',
     content: (
       <div className="space-y-2">
-        <p><strong>Urlaubsanträge:</strong> Toggle „Genehmigungspflicht" aktiviert den Workflow. Anträge erscheinen als „Offen" → Genehmigen (grün) oder Ablehnen (rot, optional Grund).</p>
+        <p><strong>Urlaubsanträge:</strong> Toggle „Genehmigungspflicht" aktiviert den Workflow. Anträge erscheinen als „Offen" → Genehmigen (grün) oder Ablehnen (rot, optional Grund). <strong>Stornieren:</strong> Im Filter „Genehmigt" lässt sich ein genehmigter Antrag über <strong>„Urlaub stornieren"</strong> rückgängig machen, solange der Zeitraum noch nicht begonnen hat – die erzeugten Abwesenheiten werden dabei <strong>automatisch entfernt</strong>, der Antrag wird auf „Zurückgezogen" gesetzt.</p>
         <p><strong>Betriebsferien:</strong> Abwesenheiten → Tab „Betriebsferien" → Neue Betriebsferien. Alle aktiven Mitarbeiter mit der Option „Nimmt an Betriebsferien teil" (Standard, rollenunabhängig) erhalten automatisch Abwesenheitseinträge (kein Urlaubsabzug); Tage außerhalb des Beschäftigungszeitraums (noch nicht eingetreten / bereits ausgetreten) werden übersprungen. Nachträglich Berechtigte: Option setzen – die Einträge werden automatisch für laufende und künftige Betriebsferien nachgetragen. Beim Löschen werden alle Einträge entfernt.</p>
         <p className="text-gray-700"><strong>Betriebsferien länger als der Jahresurlaub:</strong> Sind als Urlaub zählende Betriebsferien länger als das Resturlaub-Budget, entstehen standardmäßig <strong>Minus-Urlaubstage</strong>. Unter <strong>Einstellungen → „Betriebsferien &amp; Urlaub"</strong> aktivieren Sie optional <strong>„Überzählige Betriebsferien als Überstundenabbau"</strong>: dann wird zuerst der Urlaub aufgezehrt und die überzähligen Tage werden als Überstundenausgleich gebucht (Konto darf ins Minus) – statt Minus-Urlaub. Global, Standard <strong>aus</strong>. Wirkt beim Anlegen/erneuten Speichern – für bestehende Betriebsferien einmal öffnen und neu speichern.</p>
         <p className="text-gray-700"><strong>Urlaubsberechnung (Tagesprinzip, §3 BUrlG):</strong> Urlaub wird nach Arbeitstagen geführt – ein freier Arbeitstag = <strong>1 Urlaubstag</strong>, unabhängig von Tagesstunden und Wochentag (auch bei individuellen Tagesstunden). Jahresanspruch anteilig: <code>30 × Arbeitstage ÷ 5</code> (überschreibbar beim Anlegen). Verbrauch wird tagebasiert gezählt, intern gespeicherte Stunden dienen nur der Soll-/Ist-Berechnung.</p>


### PR DESCRIPTION
Behebt die 5 Doku-Findings aus dem UC-Review (Handbücher + In-App-Hilfe konsistent, jeweils gegen den Code verifiziert):

- **IMP-01 (HIGH):** Handbuch-Import-Abschnitt beschrieb CSV/Vorlage/Abwesenheiten → korrekt: TimeRec-`.xls` (Sheet „Zeiterfassung"), nur Zeiteinträge, max. 5 MB, 3-Schritt-Wizard mit Vorschau (Konflikte/ArbZG-Warnungen) + Überschreiben.
- **ABV-07 (HIGH):** DSGVO Art. 17 (Deaktivieren → 14-Tage-Sperrfrist → Anonymisieren vs. endgültige Löschung → 730-Tage-Aufbewahrung) neu dokumentiert (HANDBUCH-ADMIN + Cheatsheet + DocViewer).
- **AUTH-02 (MEDIUM):** 2FA/TOTP dokumentiert (Aktivieren/Login/Deaktivieren) in HANDBUCH-MITARBEITER + Cheatsheet + DocViewer.
- **RPT-05 (MEDIUM):** „CSV"-Falschangabe entfernt → Exportformate XLSX/ODS/PDF (PDF nur Monatsreport) + Hinweis Krankheitsdaten-Checkbox (Art. 9).
- **AC-08 (MEDIUM):** Falsche „Genehmigung unwiderruflich"-Aussage ersetzt → Urlaub stornierbar (Absencen werden automatisch entfernt).

tsc grün; nur Doku + DocViewer, kein Anwendungscode.
