### PR TITLE
Release 1.12.2

### DIFF
--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.12.1"
+APP_VERSION = "1.12.2"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.12.1",
+  "version": "1.12.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.12.1"
+APP_VERSION="1.12.2"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
PATCH-Release — UC-Review-Härtung dieser Session (drei Review-Runden, alle Findings ≥/≤ medium gefixt + adversarial verifiziert). **Keine Migration** (alembic bleibt 057).

**Enthalten (bereits via #346–#352 auf master gemergt, hier nur der Version-Bump):**
- UC-Inventar (177 UCs) + durchsuchbares HTML-Verzeichnis (#346)
- Runde 1 (16 Findings ≥ medium): §5-same-day, Approval-Bypass, §18-Konsistenz, change_password-Cookie, Jahresabschluss untracked, §16-Rohstempel, DSGVO-Schichtexport, free-Sondertage (Closure+Urlaub), Doku (2FA/Import/DSGVO-Löschung/Storno/CSV), Frontend (Gründe-Picker, weekly_hours-Hinweis, Audit-Pagination) (#347–#350)
- Runde 2 (3 med + 3 low): AC-11-Direktpfad, Audit-Keyset-Tiebreaker, FocusTrap-Dialog, SP-04-Doku, UC-Doku aktualisiert (#351)
- Runde 3 (ArbZG/DSGVO, 2 med + 1 low): §5 gegen Rohstempel, Purge-Audit-Hash-Recompute, reason_id in Exporten (#352)

**QA:** Backend-Suite 1141 passed · validate-release 5/5 (PG 18.4) · Artefakt-Integrität (6 Artefakte, kein setup.exe im ZIP, PG-SHA==Pin, Bundle=1.12.2) · **.131 native Update 1.12.1→1.12.2 mit Daten-Erhalt + echtem Login** · lokaler Docker echter Login. Windows-Emulator übersprungen (0 Installer-Skript-Änderungen seit v1.12.0).
