### PR TITLE
fix(#314): Betriebsferien-Urlaub kalenderchronologisch über alle Schließungen verteilen

### DIFF
--- a/backend/app/routers/company_closures.py
+++ b/backend/app/routers/company_closures.py
@@ -253,6 +253,136 @@ def _create_closure_absences(
     return affected
 
 
+def _resplit_year_closures(db: Session, tenant_id, year: int, current_user: User) -> None:
+    """#314 follow-up: re-classify ALL split-able Betriebsferien absences of a
+    year into VACATION/OVERTIME in CALENDAR order.
+
+    ``_create_closure_absences`` decides VACATION-vs-OVERTIME per closure at save
+    time against the then-current remaining budget. Entering the December closure
+    BEFORE the (calendar-earlier) June closure therefore let December "inherit"
+    the vacation budget and pushed June onto OVERTIME — the booking followed the
+    INPUT order, not the calendar. This second pass fixes that surgically: it
+    walks ALL of the year's closure days in DATE order against the gross annual
+    budget minus all non-closure vacation consumption (private vacation + free
+    special days) and flips only ``absence.type``. The surplus over the budget
+    thus lands on the LAST closure of the year (never minus-vacation; once the
+    budget is exhausted the walk switches to OVERTIME).
+
+    Only ``absence.type`` of existing closure absences is mutated — no day is
+    created or deleted, so every guard in ``_create_closure_absences`` (#298
+    employment window, off-day skip, AC-11 free special days, #290 logged-work,
+    foreign-absence skip, audit log, half_day, closure_id, hours) stays intact.
+
+    Runs only when the global ``closure_overtime_after_vacation`` toggle is on
+    (otherwise legacy all-VACATION). Untracked employees (track_hours=False) have
+    no overtime account and are left as VACATION (mirrors the emp_split guard).
+    F-026: every query is tenant-scoped.
+    """
+    if not settings_service.get_bool_setting(
+        db, "closure_overtime_after_vacation", tenant_id, False
+    ):
+        return
+
+    year_start = date(year, 1, 1)
+    year_end = date(year, 12, 31)
+
+    # Split-able closures = vacation closures of this tenant that touch the year.
+    closures = db.query(CompanyClosure).filter(
+        CompanyClosure.tenant_id == tenant_id,
+        CompanyClosure.counts_as_vacation == True,
+        CompanyClosure.start_date <= year_end,
+        CompanyClosure.end_date >= year_start,
+    ).all()
+    if not closures:
+        return
+    closure_ids = [c.id for c in closures]
+
+    # All generated absences of those closures that fall in this year.
+    closure_absences = db.query(Absence).filter(
+        Absence.tenant_id == tenant_id,
+        Absence.closure_id.in_(closure_ids),
+        Absence.date >= year_start,
+        Absence.date <= year_end,
+    ).all()
+    if not closure_absences:
+        return
+
+    by_user: dict = {}
+    for a in closure_absences:
+        by_user.setdefault(a.user_id, []).append(a)
+
+    users = {
+        u.id: u
+        for u in db.query(User).filter(
+            User.id.in_(list(by_user.keys())),
+            User.tenant_id == tenant_id,
+        ).all()
+    }
+
+    # Free special days (24./31.12.) that cost a vacation day this year — same
+    # source get_vacation_account uses, so the budget bookkeeping matches.
+    holiday_dates_year = {
+        h.date
+        for h in db.query(PublicHoliday).filter(
+            PublicHoliday.year == year,
+            PublicHoliday.tenant_id == tenant_id,
+        ).all()
+    }
+    deduction_dates = special_days_service.vacation_deduction_dates_for_year(
+        db, tenant_id, year, holiday_dates_year
+    )
+
+    for user_id, absences in by_user.items():
+        employee = users.get(user_id)
+        # Untracked MA: no overtime account → keep legacy VACATION. Missing user
+        # (shouldn't happen) → leave untouched.
+        if employee is None or not employee.track_hours:
+            continue
+
+        # Gross annual budget (pro-rata + carryover), independent of bookings.
+        budget = float(
+            calculation_service.get_vacation_account(db, employee, year)["budget_days"]
+        )
+
+        # Non-closure vacation consumption (private vacation + free special days)
+        # is ALL deducted up front, so the closure days only ever take the
+        # REMAINING budget — even vacation booked LATER in the year (e.g. summer)
+        # reduces the closure budget (#314 reopened: NIE Minus-Urlaub).
+        private = db.query(Absence).filter(
+            Absence.user_id == user_id,
+            Absence.tenant_id == tenant_id,
+            Absence.type == AbsenceType.VACATION,
+            Absence.closure_id.is_(None),
+            Absence.date >= year_start,
+            Absence.date <= year_end,
+        ).all()
+        private_dates = {a.date for a in private}
+        consumed = 0.0
+        for a in private:
+            consumed += 0.5 if a.half_day else 1.0
+        for d in deduction_dates:
+            if d in private_dates:
+                continue  # already counted via a real VACATION absence
+            if employee.first_work_day and d < employee.first_work_day:
+                continue
+            if employee.last_work_day and d > employee.last_work_day:
+                continue
+            consumed += 1.0
+
+        closure_budget = budget - consumed
+
+        # Walk the closure days in CALENDAR order: VACATION while the remaining
+        # closure budget covers a full day, OVERTIME afterwards. The surplus
+        # therefore lands on the latest closure of the year.
+        used = 0.0
+        for a in sorted(absences, key=lambda x: x.date):
+            if closure_budget - used >= 1.0:
+                a.type = AbsenceType.VACATION
+                used += 1.0
+            else:
+                a.type = AbsenceType.OVERTIME
+
+
 @router.get("/", response_model=List[CompanyClosureResponse])
 def list_closures(
     skip: int = 0,
@@ -352,6 +482,17 @@ def create_closure(
     ).all()
 
     affected = _create_closure_absences(db, closure, workdays, employees, current_user)
+
+    # #314 follow-up: re-classify ALL of the year's vacation-closure absences in
+    # CALENDAR order so the budget is consumed earliest-first across closures
+    # (surplus → OVERTIME on the LAST closure), independent of the order the
+    # closures were entered. Only for a vacation closure with the toggle on.
+    if data.counts_as_vacation and settings_service.get_bool_setting(
+        db, "closure_overtime_after_vacation", current_user.tenant_id, False
+    ):
+        db.flush()  # make the freshly created absences visible to the re-split queries
+        for yr in range(data.start_date.year, data.end_date.year + 1):
+            _resplit_year_closures(db, current_user.tenant_id, yr, current_user)
 
     db.commit()
     db.refresh(closure)
@@ -497,6 +638,15 @@ def update_closure(
     _create_closure_absences(
         db, closure, workdays, employees, current_user, delete_time_entries=False
     )
+
+    # #314 follow-up: re-split the whole year in CALENDAR order (see create_closure)
+    # so editing/re-saving ONE closure re-classifies ALL closures of the year
+    # correctly (surplus → OVERTIME on the latest one). ``split_active`` already
+    # encodes "vacation closure AND toggle on".
+    if split_active:
+        db.flush()
+        for yr in range(data.start_date.year, data.end_date.year + 1):
+            _resplit_year_closures(db, current_user.tenant_id, yr, current_user)
 
     db.commit()
     db.refresh(closure)

--- a/backend/tests/test_closure_overtime_split.py
+++ b/backend/tests/test_closure_overtime_split.py
@@ -338,6 +338,129 @@ class TestClosureOvertimeSplitBudgetAndOffday:
         ]
 
 
+def _closure_types_by_date(db, user, closure_id):
+    return {a.date: a.type for a in db.query(Absence).filter(
+        Absence.user_id == user.id, Absence.closure_id == uuid.UUID(closure_id),
+    ).all()}
+
+
+class TestClosureCalendarOrderResplit:
+    """#314 Folge-Fix: Urlaub wird über ALLE Betriebsferien eines Jahres in
+    KALENDERreihenfolge verteilt — unabhängig von der Eingabe-/Speicherreihenfolge.
+    Der Überstundenausgleich landet auf der LETZTEN Schließung des Jahres, nie auf
+    einer kalendarisch früheren, nur weil sie zuerst gespeichert wurde."""
+
+    def test_overflow_lands_on_latest_closure_not_input_order(self, db, default_tenant, admin_client):
+        # Budget 30. Lege ZUERST die Dezember-Ferien an, DANN die kalendarisch
+        # frühere Juni-Ferien, sodass die Summe das Budget übersteigt.
+        emp = _make_user(db, "e_cal", vacation_days=30)
+        _set_toggle(db, True)
+        r_dec = admin_client.post("/api/company-closures/", json={
+            "name": "Dezember", "start_date": "2025-12-01", "end_date": "2025-12-31",
+            "counts_as_vacation": True})
+        assert r_dec.status_code == 201, r_dec.text
+        r_jun = admin_client.post("/api/company-closures/", json={
+            "name": "Juni", "start_date": "2025-06-09", "end_date": "2025-06-20",
+            "counts_as_vacation": True})
+        assert r_jun.status_code == 201, r_jun.text
+
+        jun = _closure_types_by_date(db, emp, r_jun.json()["id"])
+        dec = _closure_types_by_date(db, emp, r_dec.json()["id"])
+
+        # Juni (kalendarisch früher) ist KOMPLETT Urlaub, obwohl zuletzt angelegt.
+        assert set(jun.values()) == {AbsenceType.VACATION}
+        assert AbsenceType.OVERTIME not in jun.values()
+        # Der Überhang über das 30-Tage-Budget landet als OVERTIME im DEZEMBER.
+        assert AbsenceType.OVERTIME in dec.values()
+        # Kein Minus-Urlaub: genau das Budget (30) ist als Urlaub gebucht.
+        total = len(jun) + len(dec)
+        total_vac = sum(1 for t in list(jun.values()) + list(dec.values())
+                        if t == AbsenceType.VACATION)
+        total_ot = sum(1 for t in list(jun.values()) + list(dec.values())
+                       if t == AbsenceType.OVERTIME)
+        assert total > 30, "Testaufbau muss das Budget übersteigen"
+        assert total_vac == 30
+        assert total_ot == total - 30
+        # Die OVERTIME-Tage im Dezember sind die chronologisch LETZTEN.
+        dec_vac_dates = [d for d, t in dec.items() if t == AbsenceType.VACATION]
+        dec_ot_dates = [d for d, t in dec.items() if t == AbsenceType.OVERTIME]
+        assert min(dec_ot_dates) > max(dec_vac_dates)
+
+    def test_resave_is_idempotent(self, db, default_tenant, admin_client):
+        # Erneutes Speichern (PUT) einer der Schließungen ohne inhaltliche Änderung
+        # lässt die Typen aller Schließungen des Jahres unverändert.
+        emp = _make_user(db, "e_idem", vacation_days=30)
+        _set_toggle(db, True)
+        r_dec = admin_client.post("/api/company-closures/", json={
+            "name": "Dezember", "start_date": "2025-12-01", "end_date": "2025-12-31",
+            "counts_as_vacation": True})
+        assert r_dec.status_code == 201, r_dec.text
+        r_jun = admin_client.post("/api/company-closures/", json={
+            "name": "Juni", "start_date": "2025-06-09", "end_date": "2025-06-20",
+            "counts_as_vacation": True})
+        assert r_jun.status_code == 201, r_jun.text
+
+        jun_before = _closure_types_by_date(db, emp, r_jun.json()["id"])
+        dec_before = _closure_types_by_date(db, emp, r_dec.json()["id"])
+
+        # Juni unverändert erneut speichern.
+        r = admin_client.put(f"/api/company-closures/{r_jun.json()['id']}", json={
+            "name": "Juni", "start_date": "2025-06-09", "end_date": "2025-06-20",
+            "counts_as_vacation": True})
+        assert r.status_code == 200, r.text
+
+        jun_after = _closure_types_by_date(db, emp, r_jun.json()["id"])
+        dec_after = _closure_types_by_date(db, emp, r_dec.json()["id"])
+        assert jun_after == jun_before
+        assert dec_after == dec_before
+
+    def test_untracked_employee_not_resplit(self, db, default_tenant, admin_client):
+        # Ein untracked MA (track_hours=False) hat kein Überstundenkonto → der
+        # Resplit darf ihn NICHT anfassen; seine Closure-Tage bleiben VACATION,
+        # auch wenn die Summe das (0-)Budget weit übersteigt.
+        emp = _make_user(db, "e_unt_cal", vacation_days=0, track_hours=False)
+        _set_toggle(db, True)
+        r_dec = admin_client.post("/api/company-closures/", json={
+            "name": "Dezember", "start_date": "2025-12-01", "end_date": "2025-12-31",
+            "counts_as_vacation": True})
+        assert r_dec.status_code == 201, r_dec.text
+        r_jun = admin_client.post("/api/company-closures/", json={
+            "name": "Juni", "start_date": "2025-06-09", "end_date": "2025-06-20",
+            "counts_as_vacation": True})
+        assert r_jun.status_code == 201, r_jun.text
+
+        all_types = [a.type for a in db.query(Absence).filter(
+            Absence.user_id == emp.id).all()]
+        assert all_types, "MA sollte Closure-Absencen haben"
+        assert set(all_types) == {AbsenceType.VACATION}
+        assert AbsenceType.OVERTIME not in all_types
+
+    def test_free_special_day_reduces_closure_budget(self, db, default_tenant, admin_client):
+        # Ein als 'free'+counts_as_vacation konfigurierter Sondertag (24.12.) zehrt
+        # einen Urlaubstag mit → reduziert das Budget für eine späte Dezember-Ferien:
+        # bei Budget 4 und 4 gebuchten Closure-Tagen wird ein Tag OVERTIME.
+        from app.models.system_setting import SystemSetting
+        emp = _make_user(db, "e_xmas_ot", vacation_days=4)
+        db.add(SystemSetting(key="special_day_dec24_mode",
+                             tenant_id=DEFAULT_TENANT_ID, value="free"))
+        db.add(SystemSetting(key="special_day_dec24_counts_as_vacation",
+                             tenant_id=DEFAULT_TENANT_ID, value="true"))
+        db.commit()
+        _set_toggle(db, True)
+        r = admin_client.post("/api/company-closures/", json={
+            "name": "Weihnachten", "start_date": "2025-12-22", "end_date": "2025-12-26",
+            "counts_as_vacation": True})
+        assert r.status_code == 201, r.text
+        by_date = _closure_types_by_date(db, emp, r.json()["id"])
+        # 24.12. (free) wird nicht gebucht.
+        assert date(2025, 12, 24) not in by_date
+        # 24.12. verbraucht 1 Budget-Tag → nur 3 Closure-Tage Urlaub, der 4. OVERTIME.
+        assert by_date[date(2025, 12, 22)] == AbsenceType.VACATION
+        assert by_date[date(2025, 12, 23)] == AbsenceType.VACATION
+        assert by_date[date(2025, 12, 25)] == AbsenceType.VACATION
+        assert by_date[date(2025, 12, 26)] == AbsenceType.OVERTIME
+
+
 class TestClosureSpecialDays:
     """AC-11: als 'free' konfigurierte Sondertage (24./31.12.) sind soll-frei und
     bekommen KEINE Betriebsferien-Absence (sonst kostet ein freier Tag fälschlich


### PR DESCRIPTION
Behebt philvdbs Mehrfach-Betriebsferien-Befund auf #314: Urlaub wurde über mehrere Betriebsferien in **Speicher-/Eingabereihenfolge** statt **kalenderchronologisch** verteilt → die Überstunden landeten auf der zuerst eingegebenen statt der letzten Schließung im Jahr (z. B. Pfingsten-Überstunden im Juni, weil Weihnachten zuerst eingegeben wurde).

**Fix:** Neue Funktion `_resplit_year_closures(...)` stuft nach jedem Anlegen/Ändern **alle** Urlaubs-Betriebsferien eines Jahres in **Kalenderreihenfolge** neu ein (nur `absence.type`-Flip VACATION↔OVERTIME). Budget = Brutto-Jahresbudget − gesamter Nicht-Closure-Verbrauch (privater Urlaub + free-Sondertage); Closure-Tage füllen den Rest chronologisch → Überhang als Überstundenausgleich auf der **letzten** Schließung, nie Minus-Urlaub. Alle bestehenden Guards (#298 Beschäftigungsfenster, off-day-Skip, AC-11 free-Sondertage, #290 geloggte Arbeit, Audit) bleiben unberührt. Untracked MA (kein Überstundenkonto) bleiben Urlaub. Gated auf `closure_overtime_after_vacation`, tenant-scoped (F-026).

**Bewusst konservativ:** der gesamte private Jahresurlaub reduziert das Closure-Budget (datumsunabhängig), damit die bestehende „nie Minus-Urlaub"-Garantie auch bei später im Jahr gebuchtem Urlaub hält (Bestandstest `test_future_vacation_consumes_remaining_then_overtime_no_minus`).

**Tests:** 4 neue (`TestClosureCalendarOrderResplit`: Kalenderreihenfolge unabhängig von Eingabe, Idempotenz, untracked, free-Sondertag) + 95 betroffene Closure-/Urlaubs-Tests grün.
