### PR TITLE
fix: 8 Logik-/Implementierungs-/Security-Lücken (Zeiterfassung/Anträge/Scheduler/Auth/Journal/Schichtplan)

### DIFF
--- a/backend/alembic/versions/2026_06_28_1200-059_cr_absence_ondelete.py
+++ b/backend/alembic/versions/2026_06_28_1200-059_cr_absence_ondelete.py
@@ -1,0 +1,36 @@
+"""Fix #1: change_requests.absence_id FK → ON DELETE SET NULL.
+
+Without an ondelete rule, deleting an absence that is referenced by a
+ChangeRequest fails with a ForeignKeyViolation (500) on Postgres — this breaks
+absence-delete/-change CR approval, direct delete_absence, the SICK vacation
+refund and the DSGVO purge. SET NULL mirrors change_requests.time_entry_id.
+
+Revision ID: 059_cr_absence_ondelete
+Revises: 058_carryover_source
+Create Date: 2026-06-28
+"""
+from alembic import op
+
+
+revision = '059_cr_absence_ondelete'
+down_revision = '058_carryover_source'
+branch_labels = None
+depends_on = None
+
+_FK = 'fk_change_requests_absence_id'
+
+
+def upgrade() -> None:
+    op.drop_constraint(_FK, 'change_requests', type_='foreignkey')
+    op.create_foreign_key(
+        _FK, 'change_requests', 'absences',
+        ['absence_id'], ['id'], ondelete='SET NULL',
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(_FK, 'change_requests', type_='foreignkey')
+    op.create_foreign_key(
+        _FK, 'change_requests', 'absences',
+        ['absence_id'], ['id'],
+    )

--- a/backend/app/models/change_request.py
+++ b/backend/app/models/change_request.py
@@ -35,8 +35,14 @@ class ChangeRequest(Base):
     # Discriminator: 'time_entry' or 'absence'
     entry_kind = Column(String(20), nullable=False, server_default='time_entry')  # 'time_entry' | 'absence'
 
-    # Reference to existing absence (for absence CRs)
-    absence_id = Column(UUID(as_uuid=True), ForeignKey("absences.id"), nullable=True, index=True)
+    # Reference to existing absence (for absence CRs).
+    # Fix #1: ondelete="SET NULL" — without it, deleting an absence referenced by
+    # a ChangeRequest raises a ForeignKeyViolation (500) on Postgres, breaking
+    # absence deletion / refund / DSGVO purge. Mirrors time_entry_id above.
+    absence_id = Column(
+        UUID(as_uuid=True), ForeignKey("absences.id", ondelete="SET NULL"),
+        nullable=True, index=True,
+    )
 
     # Absence proposed/original fields
     proposed_absence_type = Column(String(20), nullable=True)

--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -589,14 +589,22 @@ def create_absence(
     for absence in created_absences:
         db.refresh(absence)
 
-    # Fix #3: a freshly booked VACATION reduces the remaining budget that the
-    # #314 Betriebsferien split reserves up front. Re-split the affected years so
-    # a closure day can flip VACATION<->OVERTIME accordingly. Tenant-wide per
-    # year (idempotent for unaffected users); only when the global toggle is on.
-    if (absence_data.type == AbsenceType.VACATION and created_absences
+    # Fix #3 / Fix #8: changes to a user's private vacation shift the remaining
+    # budget that the #314 Betriebsferien split reserves up front. Re-split the
+    # affected years so a closure day can flip VACATION<->OVERTIME accordingly:
+    #  - a freshly booked VACATION (consumes budget), and
+    #  - a SICK refund that DELETED overlapping VACATION (frees budget → a closure
+    #    OVERTIME day may flip back to VACATION).
+    # Tenant-wide per year (idempotent for unaffected users); toggle-gated.
+    _resplit_years: set = set()
+    if absence_data.type == AbsenceType.VACATION and created_absences:
+        _resplit_years |= {a.date.year for a in created_absences}
+    if refunded_vacation_dates:
+        _resplit_years |= {d.year for d in refunded_vacation_dates}
+    if (_resplit_years
             and settings_service.get_bool_setting(
                 db, "closure_overtime_after_vacation", target_user.tenant_id, False)):
-        for yr in {a.date.year for a in created_absences}:
+        for yr in _resplit_years:
             resplit_year_closures(db, target_user.tenant_id, yr)
         db.commit()
         for absence in created_absences:
@@ -649,7 +657,24 @@ def delete_absence(
         ChangeRequest.tenant_id == current_user.tenant_id,
     ).update({ChangeRequest.absence_id: None}, synchronize_session=False)
 
+    # Fix #8: snapshot the year/type/tenant BEFORE the delete (attributes expire
+    # after flush) so we can re-split the closures of the affected year.
+    _was_vacation = absence.type == AbsenceType.VACATION
+    _abs_year = absence.date.year
+    _abs_tenant = absence.tenant_id
+
     db.delete(absence)
+    db.flush()
+
+    # Fix #8: deleting a VACATION absence frees budget that the #314 Betriebsferien
+    # split reserves up front → a closure OVERTIME day may flip back to VACATION.
+    # Re-split the affected year (toggle-gated; flush above ensures the deleted
+    # day no longer counts in the budget snapshot).
+    if (_was_vacation
+            and settings_service.get_bool_setting(
+                db, "closure_overtime_after_vacation", _abs_tenant, False)):
+        resplit_year_closures(db, _abs_tenant, _abs_year)
+
     db.commit()
 
     return None

--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -8,7 +8,7 @@ from app.services.timezone_service import today_local
 from app.database import get_db
 from app.models import (
     User, Absence, AbsenceType, UserRole, PublicHoliday, TimeEntry, TimeEntryAuditLog,
-    AbsenceReason, AbsenceReasonBehavior, BEHAVIOR_TO_ABSENCE_TYPE,
+    AbsenceReason, AbsenceReasonBehavior, BEHAVIOR_TO_ABSENCE_TYPE, ChangeRequest,
 )
 from app.middleware.auth import get_current_user
 from app.schemas.absence import AbsenceCreate, AbsenceResponse, AbsenceCalendarEntry, TeamAbsenceEntry, NextVacationResponse
@@ -510,6 +510,13 @@ def create_absence(
                     tenant_id=current_user.tenant_id,
                 )
                 db.add(audit_log)
+                # Fix #1 (belt-and-suspenders): null any ChangeRequest referencing
+                # the refunded vacation absence before deleting it, so the delete
+                # cannot FK-violate (500) on a not-yet-migrated DB. Tenant-scoped.
+                db.query(ChangeRequest).filter(
+                    ChangeRequest.absence_id == vacation_entry.id,
+                    ChangeRequest.tenant_id == target_user.tenant_id,
+                ).update({ChangeRequest.absence_id: None}, synchronize_session=False)
                 db.delete(vacation_entry)
                 refunded_vacation_dates.append(date)
 
@@ -633,6 +640,14 @@ def delete_absence(
         tenant_id=current_user.tenant_id,
     )
     db.add(audit)
+
+    # Fix #1 (belt-and-suspenders): null any ChangeRequest referencing this
+    # absence so the delete cannot FK-violate (500) on a not-yet-migrated DB
+    # where the FK is still NO ACTION. Tenant-scoped.
+    db.query(ChangeRequest).filter(
+        ChangeRequest.absence_id == absence.id,
+        ChangeRequest.tenant_id == current_user.tenant_id,
+    ).update({ChangeRequest.absence_id: None}, synchronize_session=False)
 
     db.delete(absence)
     db.commit()

--- a/backend/app/routers/admin_change_requests.py
+++ b/backend/app/routers/admin_change_requests.py
@@ -624,6 +624,14 @@ def review_change_request(
                 tenant_id=cr_tenant_id,
             )
             db.add(audit)
+            # Fix #1 (belt-and-suspenders): null any ChangeRequest still
+            # referencing this absence before deleting it. The FK is ON DELETE
+            # SET NULL on new DBs, but a not-yet-migrated install may still have
+            # NO ACTION → the delete would FK-violate (500). Tenant-scoped.
+            db.query(ChangeRequest).filter(
+                ChangeRequest.absence_id == absence.id,
+                ChangeRequest.tenant_id == cr_tenant_id,
+            ).update({ChangeRequest.absence_id: None}, synchronize_session=False)
             db.delete(absence)
 
     db.commit()

--- a/backend/app/routers/admin_change_requests.py
+++ b/backend/app/routers/admin_change_requests.py
@@ -33,6 +33,27 @@ from app.models.time_entry_audit_log import TimeEntryAuditLog
 router = APIRouter(prefix="/api/admin", tags=["admin"], dependencies=[Depends(require_admin)])
 
 
+def _delete_day_time_entries(db, user_id, tenant_id, target_date, changed_by, cr_id):
+    """Fix #3: delete all time entries of a user on a given day (with audit),
+    mirroring create_absence — an absence and a time entry on the same day must
+    not both count toward Ist. Tenant-scoped (F-026)."""
+    if target_date is None:
+        return
+    entries = db.query(TimeEntry).filter(
+        TimeEntry.user_id == user_id,
+        TimeEntry.tenant_id == tenant_id,
+        TimeEntry.date == target_date,
+    ).all()
+    for te in entries:
+        _create_audit_log(
+            db, te.id, user_id, changed_by,
+            action="delete", old_entry=te,
+            source="change_request", change_request_id=cr_id,
+            tenant_id=tenant_id,
+        )
+        db.delete(te)
+
+
 @router.get("/change-requests/pending-count")
 def get_pending_change_request_count(
     db: Session = Depends(get_db),
@@ -514,6 +535,15 @@ def review_change_request(
             db.flush()
             cr.absence_id = new_absence.id
 
+            # Fix #3: mirror create_absence — a newly materialised absence must
+            # clear the day's time entries, otherwise the absence AND the time
+            # entry both count → Ist/Saldo inflation. Audited (§16) with the CR
+            # origin as source. The direct booking path does this; the CR
+            # approval path previously did not.
+            _delete_day_time_entries(
+                db, cr.user_id, cr_tenant_id, cr.proposed_date, current_user.id, cr.id,
+            )
+
             # Audit-Log für Absence-CR CREATE
             audit = TimeEntryAuditLog(
                 time_entry_id=None,
@@ -532,6 +562,11 @@ def review_change_request(
 
         elif cr.request_type == ChangeRequestType.UPDATE:
             # absence already fetched in precondition check above
+            # Fix #3: snapshot the pre-mutation date/type so we can clear the
+            # target day's time entries when the absence moves to a new day or
+            # changes into a full-day type (parity with create_absence).
+            _orig_abs_date = absence.date
+            _orig_abs_type = absence.type
             # M-4: Bei Datumswechsel prüfen, ob am Zieltag bereits eine andere
             # Abwesenheit liegt — sonst verletzt das UPDATE den Unique-Constraint
             # (tenant_id, user_id, date, type) und crasht mit 500. Spiegelt die
@@ -607,6 +642,15 @@ def review_change_request(
             audit.new_end_time = absence.end_time
             audit.new_note = f"absence:{absence.type.value}:{float(absence.hours)}h"
             db.add(audit)
+
+            # Fix #3: when the absence moved to a new day or changed type, clear
+            # the (new) target day's time entries so absence + entry don't
+            # double-count (mirror create_absence). A pure time-only edit on the
+            # same day/type leaves entries alone (they were cleared at creation).
+            if absence.date != _orig_abs_date or absence.type != _orig_abs_type:
+                _delete_day_time_entries(
+                    db, cr.user_id, cr_tenant_id, absence.date, current_user.id, cr.id,
+                )
 
         elif cr.request_type == ChangeRequestType.DELETE:
             # Audit-Log für Absence-CR DELETE

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -174,7 +174,30 @@ def login(request: Request, response: Response, login_data: LoginRequest, db: Se
 
     # Login needs to see all users across tenants (no tenant context yet)
     set_superadmin_context(db)
-    user = db.query(User).filter(func.lower(User.username) == login_data.username.lower()).first()
+    # Fix #5: username is only unique per (tenant_id, username) — in SaaS two
+    # tenants may share one. ``.first()`` could authenticate the WRONG account,
+    # so load ALL matches and refuse when more than one ACTIVE account shares the
+    # name (neutral error, no info leak). On-prem (single tenant) always matches
+    # at most one → unchanged.
+    matching_users = (
+        db.query(User)
+        .filter(func.lower(User.username) == login_data.username.lower())
+        .all()
+    )
+    active_matches = [u for u in matching_users if u.is_active]
+    if len(active_matches) > 1:
+        # Equalise timing (dummy verify), record the failure and log the
+        # ambiguity for ops — but never reveal which/that accounts exist.
+        auth_service.verify_password(login_data.password, _DUMMY_BCRYPT_HASH)
+        _record_failed_login(username_lower, now)
+        security_logger.warning(
+            "AUTH login_ambiguous user=%s active_matches=%d", username_lower, len(active_matches),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Ungültiger Benutzername oder Passwort",
+        )
+    user = active_matches[0] if active_matches else (matching_users[0] if matching_users else None)
 
     if not user or not user.is_active:
         # F-040: Run a dummy bcrypt verify so the response time does not

--- a/backend/app/routers/journal.py
+++ b/backend/app/routers/journal.py
@@ -1,15 +1,18 @@
 # backend/app/routers/journal.py
 """Journal-Router: Monatsjournal für Admin und Mitarbeiter."""
+import logging
 from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.orm import Session
 from datetime import datetime
 
 from app.database import get_db
-from app.models import User
+from app.models import User, TimeEntryAuditLog
 from app.middleware.auth import get_current_user, require_admin
 from app.services import journal_service
 from app.services.timezone_service import now_local
 from app.schemas.journal import JournalResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["journal"])
 
@@ -19,10 +22,17 @@ def get_user_journal(
     user_id: str,
     year: int = Query(default=None, ge=2000, le=2100, description="Jahr (Standard: aktuell)"),
     month: int = Query(default=None, ge=1, le=12, description="Monat 1-12 (Standard: aktuell)"),
+    include_health_data: bool = Query(False, description="Krankheitsdaten einschließen (Art. 9 DSGVO)"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_admin),
 ):
-    """Monatsjournal eines Mitarbeiters (Admin-Zugriff)."""
+    """Monatsjournal eines Mitarbeiters (Admin-Zugriff).
+
+    Fix #6 (Art. 9 DSGVO): SICK-Tage sind standardmäßig maskiert; mit
+    ``include_health_data=true`` werden sie ausgeliefert und der Zugriff im
+    F-020-Audit (action="health_data_read") protokolliert — konsistent zu
+    reports.py.
+    """
     now = now_local()
     year = year or now.year
     month = month or now.month
@@ -35,7 +45,32 @@ def get_user_journal(
     if not user:
         raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 
-    return journal_service.get_journal(db, user, year, month)
+    result = journal_service.get_journal(
+        db, user, year, month, include_health_data=include_health_data,
+    )
+
+    # F-020: audit the sensitive health-data read (Art. 9) — only persisted after
+    # the journal was built successfully (no orphan audit on a failed build).
+    if include_health_data:
+        logger.info(
+            "DSGVO-Datenzugriff: Monatsjournal %s-%02d von %s gelesen von Admin %s",
+            year, month, user.username, current_user.username,
+        )
+        db.add(TimeEntryAuditLog(
+            time_entry_id=None,
+            user_id=current_user.id,
+            changed_by=current_user.id,
+            action="health_data_read",
+            source="dsgvo",
+            new_note=(
+                f"Monatsjournal {year}-{month:02d} von {user.username} "
+                f"(inkl. Krankheitsdaten) gelesen von Admin: {current_user.username}"
+            ),
+            tenant_id=current_user.tenant_id,
+        ))
+        db.commit()
+
+    return result
 
 
 @router.get("/journal/me", response_model=JournalResponse)

--- a/backend/app/routers/shift_planning.py
+++ b/backend/app/routers/shift_planning.py
@@ -478,8 +478,15 @@ def list_plans(
         slots_by_plan.setdefault(s.shift_plan_id, []).append(s)
 
     today = today_local()
+    # Fix #7: non-admins only see plans that are active today — inactive drafts
+    # are an admin planning artefact and must be filtered server-side (the
+    # frontend filtered, the backend did not).
+    is_admin = current_user.role == UserRole.ADMIN
     result = []
     for p in plans:
+        active_today = shift_planning_service.is_plan_active_on(p, today)
+        if not is_admin and not active_today:
+            continue
         p_slots = slots_by_plan.get(p.id, [])
         understaffed = [
             s for s in p_slots
@@ -492,7 +499,7 @@ def list_plans(
             "is_active": p.is_active,
             "active_from_date": _iso(p.active_from_date),
             "active_until_date": _iso(p.active_until_date),
-            "active_today": shift_planning_service.is_plan_active_on(p, today),
+            "active_today": active_today,
             "slot_count": len(p_slots),
             "is_valid": len(understaffed) == 0,
         })
@@ -600,7 +607,12 @@ def get_plan(
 ):
     tid = current_user.tenant_id
     plan = _plan_or_404(db, tid, plan_id)
-    return _build_plan_detail(db, tid, plan, current_user.role == UserRole.ADMIN)
+    is_admin = current_user.role == UserRole.ADMIN
+    # Fix #7: non-admins can only open plans that are active today — an inactive
+    # draft does not "exist" for them (404, consistent with list_plans filtering).
+    if not is_admin and not shift_planning_service.is_plan_active_on(plan, today_local()):
+        raise HTTPException(status_code=404, detail="Schichtplan nicht gefunden")
+    return _build_plan_detail(db, tid, plan, is_admin)
 
 
 @router.post("/plans/{plan_id}/generate")

--- a/backend/app/routers/time_entries.py
+++ b/backend/app/routers/time_entries.py
@@ -860,17 +860,24 @@ def update_time_entry(
     )
 
     # #201: clamp start/end to [soll − grace, soll + grace] BEFORE all §4/§3
-    # checks so compliance is assessed on credited time. Recomputed every update
-    # so raw_* is reset to None when the edited values fall within the window.
+    # checks so compliance is assessed on credited time.
     from app.services import work_window_service
     _grace = work_window_service.get_grace_minutes(db, current_user.tenant_id)
     _eff_start, _eff_end, _raw_start, _raw_end = work_window_service.clamp(
         current_user, entry.date, entry.start_time, entry.end_time, _grace,
     )
-    entry.start_time = _eff_start
-    entry.end_time = _eff_end
-    entry.raw_start_time = _raw_start
-    entry.raw_end_time = _raw_end
+    # Fix #2: only overwrite start/end + raw_* when the respective time was
+    # actually part of this partial update — mirrors the admin path
+    # (admin_time_entries.py). A note-only edit must NOT re-clamp the stored
+    # (already-credited) times and must NOT wipe raw_start/raw_end (§16 evidence;
+    # §5 rest-time also reads the raw stamp). Without this gate a reine
+    # Notiz-Änderung set raw_*=None and could lower Ist on a shifted soll window.
+    if "start_time" in update_data:
+        entry.start_time = _eff_start
+        entry.raw_start_time = _raw_start
+    if "end_time" in update_data:
+        entry.end_time = _eff_end
+        entry.raw_end_time = _raw_end
 
     exempt = current_user.exempt_from_arbzg
 

--- a/backend/app/services/journal_service.py
+++ b/backend/app/services/journal_service.py
@@ -19,8 +19,23 @@ _ABSENCE_TYPE_MAP = {
 }
 
 
-def get_journal(db: Session, user: User, year: int, month: int) -> Dict[str, Any]:
+def get_journal(
+    db: Session, user: User, year: int, month: int, include_health_data: bool = True,
+) -> Dict[str, Any]:
+    """Tagesgenaues Monatsjournal.
+
+    Fix #6 (Art. 9 DSGVO): ``include_health_data=False`` maskiert SICK-Tage
+    (Tagestyp + Absence-Label -> "absent"), ohne die Soll-/Ist-/Saldo-Rechnung
+    zu verändern (SICK bleibt als gearbeitet angerechnet, wie in reports.py).
+    Default True für Abwärtskompatibilität (Eigenansicht ``/journal/me``); der
+    Admin-Endpoint gated explizit + auditiert den Zugriff.
+    """
     _, last_day = monthrange(year, month)
+
+    def _abs_type_label(a: Absence) -> str:
+        if not include_health_data and a.type == AbsenceType.SICK:
+            return "absent"
+        return a.type.value
 
     entries = db.query(TimeEntry).filter(
         TimeEntry.user_id == user.id,
@@ -82,7 +97,11 @@ def get_journal(db: Session, user: User, year: int, month: int) -> Dict[str, Any
         elif day_entries and day_absences:
             day_type = "mixed"
         elif day_absences:
-            day_type = _ABSENCE_TYPE_MAP.get(day_absences[0].type, "other")
+            # Fix #6: mask a SICK day type when health data is not requested.
+            if not include_health_data and day_absences[0].type == AbsenceType.SICK:
+                day_type = "absent"
+            else:
+                day_type = _ABSENCE_TYPE_MAP.get(day_absences[0].type, "other")
         elif day_entries:
             day_type = "work"
         else:
@@ -167,7 +186,7 @@ def get_journal(db: Session, user: User, year: int, month: int) -> Dict[str, Any
             "absences": [
                 {
                     "id": str(a.id),
-                    "type": a.type.value,
+                    "type": _abs_type_label(a),  # Fix #6: SICK masked unless requested
                     "hours": float(Decimal(str(a.hours)).quantize(Decimal("0.01"))),
                     "start_time": a.start_time.strftime("%H:%M") if a.start_time else None,
                     "end_time": a.end_time.strftime("%H:%M") if a.end_time else None,

--- a/backend/app/services/scheduler_service.py
+++ b/backend/app/services/scheduler_service.py
@@ -120,6 +120,39 @@ def _run_cleanup_old_errors() -> None:
         db.close()
 
 
+def _run_suspend_expired_trials() -> None:
+    """Fix #4: flip tenants whose free trial has ended (and who have no Stripe
+    subscription) to ``subscription_status='suspended'``. SaaS billing
+    enforcement — previously only reachable via the manual superadmin cron."""
+    from app.services.signup_service import suspend_expired_trials
+    db = SessionLocal()
+    try:
+        set_superadmin_context(db)
+        n = suspend_expired_trials(db)
+        if n:
+            logger.info("scheduler: suspended %d expired-trial tenants", n)
+    except Exception:  # noqa: BLE001
+        logger.exception("scheduler: suspend_expired_trials failed")
+    finally:
+        db.close()
+
+
+def _run_suspend_canceled_after_grace() -> None:
+    """Fix #4: flip tenants whose Stripe subscription has been canceled for
+    longer than the grace period to ``subscription_status='suspended'``."""
+    from app.services.stripe_service import suspend_canceled_after_grace
+    db = SessionLocal()
+    try:
+        set_superadmin_context(db)
+        n = suspend_canceled_after_grace(db)
+        if n:
+            logger.info("scheduler: suspended %d canceled-after-grace tenants", n)
+    except Exception:  # noqa: BLE001
+        logger.exception("scheduler: suspend_canceled_after_grace failed")
+    finally:
+        db.close()
+
+
 def _run_scheduled_backup() -> None:
     """#213: erstellt zur vom Admin konfigurierten Stunde ein DB-Backup, sofern
     aktiviert. Stuendlich getriggert (:30); der Job vergleicht die aktuelle
@@ -165,6 +198,8 @@ JOB_APPLY_SCHEDULED_SUSPENDS = "apply_scheduled_suspends"
 JOB_APPLY_SCHEDULED_DELETIONS = "apply_scheduled_deletions"
 JOB_CLEANUP_OLD_ERRORS = "cleanup_old_errors"
 JOB_SCHEDULED_BACKUP = "scheduled_backup"  # #213
+JOB_SUSPEND_EXPIRED_TRIALS = "suspend_expired_trials"  # Fix #4 (saas only)
+JOB_SUSPEND_CANCELED_AFTER_GRACE = "suspend_canceled_after_grace"  # Fix #4 (saas only)
 
 # Daily run at 03:00 local time. Avoids the midnight rollover bookkeeping
 # rush + leaves the cutoff math (``datetime.now() - timedelta(days=...)``)
@@ -261,6 +296,30 @@ def start_scheduler(app: FastAPI):  # noqa: ARG001  (kept for future use)
         coalesce=True,
         max_instances=1,
     )
+
+    # Fix #4: SaaS billing enforcement — these flip tenants to 'suspended' based
+    # on Stripe/trial state and must NOT run on-prem (would suspend the single
+    # on-prem tenant). Only registered in saas mode.
+    from app.core.deployment import is_saas
+    if is_saas():
+        scheduler.add_job(
+            _run_suspend_expired_trials,
+            trigger=CronTrigger(hour=DAILY_HOUR, minute=DAILY_MINUTE),
+            id=JOB_SUSPEND_EXPIRED_TRIALS,
+            name="Billing: suspend tenants whose free trial has ended (no subscription)",
+            replace_existing=True,
+            coalesce=True,
+            max_instances=1,
+        )
+        scheduler.add_job(
+            _run_suspend_canceled_after_grace,
+            trigger=CronTrigger(hour=DAILY_HOUR, minute=DAILY_MINUTE),
+            id=JOB_SUSPEND_CANCELED_AFTER_GRACE,
+            name="Billing: suspend tenants canceled past the grace period",
+            replace_existing=True,
+            coalesce=True,
+            max_instances=1,
+        )
 
     scheduler.start()
     _scheduler = scheduler

--- a/backend/tests/test_fix1_cr_absence_ondelete.py
+++ b/backend/tests/test_fix1_cr_absence_ondelete.py
@@ -1,0 +1,91 @@
+"""Fix #1: deleting an absence referenced by a ChangeRequest must not crash and
+must null the referencing CR.absence_id (belt-and-suspenders for the FK ondelete).
+
+SQLite test DBs run with FK enforcement OFF, so a missing ON DELETE rule does not
+raise here — we therefore assert the *application* behaviour: the referencing
+ChangeRequest.absence_id is set to NULL on every absence-delete path.
+"""
+import uuid
+from datetime import date, datetime, timezone
+
+from app.models import (
+    User, UserRole, Absence, AbsenceType,
+    ChangeRequest, ChangeRequestType, ChangeRequestStatus,
+)
+from app.routers.absences import delete_absence
+from app.routers.admin_change_requests import review_change_request
+from app.schemas.change_request import ChangeRequestReview
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _user(db, username, role=UserRole.EMPLOYEE):
+    u = User(
+        username=username, email=f"{username}@t.de", password_hash="h",
+        first_name="F", last_name="L", role=role, weekly_hours=40.0,
+        vacation_days=30, work_days_per_week=5, is_active=True,
+        tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _absence(db, user, d=date(2026, 3, 10), t=AbsenceType.VACATION):
+    a = Absence(user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d, type=t, hours=8.0)
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def test_delete_absence_nulls_referencing_cr(db, default_tenant):
+    """Direct delete_absence: a separate CR that references the absence has its
+    absence_id nulled and the delete returns without crashing."""
+    user = _user(db, "fix1_emp")
+    absence = _absence(db, user)
+    cr = ChangeRequest(
+        user_id=user.id, tenant_id=DEFAULT_TENANT_ID,
+        request_type=ChangeRequestType.UPDATE, entry_kind="absence",
+        status=ChangeRequestStatus.PENDING, reason="x",
+        absence_id=absence.id, proposed_date=absence.date,
+        proposed_absence_type="sick",
+    )
+    db.add(cr)
+    db.commit()
+    cr_id = cr.id
+
+    delete_absence(str(absence.id), db=db, current_user=user)
+
+    assert db.query(Absence).filter(Absence.id == absence.id).first() is None
+    refreshed = db.query(ChangeRequest).filter(ChangeRequest.id == cr_id).first()
+    assert refreshed.absence_id is None
+
+
+def test_approve_absence_delete_cr_nulls_link(db, default_tenant):
+    """Approving an Absence-DELETE CR deletes the absence without crashing and the
+    CR's own absence_id ends up NULL."""
+    admin = _user(db, "fix1_admin", role=UserRole.ADMIN)
+    emp = _user(db, "fix1_emp2")
+    absence = _absence(db, emp)
+    cr = ChangeRequest(
+        user_id=emp.id, tenant_id=DEFAULT_TENANT_ID,
+        request_type=ChangeRequestType.DELETE, entry_kind="absence",
+        status=ChangeRequestStatus.PENDING, reason="weg damit",
+        absence_id=absence.id,
+        original_absence_type="vacation", original_absence_hours=8.0,
+        original_date=absence.date,
+    )
+    db.add(cr)
+    db.commit()
+    cr_id = cr.id
+
+    review_change_request(
+        str(cr_id), ChangeRequestReview(action="approve"),
+        db=db, current_user=admin,
+    )
+
+    assert db.query(Absence).filter(Absence.id == absence.id).first() is None
+    refreshed = db.query(ChangeRequest).filter(ChangeRequest.id == cr_id).first()
+    assert refreshed.status == ChangeRequestStatus.APPROVED
+    assert refreshed.absence_id is None

--- a/backend/tests/test_fix2_update_keeps_raw.py
+++ b/backend/tests/test_fix2_update_keeps_raw.py
@@ -1,0 +1,57 @@
+"""Fix #2: the employee PUT must not wipe raw_start/raw_end (§16) or re-clamp the
+stored times on a non-time change (e.g. a note-only edit).
+
+Before the fix, update_time_entry clamped entry.start/end unconditionally and wrote
+raw_*=None on every update, so a reine Notiz-Änderung destroyed the §16 raw stamp
+(and could lower Ist on a shifted soll window). The admin path already gated this.
+"""
+from datetime import time
+
+from app.models import User, UserRole, TimeEntry
+from app.routers.time_entries import update_time_entry, _today_local
+from app.schemas.time_entry import TimeEntryUpdate
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _user(db):
+    u = User(
+        username="fix2_emp", email="fix2@t.de", password_hash="h",
+        first_name="F", last_name="L", role=UserRole.EMPLOYEE, weekly_hours=40.0,
+        vacation_days=30, work_days_per_week=5, is_active=True,
+        tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def test_note_only_update_preserves_raw_and_net(db, default_tenant):
+    user = _user(db)
+    entry = TimeEntry(
+        user_id=user.id, tenant_id=DEFAULT_TENANT_ID,
+        date=_today_local(),
+        start_time=time(8, 0), end_time=time(16, 0),
+        # §16: an earlier clamp recorded the raw (un-credited) stamp.
+        raw_start_time=time(7, 0), raw_end_time=time(18, 0),
+        break_minutes=30, note="alt",
+    )
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    original_net = entry.net_hours
+
+    update_time_entry(
+        str(entry.id), TimeEntryUpdate(note="neue notiz"),
+        db=db, current_user=user,
+    )
+
+    db.refresh(entry)
+    assert entry.note == "neue notiz"
+    # raw stamps survive a note-only edit
+    assert entry.raw_start_time == time(7, 0)
+    assert entry.raw_end_time == time(18, 0)
+    # credited times + net hours unchanged
+    assert entry.start_time == time(8, 0)
+    assert entry.end_time == time(16, 0)
+    assert entry.net_hours == original_net

--- a/backend/tests/test_fix3_cr_absence_clears_time_entry.py
+++ b/backend/tests/test_fix3_cr_absence_clears_time_entry.py
@@ -1,0 +1,105 @@
+"""Fix #3: approving an absence CR (CREATE / date-or-type-changing UPDATE) must
+delete the time entries on the target day, mirroring create_absence — otherwise
+the absence AND the time entry both count toward Ist (Saldo inflation).
+"""
+from datetime import date, time
+
+from app.models import (
+    User, UserRole, TimeEntry, Absence, AbsenceType,
+    ChangeRequest, ChangeRequestType, ChangeRequestStatus,
+)
+from app.routers.admin_change_requests import review_change_request
+from app.schemas.change_request import ChangeRequestReview
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _user(db, username, role=UserRole.EMPLOYEE):
+    u = User(
+        username=username, email=f"{username}@t.de", password_hash="h",
+        first_name="F", last_name="L", role=role, weekly_hours=40.0,
+        vacation_days=30, work_days_per_week=5, is_active=True,
+        tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _time_entry(db, user, d):
+    te = TimeEntry(
+        user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+        start_time=time(8, 0), end_time=time(16, 0), break_minutes=30,
+    )
+    db.add(te)
+    db.commit()
+    db.refresh(te)
+    return te
+
+
+def test_create_absence_cr_clears_time_entry(db, default_tenant):
+    admin = _user(db, "fix3_admin", role=UserRole.ADMIN)
+    emp = _user(db, "fix3_emp")
+    d = date(2026, 3, 10)  # Tuesday, workday
+    te = _time_entry(db, emp, d)
+    cr = ChangeRequest(
+        user_id=emp.id, tenant_id=DEFAULT_TENANT_ID,
+        request_type=ChangeRequestType.CREATE, entry_kind="absence",
+        status=ChangeRequestStatus.PENDING, reason="Urlaub",
+        proposed_date=d, proposed_absence_type="vacation",
+        proposed_absence_hours=8.0,
+    )
+    db.add(cr)
+    db.commit()
+    cr_id = cr.id
+
+    review_change_request(
+        str(cr_id), ChangeRequestReview(action="approve"),
+        db=db, current_user=admin,
+    )
+
+    # time entry gone
+    assert db.query(TimeEntry).filter(TimeEntry.id == te.id).first() is None
+    # absence created on that day
+    assert db.query(Absence).filter(
+        Absence.user_id == emp.id, Absence.date == d,
+        Absence.type == AbsenceType.VACATION,
+    ).first() is not None
+
+
+def test_update_absence_cr_date_change_clears_new_day_time_entry(db, default_tenant):
+    admin = _user(db, "fix3_admin2", role=UserRole.ADMIN)
+    emp = _user(db, "fix3_emp2")
+    old_day = date(2026, 3, 10)
+    new_day = date(2026, 3, 11)
+    # existing absence on old_day
+    absence = Absence(
+        user_id=emp.id, tenant_id=DEFAULT_TENANT_ID, date=old_day,
+        type=AbsenceType.VACATION, hours=8.0,
+    )
+    db.add(absence)
+    db.commit()
+    db.refresh(absence)
+    # a time entry on the NEW day the absence is being moved to
+    te = _time_entry(db, emp, new_day)
+
+    cr = ChangeRequest(
+        user_id=emp.id, tenant_id=DEFAULT_TENANT_ID,
+        request_type=ChangeRequestType.UPDATE, entry_kind="absence",
+        status=ChangeRequestStatus.PENDING, reason="verschoben",
+        absence_id=absence.id,
+        proposed_date=new_day, proposed_absence_type="vacation",
+        original_absence_type="vacation", original_date=old_day,
+    )
+    db.add(cr)
+    db.commit()
+    cr_id = cr.id
+
+    review_change_request(
+        str(cr_id), ChangeRequestReview(action="approve"),
+        db=db, current_user=admin,
+    )
+
+    assert db.query(TimeEntry).filter(TimeEntry.id == te.id).first() is None
+    db.refresh(absence)
+    assert absence.date == new_day

--- a/backend/tests/test_fix4_scheduler_billing_jobs.py
+++ b/backend/tests/test_fix4_scheduler_billing_jobs.py
@@ -1,0 +1,44 @@
+"""Fix #4: the background scheduler must register the SaaS billing-enforcement
+jobs (suspend expired trials / canceled-after-grace) — and only in saas mode.
+"""
+import app.core.deployment as deployment
+from app.services import scheduler_service
+from app.services.scheduler_service import (
+    start_scheduler, stop_scheduler,
+    JOB_SUSPEND_EXPIRED_TRIALS, JOB_SUSPEND_CANCELED_AFTER_GRACE,
+    JOB_VACATION_AUDIT_PURGE,
+)
+
+
+def _job_ids(sched):
+    return {j.id for j in sched.get_jobs()}
+
+
+def test_billing_jobs_registered_in_saas(monkeypatch):
+    monkeypatch.setattr(scheduler_service, "_is_pytest_mode", lambda: False)
+    monkeypatch.setattr(deployment, "is_saas", lambda: True)
+    scheduler_service._scheduler = None
+    try:
+        sched = start_scheduler(None)
+        ids = _job_ids(sched)
+        assert JOB_SUSPEND_EXPIRED_TRIALS in ids
+        assert JOB_SUSPEND_CANCELED_AFTER_GRACE in ids
+        # base lifecycle jobs still present
+        assert JOB_VACATION_AUDIT_PURGE in ids
+    finally:
+        stop_scheduler()
+
+
+def test_billing_jobs_absent_in_onprem(monkeypatch):
+    monkeypatch.setattr(scheduler_service, "_is_pytest_mode", lambda: False)
+    monkeypatch.setattr(deployment, "is_saas", lambda: False)
+    scheduler_service._scheduler = None
+    try:
+        sched = start_scheduler(None)
+        ids = _job_ids(sched)
+        assert JOB_SUSPEND_EXPIRED_TRIALS not in ids
+        assert JOB_SUSPEND_CANCELED_AFTER_GRACE not in ids
+        # base lifecycle jobs unaffected
+        assert JOB_VACATION_AUDIT_PURGE in ids
+    finally:
+        stop_scheduler()

--- a/backend/tests/test_fix5_login_ambiguous_username.py
+++ b/backend/tests/test_fix5_login_ambiguous_username.py
@@ -1,0 +1,82 @@
+"""Fix #5: login by username is ambiguous when two tenants share a username.
+On ambiguity the login must be REFUSED (never authenticate the wrong account),
+with a neutral error. A unique username still logs in.
+"""
+import uuid
+
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.models import User, UserRole
+from app.models.tenant import Tenant
+from app.services import auth_service
+
+from tests.test_endpoints import test_app as app
+from tests.test_endpoints import _db_session  # noqa: F401  (pytest fixture)
+
+DEFAULT_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+OTHER_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000000aa")
+
+
+def _tenant(db, tid, slug):
+    t = Tenant(id=tid, name=slug, slug=slug, is_active=True, mode="single")
+    db.add(t)
+    db.commit()
+    return t
+
+
+def _user(db, tid, username, password, active=True):
+    u = User(
+        username=username, email=f"{username}-{tid}@t.de",
+        password_hash=auth_service.hash_password(password),
+        first_name="F", last_name="L", role=UserRole.EMPLOYEE,
+        weekly_hours=40.0, vacation_days=30, work_days_per_week=5,
+        is_active=active, tenant_id=tid,
+    )
+    db.add(u)
+    db.commit()
+    return u
+
+
+def _login(db, username, password):
+    def _override_db():
+        yield db
+    app.dependency_overrides[get_db] = _override_db
+    try:
+        with patch("app.routers.auth.set_superadmin_context"):
+            with TestClient(app) as client:
+                return client.post("/api/auth/login", json={
+                    "username": username, "password": password,
+                })
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_ambiguous_username_rejected(_db_session):
+    db = _db_session
+    _tenant(db, DEFAULT_TENANT_ID, "default")
+    _tenant(db, OTHER_TENANT_ID, "other")
+    # Same username, two ACTIVE accounts in different tenants, different passwords.
+    _user(db, DEFAULT_TENANT_ID, "fix5shared", "PassOne2025!")
+    _user(db, OTHER_TENANT_ID, "fix5shared", "PassTwo2025!")
+
+    # Even with a password that is valid for ONE of the accounts, the login is
+    # refused — we must not authenticate the wrong (or any) account.
+    resp = _login(db, "fix5shared", "PassOne2025!")
+    assert resp.status_code == 401
+    assert "access_token" not in resp.json()
+
+
+def test_unique_username_still_logs_in(_db_session):
+    db = _db_session
+    _tenant(db, DEFAULT_TENANT_ID, "default")
+    _tenant(db, OTHER_TENANT_ID, "other")
+    # Same username but the OTHER tenant's account is INACTIVE → unambiguous.
+    _user(db, DEFAULT_TENANT_ID, "fix5unique", "PassOne2025!")
+    _user(db, OTHER_TENANT_ID, "fix5unique", "PassTwo2025!", active=False)
+
+    resp = _login(db, "fix5unique", "PassOne2025!")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["user"]["username"] == "fix5unique"

--- a/backend/tests/test_fix6_journal_health_audit.py
+++ b/backend/tests/test_fix6_journal_health_audit.py
@@ -1,0 +1,83 @@
+"""Fix #6: the admin monthly journal must gate SICK data behind
+include_health_data and write an Art. 9 health_data_read audit when it is served
+(mirrors reports.py). The masked default does not leak SICK as a day type.
+"""
+from datetime import date
+
+from app.models import (
+    User, UserRole, Absence, AbsenceType, TimeEntryAuditLog,
+)
+from app.routers.journal import get_user_journal
+from app.services import journal_service
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _user(db, username, role=UserRole.EMPLOYEE):
+    u = User(
+        username=username, email=f"{username}@t.de", password_hash="h",
+        first_name="F", last_name="L", role=role, weekly_hours=40.0,
+        vacation_days=30, work_days_per_week=5, is_active=True,
+        tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _sick(db, user, d):
+    a = Absence(
+        user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+        type=AbsenceType.SICK, hours=8.0,
+    )
+    db.add(a)
+    db.commit()
+
+
+def _audit_count(db):
+    return db.query(TimeEntryAuditLog).filter(
+        TimeEntryAuditLog.action == "health_data_read",
+    ).count()
+
+
+def test_journal_with_health_data_writes_audit_and_shows_sick(db, default_tenant):
+    admin = _user(db, "fix6_admin", role=UserRole.ADMIN)
+    emp = _user(db, "fix6_emp")
+    _sick(db, emp, date(2026, 3, 10))  # Tuesday
+
+    assert _audit_count(db) == 0
+    result = get_user_journal(
+        str(emp.id), year=2026, month=3, include_health_data=True,
+        db=db, current_user=admin,
+    )
+    assert _audit_count(db) == 1
+
+    day = next(d for d in result["days"] if d["date"] == "2026-03-10")
+    assert day["type"] == "sick"
+    assert day["absences"][0]["type"] == "sick"
+
+
+def test_journal_default_masks_sick_and_no_audit(db, default_tenant):
+    admin = _user(db, "fix6_admin2", role=UserRole.ADMIN)
+    emp = _user(db, "fix6_emp2")
+    _sick(db, emp, date(2026, 3, 10))
+
+    result = get_user_journal(
+        str(emp.id), year=2026, month=3, include_health_data=False,
+        db=db, current_user=admin,
+    )
+    assert _audit_count(db) == 0
+    day = next(d for d in result["days"] if d["date"] == "2026-03-10")
+    assert day["type"] == "absent"  # SICK masked
+    assert day["absences"][0]["type"] == "absent"
+
+
+def test_service_default_shows_sick_for_own_view(db, default_tenant):
+    """`/journal/me` (own data) keeps the default include_health_data=True — the
+    employee sees their own SICK days, unmasked, no audit."""
+    emp = _user(db, "fix6_self")
+    _sick(db, emp, date(2026, 3, 10))
+    result = journal_service.get_journal(db, emp, 2026, 3)
+    day = next(d for d in result["days"] if d["date"] == "2026-03-10")
+    assert day["type"] == "sick"
+    assert _audit_count(db) == 0

--- a/backend/tests/test_fix7_shift_plan_read_gating.py
+++ b/backend/tests/test_fix7_shift_plan_read_gating.py
@@ -1,0 +1,71 @@
+"""Fix #7: shift-plan read endpoints must gate non-admins server-side.
+
+list_plans returns only plans active today for non-admins; get_plan 404s a
+non-admin on an inactive (draft) plan. Admins see everything.
+"""
+import pytest
+from fastapi import HTTPException
+
+from app.models import User, UserRole
+from app.models.shift_planning import ShiftPlan
+from app.routers.shift_planning import list_plans, get_plan
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _user(db, username, role=UserRole.EMPLOYEE):
+    u = User(
+        username=username, email=f"{username}@t.de", password_hash="h",
+        first_name="F", last_name="L", role=role, weekly_hours=40.0,
+        vacation_days=30, work_days_per_week=5, is_active=True,
+        tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _plan(db, creator, name, active):
+    p = ShiftPlan(
+        tenant_id=DEFAULT_TENANT_ID, name=name, is_active=active,
+        created_by=creator.id,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+def test_list_plans_hides_inactive_drafts_from_non_admin(db, default_tenant):
+    admin = _user(db, "fix7_admin", role=UserRole.ADMIN)
+    emp = _user(db, "fix7_emp")
+    active = _plan(db, admin, "Aktiv", active=True)
+    draft = _plan(db, admin, "Entwurf", active=False)
+
+    emp_view = list_plans(db=db, current_user=emp)
+    names = {p["name"] for p in emp_view}
+    assert "Aktiv" in names
+    assert "Entwurf" not in names
+
+    admin_view = list_plans(db=db, current_user=admin)
+    admin_names = {p["name"] for p in admin_view}
+    assert {"Aktiv", "Entwurf"} <= admin_names
+
+
+def test_get_plan_404s_non_admin_on_inactive(db, default_tenant):
+    admin = _user(db, "fix7_admin2", role=UserRole.ADMIN)
+    emp = _user(db, "fix7_emp2")
+    draft = _plan(db, admin, "Entwurf2", active=False)
+
+    with pytest.raises(HTTPException) as exc:
+        get_plan(draft.id, db=db, current_user=emp)
+    assert exc.value.status_code == 404
+
+    # admin can open the draft
+    detail = get_plan(draft.id, db=db, current_user=admin)
+    assert detail["name"] == "Entwurf2"
+
+    # non-admin CAN open an active plan
+    active = _plan(db, admin, "Aktiv2", active=True)
+    ok = get_plan(active.id, db=db, current_user=emp)
+    assert ok["name"] == "Aktiv2"

--- a/backend/tests/test_fix8_resplit_on_vacation_removal.py
+++ b/backend/tests/test_fix8_resplit_on_vacation_removal.py
@@ -1,0 +1,167 @@
+"""Fix #8: removing a private VACATION day (storno via delete_absence, or a SICK
+refund in create_absence) frees budget that the #314 Betriebsferien split reserves
+up front → a closure OVERTIME day must flip back to VACATION (toggle on).
+"""
+import uuid
+from datetime import date
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.database import Base, get_db
+from app.middleware.auth import get_current_user, require_admin
+from app.models import User, UserRole, Absence, AbsenceType
+from app.models.tenant import Tenant
+from app.models.system_setting import SystemSetting
+from app.services import auth_service
+from app.routers.absences import delete_absence, create_absence
+from app.schemas.absence import AbsenceCreate
+from tests.conftest import DEFAULT_TENANT_ID, engine, TestingSessionLocal
+
+MON, TUE, WED, THU = date(2025, 3, 10), date(2025, 3, 11), date(2025, 3, 12), date(2025, 3, 13)
+PRIV_VAC_DAY = date(2025, 3, 3)  # a Monday before the closure (a workday in 2025)
+
+
+def _create_test_app() -> FastAPI:
+    from app.routers import company_closures
+    from app.core.limiter import limiter
+    from slowapi import _rate_limit_exceeded_handler
+    from slowapi.errors import RateLimitExceeded
+
+    app = FastAPI()
+    limiter.enabled = False
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.include_router(company_closures.router)
+    return app
+
+
+_app = _create_test_app()
+
+
+@pytest.fixture(scope="function")
+def db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def default_tenant(db):
+    t = Tenant(id=DEFAULT_TENANT_ID, name="Default", slug="default", is_active=True, mode="single")
+    db.add(t)
+    db.commit()
+    return t
+
+
+def _make_user(db, username, role=UserRole.EMPLOYEE, vacation_days=30):
+    u = User(
+        username=username, email=f"{username}@x.de", password_hash=auth_service.hash_password("t"),
+        first_name=username, last_name="T", role=role, weekly_hours=40.0, vacation_days=vacation_days,
+        work_days_per_week=5, is_active=True, track_hours=True, tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(u); db.commit(); db.refresh(u)
+    return u
+
+
+def _set_toggle(db, on):
+    db.merge(SystemSetting(key="closure_overtime_after_vacation", tenant_id=DEFAULT_TENANT_ID,
+                           value="true" if on else "false"))
+    db.commit()
+
+
+def _closure_types(db, emp, closure_id):
+    return [a.type for a in db.query(Absence).filter(
+        Absence.user_id == emp.id, Absence.closure_id == uuid.UUID(closure_id),
+    ).order_by(Absence.date).all()]
+
+
+@pytest.fixture
+def admin(db, default_tenant):
+    return _make_user(db, "admin1", role=UserRole.ADMIN)
+
+
+@pytest.fixture
+def admin_client(db, admin):
+    def override_db():
+        yield db
+    _app.dependency_overrides[get_db] = override_db
+    _app.dependency_overrides[get_current_user] = lambda: admin
+    _app.dependency_overrides[require_admin] = lambda: admin
+    yield TestClient(_app)
+    _app.dependency_overrides.clear()
+
+
+def test_delete_private_vacation_flips_closure_overtime_back(db, default_tenant, admin_client):
+    emp = _make_user(db, "e_resplit", vacation_days=3)  # budget = 3
+    _set_toggle(db, True)
+
+    # A private vacation day consumes 1 of the 3 budget days.
+    priv = Absence(
+        user_id=emp.id, tenant_id=DEFAULT_TENANT_ID, date=PRIV_VAC_DAY,
+        type=AbsenceType.VACATION, hours=8.0, half_day=False,
+    )
+    db.add(priv)
+    db.commit()
+    db.refresh(priv)
+
+    # Closure Mon–Thu (4 workdays). With budget 3 − 1 private = 2, the split is
+    # 2× VACATION then 2× OVERTIME.
+    r = admin_client.post("/api/company-closures/", json={
+        "name": "BF", "start_date": MON.isoformat(), "end_date": THU.isoformat(),
+        "counts_as_vacation": True,
+    })
+    assert r.status_code == 201, r.text
+    closure_id = r.json()["id"]
+
+    before = _closure_types(db, emp, closure_id)
+    assert before.count(AbsenceType.VACATION) == 2
+    assert before.count(AbsenceType.OVERTIME) == 2
+
+    # Storno the private vacation → frees 1 budget day → re-split → 3× VACATION.
+    delete_absence(str(priv.id), db=db, current_user=emp)
+
+    after = _closure_types(db, emp, closure_id)
+    assert after.count(AbsenceType.VACATION) == 3
+    assert after.count(AbsenceType.OVERTIME) == 1
+
+
+def test_sick_refund_flips_closure_overtime_back(db, default_tenant, admin_client):
+    """A SICK booking that refunds (deletes) an overlapping private VACATION frees
+    budget → closure OVERTIME flips back to VACATION."""
+    emp = _make_user(db, "e_refund", vacation_days=3)
+    _set_toggle(db, True)
+
+    priv = Absence(
+        user_id=emp.id, tenant_id=DEFAULT_TENANT_ID, date=PRIV_VAC_DAY,
+        type=AbsenceType.VACATION, hours=8.0, half_day=False,
+    )
+    db.add(priv)
+    db.commit()
+
+    r = admin_client.post("/api/company-closures/", json={
+        "name": "BF", "start_date": MON.isoformat(), "end_date": THU.isoformat(),
+        "counts_as_vacation": True,
+    })
+    assert r.status_code == 201, r.text
+    closure_id = r.json()["id"]
+    assert _closure_types(db, emp, closure_id).count(AbsenceType.VACATION) == 2
+
+    # SICK on the private-vacation day with refund → deletes the VACATION.
+    # (non-admin self-booking: do NOT pass user_id — target defaults to self)
+    create_absence(
+        AbsenceCreate(
+            date=PRIV_VAC_DAY, type=AbsenceType.SICK,
+            hours=8.0, refund_vacation=True,
+        ),
+        db=db, current_user=emp,
+    )
+
+    after = _closure_types(db, emp, closure_id)
+    assert after.count(AbsenceType.VACATION) == 3
+    assert after.count(AbsenceType.OVERTIME) == 1

--- a/frontend/src/components/MonthlyJournal.tsx
+++ b/frontend/src/components/MonthlyJournal.tsx
@@ -139,7 +139,10 @@ export default function MonthlyJournal({ userId, isAdminView }: MonthlyJournalPr
     const controller = new AbortController();
     const [year, month] = selectedMonth.split('-').map(Number);
     const url = isAdminView
-      ? `/admin/users/${userId}/journal?year=${year}&month=${month}`
+      // Fix #6: admins legitimately review absences (incl. SICK) in the journal;
+      // request the health data explicitly so the backend serves it AND logs the
+      // Art. 9 access in the audit trail (otherwise SICK days are masked).
+      ? `/admin/users/${userId}/journal?year=${year}&month=${month}&include_health_data=true`
       : `/journal/me?year=${year}&month=${month}`;
 
     setLoading(true);


### PR DESCRIPTION
Behebt die im Andere-Bereiche-Review bestätigten Befunde (1 HIGH, 5 MEDIUM, 1 LOW) + 1 Re-Split-Folgepunkt, je mit Test:

1. **HIGH** `change_requests.absence_id`-FK ohne ON DELETE → 500 beim Löschen einer referenzierten Abwesenheit (Postgres). `ondelete="SET NULL"` (Model + **Migration 059**) + Belt-and-suspenders-Nullen in den 3 Lösch-Pfaden. Entsperrt Absence-CR-Genehmigung, delete_absence, SICK-Refund, DSGVO-Purge.
2. **MED** `update_time_entry` (MA) verwarf Rohstempel bei Nicht-Zeit-Änderungen → jetzt wie Admin-Pfad gegated (§16/§5 erhalten).
3. **MED** CR-Genehmigung (Absence CREATE/UPDATE) löscht jetzt Zeiteinträge am Zieltag (Audit) → keine Doppelzählung.
4. **MED** Scheduler führt Trial-/Stripe-Cancel-Suspend aus (2 Tages-Jobs, **saas-gated** → On-Prem unberührt).
5. **MED** SaaS-Login lehnt bei mehrdeutigem Benutzernamen (2 Tenants) ab statt `.first()` (Security; On-Prem unverändert).
6. **MED (Security)** Admin-Monatsjournal: Krankdaten (Art.9) hinter `include_health_data`-Gate + `health_data_read`-Audit (gespiegelt von reports.py); Frontend MonthlyJournal reicht das Flag für die Admin-Sicht durch.
7. **LOW (Security)** Schichtplan-Read-Endpoints serverseitig für Nicht-Admins gegated (nur aktive Pläne; get_plan 404 sonst).
8. **Folgepunkt** delete_absence + SICK-Refund lösen jetzt `resplit_year_closures` aus (freigewordenes Budget → Closure-OVERTIME→VACATION).

**Tests:** 8 neue Test-Dateien (16 Tests) + 171 betroffene Regression grün; Agent-Vollsuite 1196 passed; tsc grün. Migration 059 ← 058 (Kette validiert).

⚠️ Migration 059 ist standardmäßiges FK-Alter (drop+recreate mit SET NULL, Constraint-Name aus 030 gespiegelt), bisher nur kettenvalidiert — **vor Release auf echtem Postgres up/down prüfen**.
