### PR TITLE
fix: 5 Tiefen-Logiklücken (Halbtags-Soll, Tagesplan-WHChange, Resplit-dt_day, CR-Budget, CR-Resplit)

### DIFF
--- a/backend/app/routers/admin_change_requests.py
+++ b/backend/app/routers/admin_change_requests.py
@@ -28,7 +28,8 @@ from app.services.calculation_service import (
     get_weekly_hours_for_date, get_daily_target_for_date, get_vacation_account,
     get_daily_target,
 )
-from app.services import work_window_service
+from app.services import work_window_service, settings_service
+from app.services.closure_split_service import resplit_year_closures
 from app.models.time_entry_audit_log import TimeEntryAuditLog
 
 router = APIRouter(prefix="/api/admin", tags=["admin"], dependencies=[Depends(require_admin)])
@@ -464,6 +465,10 @@ def review_change_request(
             db.delete(entry)
 
     # Absence CR actions
+    # Fix #5: collect the years whose Betriebsferien must be re-split after this
+    # approval — every VACATION-creating/-removing path triggers resplit so a
+    # closure day can flip VACATION<->OVERTIME (toggle-gated, see end of fn).
+    _resplit_years: set = set()
     if cr.entry_kind == "absence":
         if cr.request_type == ChangeRequestType.CREATE and existing_absence is not None:
             # Review R2-a: idempotent — an absence of the SAME type already
@@ -550,6 +555,11 @@ def review_change_request(
             db.add(new_absence)
             db.flush()
             cr.absence_id = new_absence.id
+
+            # Fix #5: a newly materialised VACATION consumes budget the closure
+            # split reserves up front → re-split that year.
+            if new_absence.type == AbsenceType.VACATION and cr.proposed_date:
+                _resplit_years.add(cr.proposed_date.year)
 
             # Fix #3: mirror create_absence — a newly materialised absence must
             # clear the day's time entries, otherwise the absence AND the time
@@ -707,6 +717,14 @@ def review_change_request(
                     db, cr.user_id, cr_tenant_id, absence.date, current_user.id, cr.id,
                 )
 
+            # Fix #5: a VACATION added or removed (type change) or moved (date
+            # change) shifts the closure-split budget → re-split BOTH the old and
+            # the new year when VACATION is involved on either side.
+            if _orig_abs_type == AbsenceType.VACATION:
+                _resplit_years.add(_orig_abs_date.year)
+            if absence.type == AbsenceType.VACATION:
+                _resplit_years.add(absence.date.year)
+
         elif cr.request_type == ChangeRequestType.DELETE:
             # Audit-Log für Absence-CR DELETE
             audit = TimeEntryAuditLog(
@@ -731,10 +749,27 @@ def review_change_request(
                 ChangeRequest.absence_id == absence.id,
                 ChangeRequest.tenant_id == cr_tenant_id,
             ).update({ChangeRequest.absence_id: None}, synchronize_session=False)
+            # Fix #5: deleting a VACATION frees budget the closure split reserved
+            # → a closure OVERTIME day can flip back to VACATION (capture the year
+            # BEFORE delete, attributes expire afterwards).
+            if absence.type == AbsenceType.VACATION:
+                _resplit_years.add(absence.date.year)
             db.delete(absence)
 
     db.commit()
     db.refresh(cr)
+
+    # Fix #5: re-split the affected years' Betriebsferien so closure days flip
+    # VACATION<->OVERTIME after a VACATION-relevant approval — mirrors the direct
+    # booking / vacation-request paths. Toggle-gated; the main commit above made
+    # the absence change visible to the budget snapshot inside resplit.
+    if _resplit_years and settings_service.get_bool_setting(
+        db, "closure_overtime_after_vacation", cr_tenant_id, False
+    ):
+        for _yr in _resplit_years:
+            resplit_year_closures(db, cr_tenant_id, _yr)
+        db.commit()
+        db.refresh(cr)
 
     cr_response = _enrich_cr_response(cr, db)
 

--- a/backend/app/routers/admin_change_requests.py
+++ b/backend/app/routers/admin_change_requests.py
@@ -26,11 +26,27 @@ from app.services.break_validation_service import validate_daily_break
 from app.services.arbzg_utils import is_night_work
 from app.services.calculation_service import (
     get_weekly_hours_for_date, get_daily_target_for_date, get_vacation_account,
+    get_daily_target,
 )
 from app.services import work_window_service
 from app.models.time_entry_audit_log import TimeEntryAuditLog
 
 router = APIRouter(prefix="/api/admin", tags=["admin"], dependencies=[Depends(require_admin)])
+
+
+def _vacation_day_contribution(db, user, d, half_day) -> float:
+    """Fix #4: tagebasierter Urlaubsverbrauch EINES VACATION-Tags am Datum ``d``,
+    exakt nach der Regel in ``get_vacation_account``: untracked (Tagessoll 0
+    gesamt) → 0,5/1,0; sonst Tagessoll-des-Tages ≤ 0 → 0, sonst 0,5 (Halbtag)
+    bzw. 1,0 (voller Tag). ``half_day=None`` (Legacy/CR-Default) zählt als voller
+    Tag (ein CR bucht ganztags). Wird für den Netto-Neuverbrauch-Vergleich im
+    UPDATE-Budget-Check verwendet."""
+    if get_daily_target(user) <= 0:  # untracked / work_days_per_week == 0
+        return 0.5 if half_day else 1.0
+    dt = get_daily_target_for_date(user, d, get_weekly_hours_for_date(db, user, d))
+    if dt <= 0:
+        return 0.0
+    return 0.5 if half_day else 1.0
 
 
 def _delete_day_time_entries(db, user_id, tenant_id, target_date, changed_by, cr_id):
@@ -593,6 +609,45 @@ def review_change_request(
                             f"eine Abwesenheit ({conflicting_absence.type.value})"
                         ),
                     )
+
+            # Fix #4: Urlaubsbudget-Prüfung VOR der Mutation — der CREATE-Branch
+            # prüft sie (M-2), der UPDATE-Branch tat es nicht → ein per CR
+            # genehmigtes UPDATE auf VACATION (insb. Typwechsel→VACATION oder
+            # Datumswechsel) konnte das Budget überziehen. Tagebasiert
+            # (#156/#167). Self-Exclude: geprüft wird der NETTO-Neuverbrauch
+            # (post − bisher schon gezählt) gegen den Rest des ZIEL-Jahres, damit
+            # ein reiner Zeit-Edit eines bestehenden Urlaubstags (net_new=0) nicht
+            # an einem evtl. negativen Rest scheitert.
+            _bud_user = db.query(User).filter(
+                User.id == cr.user_id, User.tenant_id == cr_tenant_id
+            ).first()
+            _target_type = (
+                AbsenceType(cr.proposed_absence_type)
+                if cr.proposed_absence_type else absence.type
+            )
+            _target_date = cr.proposed_date or absence.date
+            if _bud_user and _target_type == AbsenceType.VACATION and _target_date:
+                _target_year = _target_date.year
+                _post_days = _vacation_day_contribution(
+                    db, _bud_user, _target_date, absence.half_day
+                )
+                _current_days = (
+                    _vacation_day_contribution(db, _bud_user, absence.date, absence.half_day)
+                    if (absence.type == AbsenceType.VACATION
+                        and absence.date.year == _target_year)
+                    else 0.0
+                )
+                _net_new = _post_days - _current_days
+                if _net_new > 1e-9:
+                    _vac_acc = get_vacation_account(db, _bud_user, _target_year)
+                    if _net_new > _vac_acc["remaining_days"] + 1e-9:
+                        raise HTTPException(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            detail=(
+                                f"Nicht genügend Urlaubstage für {_target_year} "
+                                f"({_vac_acc['remaining_days']:.1f} Tage verfügbar)"
+                            ),
+                        )
 
             # Audit-Log für Absence-CR UPDATE (alte Werte sichern)
             audit = TimeEntryAuditLog(

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -705,6 +705,22 @@ def create_working_hours_change(
     if not user:
         raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 
+    # Fix #2: a WorkingHoursChange only feeds get_weekly_hours_for_date, which
+    # get_daily_target_for_date IGNORES when use_daily_schedule=True (it reads
+    # hours_monday…friday instead). Writing such a row would have NO effect on
+    # the Soll while the UI still showed the new value → silently wrong §16
+    # records. Reject it instead of historising the per-weekday columns (which
+    # would be a separate, larger feature).
+    if getattr(user, "use_daily_schedule", False):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Für Mitarbeitende mit individuellem Tagesplan wird die "
+                "Stunden-Historie nicht unterstützt — bitte die Tagesstunden "
+                "direkt im Mitarbeiter-Profil ändern."
+            ),
+        )
+
     existing = db.query(WorkingHoursChange).filter(
         WorkingHoursChange.user_id == user_id,
         WorkingHoursChange.tenant_id == current_user.tenant_id,  # F-026

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -185,6 +185,65 @@ def _within_employment_window(user: User, d: date) -> bool:
     return True
 
 
+def _soll_reducing_absence_half_map(absences: List[Absence]) -> Dict[date, bool]:
+    """Fix #1: map each soll-reducing absence (VACATION/OTHER/PAID_LEAVE) date to
+    whether it is a HALF day, for the shared per-day Soll helper below.
+
+    Value semantics:
+
+    * date NOT in map → no soll-reducing absence that day (full Tagessoll counts)
+    * value ``False`` → full-day absence → the whole day's Soll is removed
+    * value ``True``  → half-day absence → only 0,5 × Tagessoll is removed
+                        (half the Soll remains so the worked half still counts)
+
+    ``half_day`` only counts as half when explicitly ``True``; legacy rows
+    (``None``) and full-day rows (``False``) keep the historic full-skip
+    behaviour. If two rows ever shared a date (the unique constraint normally
+    prevents it), a full day wins (more Soll removed = conservative).
+    """
+    m: Dict[date, bool] = {}
+    for a in absences:
+        is_half = a.half_day is True
+        m[a.date] = (m[a.date] and is_half) if a.date in m else is_half
+    return m
+
+
+def _day_soll_contribution(
+    db: Session,
+    user: User,
+    d: date,
+    *,
+    holiday_dates: set,
+    absence_half_map: Dict[date, bool],
+    wh_changes: Optional[List[WorkingHoursChange]],
+    special_cfg: dict,
+) -> Decimal:
+    """Fix #1: single source of truth for ONE weekday's Soll contribution, shared
+    by all four per-day Soll loops (get_range_target, get_overtime_account,
+    get_overtime_history, get_ytd_summary) so half-day handling never diverges.
+
+    The CALLER is responsible for the weekend / employment-window / up_to_date
+    cutoff skips. This helper handles, in order: holidays, soll-reducing
+    absences (full vs. half day), the per-date weekly-hours lookup, the #146
+    special-day factor and finally the half-day halving — special-day factor
+    FIRST, then ×0,5 for a half day. Returns 0 for a holiday or a full-day
+    soll-reducing absence.
+    """
+    if d in holiday_dates:
+        return Decimal('0')
+    half = absence_half_map.get(d)
+    if half is False:
+        return Decimal('0')  # full-day soll-reducing absence → no Soll this day
+    weekly_hours = get_weekly_hours_for_date(db, user, d, wh_changes=wh_changes)
+    daily_target = get_daily_target_for_date(user, d, weekly_hours)
+    factor = special_days_service.special_day_target_factor(d, special_cfg)
+    if factor is not None:
+        daily_target = daily_target * factor
+    if half is True:
+        daily_target = daily_target * Decimal('0.5')
+    return daily_target
+
+
 def get_soll_cutoff_date(db: Session, user: User, today: date = None) -> date:
     """#313: last date (inclusive) that counts toward the running Soll/Ist.
 
@@ -238,7 +297,8 @@ def get_range_target(
         date_in_range(Absence.date, start, end),
         Absence.type.notin_([AbsenceType.TRAINING, AbsenceType.SICK, AbsenceType.OVERTIME]),
     ).all()
-    absence_dates = {a.date for a in absences}
+    # Fix #1: half-day-aware map (full day → skip, half day → halve Soll).
+    absence_half_map = _soll_reducing_absence_half_map(absences)
 
     # Preload the user's WorkingHoursChange rows ONCE and resolve the per-day
     # weekly hours in memory (avoids one SELECT per day — N+1 — for a multi-day
@@ -273,21 +333,17 @@ def get_range_target(
         if not _within_employment_window(user, d):
             d += timedelta(days=1)
             continue
-        # Skip holidays and absences
-        if d in holiday_dates or d in absence_dates:
-            d += timedelta(days=1)
-            continue
 
-        weekly_hours = get_weekly_hours_for_date(db, user, d, wh_changes=wh_changes)
-        daily_target = get_daily_target_for_date(user, d, weekly_hours)
-
-        # #146: apply the special-day rule (after weekend/holiday/absence so we
-        # never double-handle a 24./31.12. that already is a weekend or holiday).
-        factor = special_days_service.special_day_target_factor(d, _special_cfg(d.year))
-        if factor is not None:
-            daily_target = (daily_target * factor)
-
-        total += daily_target
+        # Fix #1: holidays / soll-reducing absences (full vs. half day) + the #146
+        # special-day factor live in the shared per-day helper so all four Soll
+        # loops behave identically (full-day absence → 0; half-day → 0,5×Soll).
+        total += _day_soll_contribution(
+            db, user, d,
+            holiday_dates=holiday_dates,
+            absence_half_map=absence_half_map,
+            wh_changes=wh_changes,
+            special_cfg=_special_cfg(d.year),
+        )
         d += timedelta(days=1)
 
     return total.quantize(Decimal('0.01'))
@@ -537,7 +593,8 @@ def get_overtime_account(
         Absence.date <= up_to_date,
         Absence.type.notin_([AbsenceType.TRAINING, AbsenceType.SICK, AbsenceType.OVERTIME]),
     ).all()
-    absence_dates: set[date] = {a.date for a in absences}
+    # Fix #1: half-day-aware map (full day → skip, half day → halve Soll).
+    absence_half_map: Dict[date, bool] = _soll_reducing_absence_half_map(absences)
 
     # All public holidays in range
     holidays = db.query(PublicHoliday).filter(
@@ -587,15 +644,15 @@ def get_overtime_account(
             # #193: skip days outside the employment window (before entry / after exit)
             if not _within_employment_window(user, d):
                 continue
-            if d in holiday_dates or d in absence_dates:
-                continue
-            weekly_hours = get_weekly_hours_for_date(db, user, d, wh_changes=wh_changes)
-            daily_target = get_daily_target_for_date(user, d, weekly_hours)
-            # #146: apply special-day rule (half_day → ×0.5, free → ×0).
-            factor = special_days_service.special_day_target_factor(d, cfg)
-            if factor is not None:
-                daily_target = (daily_target * factor)
-            monthly_target += daily_target
+            # Fix #1: shared per-day helper (full-day absence → 0; half-day →
+            # 0,5×Soll; holiday → 0; #146 special-day factor applied first).
+            monthly_target += _day_soll_contribution(
+                db, user, d,
+                holiday_dates=holiday_dates,
+                absence_half_map=absence_half_map,
+                wh_changes=wh_changes,
+                special_cfg=cfg,
+            )
 
         monthly_actual = actual_by_month.get(key, Decimal('0'))
         total_balance += (monthly_actual - monthly_target)
@@ -686,12 +743,13 @@ def get_overtime_history(
         k = (ca.date.year, ca.date.month)
         actual_by_month[k] = actual_by_month.get(k, Decimal('0')) + Decimal(str(ca.hours))
 
-    absence_dates = {a.date for a in db.query(Absence).filter(
+    # Fix #1: half-day-aware map (full day → skip, half day → halve Soll).
+    absence_half_map = _soll_reducing_absence_half_map(db.query(Absence).filter(
         Absence.user_id == user.id,
         Absence.date >= start_date,
         Absence.date <= up_to_date,
         Absence.type.notin_([AbsenceType.TRAINING, AbsenceType.SICK, AbsenceType.OVERTIME]),
-    ).all()}
+    ).all())
 
     holiday_dates = {h.date for h in db.query(PublicHoliday).filter(
         PublicHoliday.date >= start_date,
@@ -732,14 +790,15 @@ def get_overtime_history(
                 continue
             if not _within_employment_window(user, d):
                 continue
-            if d in holiday_dates or d in absence_dates:
-                continue
-            weekly_hours = get_weekly_hours_for_date(db, user, d, wh_changes=wh_changes)
-            daily_target = get_daily_target_for_date(user, d, weekly_hours)
-            factor = special_days_service.special_day_target_factor(d, cfg)
-            if factor is not None:
-                daily_target = daily_target * factor
-            monthly_target += daily_target
+            # Fix #1: shared per-day helper (kept bit-identical with
+            # get_overtime_account so the history invariant holds).
+            monthly_target += _day_soll_contribution(
+                db, user, d,
+                holiday_dates=holiday_dates,
+                absence_half_map=absence_half_map,
+                wh_changes=wh_changes,
+                special_cfg=cfg,
+            )
 
         monthly_actual = actual_by_month.get((cy, cm), Decimal('0'))
         total_balance += (monthly_actual - monthly_target)
@@ -806,7 +865,8 @@ def get_ytd_summary(db: Session, user: User, year: int = None, cutoff_date: date
         Absence.date <= end,
         Absence.type.notin_([AbsenceType.TRAINING, AbsenceType.SICK, AbsenceType.OVERTIME]),
     ).all()
-    absence_dates: set = {a.date for a in absences}
+    # Fix #1: half-day-aware map (full day → skip, half day → halve Soll).
+    absence_half_map: Dict[date, bool] = _soll_reducing_absence_half_map(absences)
 
     # Fetch working hours changes (pre-loaded for the per-day loop).
     # F-027: routed through get_weekly_hours_for_date() with in-memory path
@@ -824,16 +884,17 @@ def get_ytd_summary(db: Session, user: User, year: int = None, cutoff_date: date
     total_target = Decimal('0')
     current = start
     while current <= end:
-        if (current.weekday() < 5 and current not in holiday_dates
-                and current not in absence_dates
+        if (current.weekday() < 5
                 and _within_employment_window(user, current)):  # #193
-            weekly_hours = get_weekly_hours_for_date(db, user, current, wh_changes=wh_changes)
-            daily_target = get_daily_target_for_date(user, current, weekly_hours)
-            # #146: apply special-day rule (half_day → ×0.5, free → ×0).
-            factor = special_days_service.special_day_target_factor(current, special_day_config)
-            if factor is not None:
-                daily_target = (daily_target * factor)
-            total_target += daily_target
+            # Fix #1: holiday / soll-reducing absence (full vs. half day) + #146
+            # special-day factor via the shared per-day helper.
+            total_target += _day_soll_contribution(
+                db, user, current,
+                holiday_dates=holiday_dates,
+                absence_half_map=absence_half_map,
+                wh_changes=wh_changes,
+                special_cfg=special_day_config,
+            )
         current += timedelta(days=1)
 
     # Sum actual hours (time entries + credited absence hours: training + sick)

--- a/backend/app/services/closure_split_service.py
+++ b/backend/app/services/closure_split_service.py
@@ -121,6 +121,17 @@ def resplit_year_closures(db: Session, tenant_id, year: int, current_user: User 
         private_dates = {a.date for a in private}
         consumed = 0.0
         for a in private:
+            # Fix #3: skip days with Tagessoll 0 (e.g. a use_daily_schedule MA's
+            # free weekday) exactly like get_vacation_account's used_days loop —
+            # a vacation day on a non-working day consumes 0 budget. Without this
+            # ``consumed`` overcounted → closure_budget too small → a closure day
+            # wrongly fell to OVERTIME.
+            dt_day = calculation_service.get_daily_target_for_date(
+                employee, a.date,
+                weekly_hours=calculation_service.get_weekly_hours_for_date(db, employee, a.date),
+            )
+            if dt_day <= 0:
+                continue
             consumed += 0.5 if a.half_day else 1.0
         for d in deduction_dates:
             if d in private_dates:
@@ -128,6 +139,15 @@ def resplit_year_closures(db: Session, tenant_id, year: int, current_user: User 
             if employee.first_work_day and d < employee.first_work_day:
                 continue
             if employee.last_work_day and d > employee.last_work_day:
+                continue
+            # Fix #3: same Tagessoll>0 guard get_vacation_account applies to free
+            # special days (24./31.12.) — a free day on the MA's non-working
+            # weekday costs no vacation, so it must not reduce closure_budget.
+            dt_day = calculation_service.get_daily_target_for_date(
+                employee, d,
+                weekly_hours=calculation_service.get_weekly_hours_for_date(db, employee, d),
+            )
+            if dt_day <= 0:
                 continue
             consumed += 1.0
 

--- a/backend/tests/test_edge_cases.py
+++ b/backend/tests/test_edge_cases.py
@@ -225,14 +225,33 @@ class TestCalculationEdgeCases:
     """Edge Cases in der Stundenberechnung."""
 
     def test_half_day_absence_reduces_target_correctly(self, db, test_user):
-        """Prüft dass Halbtags-Abwesenheit das Soll reduziert — Tag wird komplett als Abwesenheit gezaehlt."""
+        """Fix #1: Halbtags-Abwesenheit (half_day=True) reduziert das Soll um
+        GENAU 0,5 × Tagessoll (4h), NICHT um das volle Tagessoll (8h). Die
+        gearbeitete zweite Tageshälfte bleibt als Soll bestehen (kein Phantom)."""
         target_before = calculation_service.get_monthly_target(db, test_user, 2026, 3)
-        _make_absence(db, test_user, date(2026, 3, 10), AbsenceType.VACATION, 4.0)
+        # half_day=True → 0,5 × 8h = 4h des Tagessolls fallen weg, 4h bleiben Soll.
+        a = Absence(
+            user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID,
+            date=date(2026, 3, 10), type=AbsenceType.VACATION, hours=4.0, half_day=True,
+        )
+        db.add(a)
+        db.commit()
         target_after = calculation_service.get_monthly_target(db, test_user, 2026, 3)
-        # Vacation mit 4h → der Tag ist trotzdem ein "Absence-Tag" und wird komplett übersprungen
-        # Das ist by-design: absence_dates enthält den Tag, also wird das volle Tagessoll abgezogen
-        # Hier testen wir das IST-Verhalten (nicht unbedingt das gewünschte)
-        assert target_after < target_before
+        # Genau das halbe Tagessoll wird abgezogen (8h Tagessoll → −4h).
+        assert (target_before - target_after) == Decimal('4.00'), (target_before, target_after)
+
+    def test_full_day_absence_removes_whole_target(self, db, test_user):
+        """Regression zu Fix #1: ein Voll-Tag (half_day=False) entfernt weiter
+        das ganze Tagessoll (8h)."""
+        target_before = calculation_service.get_monthly_target(db, test_user, 2026, 3)
+        a = Absence(
+            user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID,
+            date=date(2026, 3, 10), type=AbsenceType.VACATION, hours=8.0, half_day=False,
+        )
+        db.add(a)
+        db.commit()
+        target_after = calculation_service.get_monthly_target(db, test_user, 2026, 3)
+        assert (target_before - target_after) == Decimal('8.00'), (target_before, target_after)
 
     def test_multiple_entries_same_day_summed(self, db, test_user):
         """Prüft dass mehrere Eintraege am selben Tag korrekt summiert werden — Multi-Entry."""

--- a/backend/tests/test_fix1_half_day_target.py
+++ b/backend/tests/test_fix1_half_day_target.py
@@ -1,0 +1,121 @@
+"""Fix #1: Halbtags-Abwesenheit (VACATION/OTHER/PAID_LEAVE mit half_day=True)
+reduziert das Soll nur um 0,5 × Tagessoll — NICHT um das ganze Tagessoll.
+
+Vorher übersprangen alle vier Soll-Per-Tag-Schleifen den ganzen Tag (reine
+Datums-Mengen-Mitgliedschaft), sodass ein Halbtags-Urlaub den Tag soll-frei
+machte → Phantom-Überstunden bei Arbeit der zweiten Hälfte, und ein ganzer
+freier Tag kostete nur 0,5 Urlaubstage. Jetzt bleibt die nicht-freie Hälfte
+als Soll bestehen (gemeinsamer Per-Tag-Helper für alle vier Schleifen).
+"""
+from decimal import Decimal
+from datetime import date, time
+
+from app.models import Absence, AbsenceType, TimeEntry
+from app.services import calculation_service
+from tests.conftest import DEFAULT_TENANT_ID
+
+# 2026-03-09 = Montag … 2026-03-13 = Freitag (saubere Woche ohne Feiertage)
+MON, TUE, WED, THU, FRI = (
+    date(2026, 3, 9), date(2026, 3, 10), date(2026, 3, 11),
+    date(2026, 3, 12), date(2026, 3, 13),
+)
+
+
+def _entry(db, user, d, start_h, end_h, break_min=0):
+    e = TimeEntry(
+        user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+        start_time=time(start_h, 0), end_time=time(end_h, 0), break_minutes=break_min,
+    )
+    db.add(e)
+    db.commit()
+    return e
+
+
+def _absence(db, user, d, absence_type, hours, half_day):
+    a = Absence(
+        user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+        type=absence_type, hours=hours, half_day=half_day,
+    )
+    db.add(a)
+    db.commit()
+    return a
+
+
+def test_half_day_vacation_plus_morning_work_balance_zero(db, test_user):
+    """8h/Tag-MA: Mo Halbtags-VACATION + 4h vormittags gearbeitet, Di–Fr je 8h.
+    Soll = 4h(Mo) + 32h = 36h; Ist = 4h + 32h = 36h → Saldo 0 (nicht +4h)."""
+    _absence(db, test_user, MON, AbsenceType.VACATION, 4.0, half_day=True)
+    _entry(db, test_user, MON, 8, 12)  # 4h vormittags
+    for d in (TUE, WED, THU, FRI):
+        _entry(db, test_user, d, 8, 16)  # 8h
+
+    target = calculation_service.get_range_target(db, test_user, MON, FRI)
+    actual = calculation_service.get_range_actual(db, test_user, MON, FRI)
+    assert target == Decimal('36.00'), target
+    assert actual == Decimal('36.00'), actual
+    assert (actual - target) == Decimal('0.00')
+
+
+def test_pure_half_day_vacation_keeps_half_target(db, test_user):
+    """Reiner Halbtags-Urlaub ohne Arbeit: 0,5 × Tagessoll (4h) bleibt Soll."""
+    _absence(db, test_user, MON, AbsenceType.VACATION, 4.0, half_day=True)
+    target = calculation_service.get_range_target(db, test_user, MON, MON)
+    assert target == Decimal('4.00'), target
+
+
+def test_full_day_vacation_still_removes_whole_target(db, test_user):
+    """Regression: Voll-Tag-Urlaub (half_day=False) entfernt weiter das ganze Soll."""
+    _absence(db, test_user, MON, AbsenceType.VACATION, 8.0, half_day=False)
+    target = calculation_service.get_range_target(db, test_user, MON, MON)
+    assert target == Decimal('0.00'), target
+
+
+def test_legacy_null_half_day_treated_as_full(db, test_user):
+    """Legacy-Row (half_day=None, vor dem Feld) bleibt Voll-Skip — keine Regression."""
+    _absence(db, test_user, MON, AbsenceType.VACATION, 8.0, half_day=None)
+    target = calculation_service.get_range_target(db, test_user, MON, MON)
+    assert target == Decimal('0.00'), target
+
+
+def test_half_day_in_overtime_account(db, test_user):
+    """Das Halbtags-Soll greift auch im Überstundenkonto (zweite Soll-Schleife):
+    Voll-Tag entfernt 8h Soll, Halbtag nur 4h → Halbtag-Konto ist 4h niedriger."""
+    _absence(db, test_user, MON, AbsenceType.VACATION, 4.0, half_day=True)
+    _entry(db, test_user, MON, 8, 12)  # 4h vormittags
+    for d in (TUE, WED, THU, FRI):
+        _entry(db, test_user, d, 8, 16)
+    acct_half = calculation_service.get_overtime_account(db, test_user, 2026, 3)
+
+    a = db.query(Absence).filter(Absence.user_id == test_user.id, Absence.date == MON).one()
+    a.half_day = False
+    a.hours = 8.0
+    db.commit()
+    acct_full = calculation_service.get_overtime_account(db, test_user, 2026, 3)
+
+    assert (acct_full - acct_half) == Decimal('4.00'), (acct_full, acct_half)
+
+
+def test_half_day_history_matches_account(db, test_user):
+    """get_overtime_history bleibt bitgleich zu get_overtime_account auch mit Halbtag."""
+    _absence(db, test_user, MON, AbsenceType.VACATION, 4.0, half_day=True)
+    _entry(db, test_user, MON, 8, 12)
+    for d in (TUE, WED, THU, FRI):
+        _entry(db, test_user, d, 8, 16)
+    acct = calculation_service.get_overtime_account(db, test_user, 2026, 3)
+    hist = calculation_service.get_overtime_history(db, test_user, 2026, 3)
+    assert hist[(2026, 3)] == acct, (hist.get((2026, 3)), acct)
+
+
+def test_half_day_in_ytd_summary(db, test_user):
+    """Das Halbtags-Soll greift auch im YTD-Summary (vierte Soll-Schleife)."""
+    _absence(db, test_user, MON, AbsenceType.VACATION, 4.0, half_day=True)
+    ytd_half = calculation_service.get_ytd_summary(db, test_user, 2026)
+
+    a = db.query(Absence).filter(Absence.user_id == test_user.id, Absence.date == MON).one()
+    a.half_day = False
+    a.hours = 8.0
+    db.commit()
+    ytd_full = calculation_service.get_ytd_summary(db, test_user, 2026)
+
+    # Voll-Tag entfernt 8h Soll, Halbtag nur 4h → Halbtag-Soll ist 4h höher.
+    assert round(ytd_half["target_hours"] - ytd_full["target_hours"], 2) == 4.0

--- a/backend/tests/test_fix2_whchange_daily_schedule.py
+++ b/backend/tests/test_fix2_whchange_daily_schedule.py
@@ -1,0 +1,72 @@
+"""Fix #2: eine WorkingHoursChange ist für use_daily_schedule-MA wirkungslos
+(get_daily_target_for_date liest dann nur hours_mon…fri, NICHT weekly_hours) →
+die Stunden-Historie hätte null Effekt aufs Soll, die UI zeigte aber den neuen
+Wert (stille falsche §16-Records). Entscheidung: solche Anträge mit HTTP 400
+ablehnen, statt eine wirkungslose Historie zu schreiben.
+"""
+from datetime import date
+
+import pytest
+from fastapi import HTTPException
+
+from app.models import User, UserRole, WorkingHoursChange
+from app.routers.admin_users import create_working_hours_change
+from app.schemas.working_hours_change import WorkingHoursChangeCreate
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _make_user(db, username, **kwargs):
+    defaults = dict(
+        email=f"{username}@x.de", password_hash="h", first_name=username,
+        last_name="T", role=UserRole.EMPLOYEE, weekly_hours=40.0, vacation_days=30,
+        work_days_per_week=5, is_active=True, tenant_id=DEFAULT_TENANT_ID,
+    )
+    defaults.update(kwargs)
+    u = User(username=username, **defaults)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _admin(db):
+    return _make_user(db, "wh_admin", role=UserRole.ADMIN)
+
+
+def test_whchange_rejected_for_daily_schedule_user(db, default_tenant):
+    """use_daily_schedule=True → 400, KEINE Historie geschrieben."""
+    admin = _admin(db)
+    emp = _make_user(
+        db, "wh_daily", use_daily_schedule=True,
+        hours_monday=8.0, hours_tuesday=8.0, hours_wednesday=8.0,
+        hours_thursday=8.0, hours_friday=8.0,
+    )
+    with pytest.raises(HTTPException) as exc:
+        create_working_hours_change(
+            user_id=str(emp.id),
+            change_data=WorkingHoursChangeCreate(
+                effective_from=date(2026, 1, 1), weekly_hours=20.0,
+            ),
+            db=db, current_user=admin,
+        )
+    assert exc.value.status_code == 400
+    assert "individuellem Tagesplan" in exc.value.detail
+    # Keine WHChange-Zeile persistiert.
+    n = db.query(WorkingHoursChange).filter(WorkingHoursChange.user_id == emp.id).count()
+    assert n == 0
+
+
+def test_whchange_ok_for_normal_user(db, default_tenant):
+    """Normaler MA (use_daily_schedule=False) → unverändert ok, Zeile angelegt."""
+    admin = _admin(db)
+    emp = _make_user(db, "wh_normal")  # use_daily_schedule default False
+    result = create_working_hours_change(
+        user_id=str(emp.id),
+        change_data=WorkingHoursChangeCreate(
+            effective_from=date(2026, 1, 1), weekly_hours=20.0,
+        ),
+        db=db, current_user=admin,
+    )
+    assert float(result.weekly_hours) == 20.0
+    n = db.query(WorkingHoursChange).filter(WorkingHoursChange.user_id == emp.id).count()
+    assert n == 1

--- a/backend/tests/test_fix3_resplit_dt_day_filter.py
+++ b/backend/tests/test_fix3_resplit_dt_day_filter.py
@@ -1,0 +1,165 @@
+"""Fix #3: resplit_year_closures berechnet ``consumed`` (privater Urlaub + freie
+Sondertage) ohne den ``dt_day>0``-Filter, den get_vacation_account anwendet.
+
+An einem für den MA freien Wochentag (use_daily_schedule, Tagessoll 0), der mit
+einem freien+counts_as_vacation-Sondertag (24.12.) bzw. mit einem privaten
+Urlaubstag zusammenfällt, überzählte ``consumed`` → closure_budget zu klein →
+ein Closure-Tag fiel fälschlich auf OVERTIME statt VACATION.
+
+2026: 24.12. ist ein Donnerstag → bei einem MA mit freiem Donnerstag ist das
+Tagessoll dort 0.
+"""
+import uuid
+from datetime import date
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.database import Base, get_db
+from app.middleware.auth import get_current_user, require_admin
+from app.models import User, UserRole, Absence, AbsenceType
+from app.models.tenant import Tenant
+from app.models.system_setting import SystemSetting
+from app.services import auth_service
+from tests.conftest import DEFAULT_TENANT_ID, engine, TestingSessionLocal
+
+# Saubere Woche im März 2026 (keine Feiertage): Mo/Di/Mi sind Arbeitstage,
+# Do ist beim Test-MA frei.
+MON, TUE, WED, THU = date(2026, 3, 9), date(2026, 3, 10), date(2026, 3, 11), date(2026, 3, 12)
+
+
+def _create_test_app() -> FastAPI:
+    from app.routers import company_closures
+    from app.core.limiter import limiter
+    from slowapi import _rate_limit_exceeded_handler
+    from slowapi.errors import RateLimitExceeded
+
+    app = FastAPI()
+    limiter.enabled = False
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.include_router(company_closures.router)
+    return app
+
+
+_app = _create_test_app()
+
+
+@pytest.fixture(scope="function")
+def db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def default_tenant(db):
+    t = Tenant(id=DEFAULT_TENANT_ID, name="Default", slug="default", is_active=True, mode="single")
+    db.add(t)
+    db.commit()
+    return t
+
+
+def _make_user(db, username, role=UserRole.EMPLOYEE, vacation_days=30, **kwargs):
+    defaults = dict(
+        email=f"{username}@x.de", password_hash=auth_service.hash_password("t"),
+        first_name=username, last_name="T", role=role, weekly_hours=40.0,
+        vacation_days=vacation_days, work_days_per_week=5, is_active=True,
+        track_hours=True, tenant_id=DEFAULT_TENANT_ID,
+    )
+    defaults.update(kwargs)
+    u = User(username=username, **defaults)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _daily_user(db, username, vacation_days):
+    """MA mit individuellem Tagesplan: Mo/Di/Mi/Fr je 8h, Donnerstag FREI (0h)."""
+    return _make_user(
+        db, username, vacation_days=vacation_days, use_daily_schedule=True,
+        hours_monday=8.0, hours_tuesday=8.0, hours_wednesday=8.0,
+        hours_thursday=None, hours_friday=8.0,
+    )
+
+
+def _set_toggle(db, on):
+    db.merge(SystemSetting(key="closure_overtime_after_vacation", tenant_id=DEFAULT_TENANT_ID,
+                           value="true" if on else "false"))
+    db.commit()
+
+
+def _set_dec24_free(db):
+    db.merge(SystemSetting(key="special_day_dec24_mode", tenant_id=DEFAULT_TENANT_ID, value="free"))
+    db.commit()
+
+
+def _closure_types(db, emp, closure_id):
+    return [a.type for a in db.query(Absence).filter(
+        Absence.user_id == emp.id, Absence.closure_id == uuid.UUID(closure_id),
+    ).order_by(Absence.date).all()]
+
+
+@pytest.fixture
+def admin(db, default_tenant):
+    return _make_user(db, "admin1", role=UserRole.ADMIN, receives_company_closures=False)
+
+
+@pytest.fixture
+def admin_client(db, admin):
+    def override_db():
+        yield db
+    _app.dependency_overrides[get_db] = override_db
+    _app.dependency_overrides[get_current_user] = lambda: admin
+    _app.dependency_overrides[require_admin] = lambda: admin
+    yield TestClient(_app)
+    _app.dependency_overrides.clear()
+
+
+def _make_closure_mon_wed(client):
+    r = client.post("/api/company-closures/", json={
+        "name": "BF", "start_date": MON.isoformat(), "end_date": WED.isoformat(),
+        "counts_as_vacation": True,
+    })
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def test_free_special_day_on_off_day_not_counted(db, default_tenant, admin_client):
+    """24.12. (Do, beim MA freier Tag → Tagessoll 0) darf consumed NICHT erhöhen:
+    Budget 3, Closure Mo–Mi (3 Arbeitstage) → alle 3 bleiben VACATION."""
+    emp = _daily_user(db, "e_freeday", vacation_days=3)
+    _set_toggle(db, True)
+    _set_dec24_free(db)  # 24.12.2026 = free + counts_as_vacation (Do)
+
+    closure_id = _make_closure_mon_wed(admin_client)
+
+    types = _closure_types(db, emp, closure_id)
+    assert types == [AbsenceType.VACATION] * 3, types
+
+
+def test_private_vacation_on_off_day_not_counted(db, default_tenant, admin_client):
+    """Privater Urlaub an einem freien Donnerstag (Tagessoll 0) darf consumed
+    NICHT erhöhen — Budget 3, Closure Mo–Mi → alle 3 bleiben VACATION."""
+    emp = _daily_user(db, "e_privoff", vacation_days=3)
+    _set_toggle(db, True)
+
+    # Privater Urlaub am freien Donnerstag (dt_day=0). get_vacation_account
+    # zählt ihn nicht (used_days unverändert); resplit darf das auch nicht.
+    priv = Absence(
+        user_id=emp.id, tenant_id=DEFAULT_TENANT_ID, date=THU,
+        type=AbsenceType.VACATION, hours=0.0, half_day=False,
+    )
+    db.add(priv)
+    db.commit()
+
+    closure_id = _make_closure_mon_wed(admin_client)
+
+    types = _closure_types(db, emp, closure_id)
+    assert types == [AbsenceType.VACATION] * 3, types

--- a/backend/tests/test_fix4_cr_update_vacation_budget.py
+++ b/backend/tests/test_fix4_cr_update_vacation_budget.py
@@ -1,0 +1,126 @@
+"""Fix #4: der UPDATE-Branch der CR-Genehmigung (review_change_request) setzte
+absence.type=VACATION + buchte das Tagessoll OHNE Urlaubsbudget-Check — der
+CREATE-Branch prüft ihn. → Eine Genehmigung konnte das Budget überziehen.
+
+Geprüft wird der NETTO-Neuverbrauch (post − bisher gezählt), damit ein reiner
+Zeit-Edit eines bestehenden Urlaubstags nicht fälschlich scheitert.
+"""
+from datetime import date, time
+
+import pytest
+from fastapi import HTTPException
+
+from app.models import (
+    User, UserRole, Absence, AbsenceType,
+    ChangeRequest, ChangeRequestType, ChangeRequestStatus,
+)
+from app.routers.admin_change_requests import review_change_request
+from app.schemas.change_request import ChangeRequestReview
+from tests.conftest import DEFAULT_TENANT_ID
+
+WORKDAY = date(2026, 3, 10)  # Dienstag
+
+
+def _make_user(db, username, role=UserRole.EMPLOYEE, vacation_days=30, **kwargs):
+    defaults = dict(
+        email=f"{username}@x.de", password_hash="h", first_name=username,
+        last_name="T", role=role, weekly_hours=40.0, vacation_days=vacation_days,
+        work_days_per_week=5, is_active=True, track_hours=True, tenant_id=DEFAULT_TENANT_ID,
+    )
+    defaults.update(kwargs)
+    u = User(username=username, **defaults)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _make_absence(db, user, d, absence_type, hours, half_day=False):
+    a = Absence(
+        user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+        type=absence_type, hours=hours, half_day=half_day,
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def _make_update_cr(db, user, absence, **kwargs):
+    defaults = dict(
+        user_id=user.id, tenant_id=DEFAULT_TENANT_ID,
+        request_type=ChangeRequestType.UPDATE, entry_kind="absence",
+        status=ChangeRequestStatus.PENDING, reason="Testantrag",
+        absence_id=absence.id,
+    )
+    defaults.update(kwargs)
+    cr = ChangeRequest(**defaults)
+    db.add(cr)
+    db.commit()
+    db.refresh(cr)
+    return cr
+
+
+def test_update_to_vacation_overrun_rejected(db, default_tenant):
+    """remaining_days=0, SICK-Absence per CR-UPDATE auf VACATION → 400."""
+    admin = _make_user(db, "fx4_admin", role=UserRole.ADMIN)
+    emp = _make_user(db, "fx4_emp", vacation_days=0)  # Budget 0 → remaining 0
+    sick = _make_absence(db, emp, WORKDAY, AbsenceType.SICK, 8.0)
+    cr = _make_update_cr(
+        db, emp, sick,
+        proposed_date=WORKDAY, proposed_absence_type="vacation",
+        proposed_absence_hours=8.0,
+    )
+    with pytest.raises(HTTPException) as exc:
+        review_change_request(
+            request_id=str(cr.id),
+            review=ChangeRequestReview(action="approve"),
+            db=db, current_user=admin,
+        )
+    assert exc.value.status_code == 400
+    assert "Urlaubstage" in exc.value.detail
+    db.rollback()
+    db.refresh(sick)
+    # Typ unverändert (Mutation nicht durchgeführt).
+    assert sick.type == AbsenceType.SICK
+
+
+def test_update_to_vacation_within_budget_ok(db, default_tenant):
+    """Genug Budget → SICK→VACATION per CR-UPDATE wird genehmigt."""
+    admin = _make_user(db, "fx4_admin2", role=UserRole.ADMIN)
+    emp = _make_user(db, "fx4_emp2", vacation_days=30)
+    sick = _make_absence(db, emp, WORKDAY, AbsenceType.SICK, 8.0)
+    cr = _make_update_cr(
+        db, emp, sick,
+        proposed_date=WORKDAY, proposed_absence_type="vacation",
+        proposed_absence_hours=8.0,
+    )
+    review_change_request(
+        request_id=str(cr.id),
+        review=ChangeRequestReview(action="approve"),
+        db=db, current_user=admin,
+    )
+    db.refresh(sick)
+    assert sick.type == AbsenceType.VACATION
+
+
+def test_update_existing_vacation_time_edit_not_blocked(db, default_tenant):
+    """Reiner Zeit-Edit eines BESTEHENDEN Urlaubstags (Typ bleibt VACATION,
+    Datum gleich) darf trotz remaining_days=0 NICHT scheitern (net_new=0)."""
+    admin = _make_user(db, "fx4_admin3", role=UserRole.ADMIN)
+    emp = _make_user(db, "fx4_emp3", vacation_days=1)  # Budget 1
+    vac = _make_absence(db, emp, WORKDAY, AbsenceType.VACATION, 8.0)  # verbraucht 1 → rest 0
+    cr = _make_update_cr(
+        db, emp, vac,
+        proposed_date=WORKDAY, proposed_absence_type="vacation",
+        proposed_absence_hours=8.0,
+        proposed_start_time=time(9, 0), proposed_end_time=time(13, 0),
+    )
+    # Darf NICHT 400 werfen, obwohl remaining_days == 0.
+    review_change_request(
+        request_id=str(cr.id),
+        review=ChangeRequestReview(action="approve"),
+        db=db, current_user=admin,
+    )
+    db.refresh(vac)
+    assert vac.type == AbsenceType.VACATION

--- a/backend/tests/test_fix5_cr_absence_resplit.py
+++ b/backend/tests/test_fix5_cr_absence_resplit.py
@@ -1,0 +1,223 @@
+"""Fix #5: die CR-Absence-Pfade (CREATE/UPDATE/DELETE) riefen NICHT
+closure_split_service.resplit_year_closures — alle anderen VACATION-anlegen/
+löschen-Pfade tun das (bei aktivem Setting closure_overtime_after_vacation),
+damit Betriebsferien-Tage korrekt zwischen VACATION/OVERTIME umklappen.
+
+Szenario: Betriebsferien mit reserviertem OVERTIME-Puffer; ein CR storniert
+(DELETE) bzw. ändert (UPDATE: VACATION→SICK) privaten Urlaub → ein
+Closure-OVERTIME-Tag klappt korrekt auf VACATION zurück.
+"""
+import uuid
+from datetime import date
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.database import Base, get_db
+from app.middleware.auth import get_current_user, require_admin
+from app.models import (
+    User, UserRole, Absence, AbsenceType,
+    ChangeRequest, ChangeRequestType, ChangeRequestStatus,
+)
+from app.models.tenant import Tenant
+from app.models.system_setting import SystemSetting
+from app.services import auth_service
+from app.routers.admin_change_requests import review_change_request
+from app.schemas.change_request import ChangeRequestReview
+from tests.conftest import DEFAULT_TENANT_ID, engine, TestingSessionLocal
+
+MON, TUE, WED, THU = date(2025, 3, 10), date(2025, 3, 11), date(2025, 3, 12), date(2025, 3, 13)
+PRIV_VAC_DAY = date(2025, 3, 3)  # Montag vor der Schließung, Arbeitstag
+
+
+def _create_test_app() -> FastAPI:
+    from app.routers import company_closures
+    from app.core.limiter import limiter
+    from slowapi import _rate_limit_exceeded_handler
+    from slowapi.errors import RateLimitExceeded
+
+    app = FastAPI()
+    limiter.enabled = False
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.include_router(company_closures.router)
+    return app
+
+
+_app = _create_test_app()
+
+
+@pytest.fixture(scope="function")
+def db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def default_tenant(db):
+    t = Tenant(id=DEFAULT_TENANT_ID, name="Default", slug="default", is_active=True, mode="single")
+    db.add(t)
+    db.commit()
+    return t
+
+
+def _make_user(db, username, role=UserRole.EMPLOYEE, vacation_days=30, **kwargs):
+    defaults = dict(
+        email=f"{username}@x.de", password_hash=auth_service.hash_password("t"),
+        first_name=username, last_name="T", role=role, weekly_hours=40.0,
+        vacation_days=vacation_days, work_days_per_week=5, is_active=True,
+        track_hours=True, tenant_id=DEFAULT_TENANT_ID,
+    )
+    defaults.update(kwargs)
+    u = User(username=username, **defaults)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _set_toggle(db, on):
+    db.merge(SystemSetting(key="closure_overtime_after_vacation", tenant_id=DEFAULT_TENANT_ID,
+                           value="true" if on else "false"))
+    db.commit()
+
+
+def _closure_types(db, emp, closure_id):
+    return [a.type for a in db.query(Absence).filter(
+        Absence.user_id == emp.id, Absence.closure_id == uuid.UUID(closure_id),
+    ).order_by(Absence.date).all()]
+
+
+@pytest.fixture
+def admin(db, default_tenant):
+    return _make_user(db, "admin1", role=UserRole.ADMIN, receives_company_closures=False)
+
+
+@pytest.fixture
+def admin_client(db, admin):
+    def override_db():
+        yield db
+    _app.dependency_overrides[get_db] = override_db
+    _app.dependency_overrides[get_current_user] = lambda: admin
+    _app.dependency_overrides[require_admin] = lambda: admin
+    yield TestClient(_app)
+    _app.dependency_overrides.clear()
+
+
+def _make_closure(admin_client):
+    r = admin_client.post("/api/company-closures/", json={
+        "name": "BF", "start_date": MON.isoformat(), "end_date": THU.isoformat(),
+        "counts_as_vacation": True,
+    })
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def _make_absence_cr(db, user, request_type, **kwargs):
+    defaults = dict(
+        user_id=user.id, tenant_id=DEFAULT_TENANT_ID,
+        request_type=request_type, entry_kind="absence",
+        status=ChangeRequestStatus.PENDING, reason="Test",
+    )
+    defaults.update(kwargs)
+    cr = ChangeRequest(**defaults)
+    db.add(cr)
+    db.commit()
+    db.refresh(cr)
+    return cr
+
+
+def test_cr_delete_private_vacation_flips_closure_back(db, default_tenant, admin, admin_client):
+    """CR-DELETE eines privaten Urlaubstags → 1 Budget-Tag frei → Resplit →
+    ein Closure-OVERTIME-Tag klappt auf VACATION (3 VAC + 1 OT statt 2/2)."""
+    emp = _make_user(db, "e_del", vacation_days=3)
+    _set_toggle(db, True)
+
+    priv = Absence(
+        user_id=emp.id, tenant_id=DEFAULT_TENANT_ID, date=PRIV_VAC_DAY,
+        type=AbsenceType.VACATION, hours=8.0, half_day=False,
+    )
+    db.add(priv)
+    db.commit()
+    db.refresh(priv)
+
+    closure_id = _make_closure(admin_client)
+    before = _closure_types(db, emp, closure_id)
+    assert before.count(AbsenceType.VACATION) == 2
+    assert before.count(AbsenceType.OVERTIME) == 2
+
+    cr = _make_absence_cr(db, emp, ChangeRequestType.DELETE, absence_id=priv.id)
+    review_change_request(
+        request_id=str(cr.id),
+        review=ChangeRequestReview(action="approve"),
+        db=db, current_user=admin,
+    )
+
+    after = _closure_types(db, emp, closure_id)
+    assert after.count(AbsenceType.VACATION) == 3, after
+    assert after.count(AbsenceType.OVERTIME) == 1, after
+
+
+def test_cr_update_vacation_to_sick_flips_closure_back(db, default_tenant, admin, admin_client):
+    """CR-UPDATE: privater VACATION→SICK → 1 Budget-Tag frei → Resplit →
+    Closure 3 VAC + 1 OT statt 2/2."""
+    emp = _make_user(db, "e_upd", vacation_days=3)
+    _set_toggle(db, True)
+
+    priv = Absence(
+        user_id=emp.id, tenant_id=DEFAULT_TENANT_ID, date=PRIV_VAC_DAY,
+        type=AbsenceType.VACATION, hours=8.0, half_day=False,
+    )
+    db.add(priv)
+    db.commit()
+    db.refresh(priv)
+
+    closure_id = _make_closure(admin_client)
+    assert _closure_types(db, emp, closure_id).count(AbsenceType.OVERTIME) == 2
+
+    cr = _make_absence_cr(
+        db, emp, ChangeRequestType.UPDATE,
+        absence_id=priv.id, proposed_date=PRIV_VAC_DAY,
+        proposed_absence_type="sick", proposed_absence_hours=8.0,
+    )
+    review_change_request(
+        request_id=str(cr.id),
+        review=ChangeRequestReview(action="approve"),
+        db=db, current_user=admin,
+    )
+
+    after = _closure_types(db, emp, closure_id)
+    assert after.count(AbsenceType.VACATION) == 3, after
+    assert after.count(AbsenceType.OVERTIME) == 1, after
+
+
+def test_cr_delete_no_resplit_when_toggle_off(db, default_tenant, admin, admin_client):
+    """Setting AUS: Closure bleibt alles VACATION (kein Split); CR-DELETE des
+    privaten Urlaubs ändert daran nichts (kein Resplit, kein Crash)."""
+    emp = _make_user(db, "e_off", vacation_days=3)
+    _set_toggle(db, False)
+
+    priv = Absence(
+        user_id=emp.id, tenant_id=DEFAULT_TENANT_ID, date=PRIV_VAC_DAY,
+        type=AbsenceType.VACATION, hours=8.0, half_day=False,
+    )
+    db.add(priv)
+    db.commit()
+    db.refresh(priv)
+
+    closure_id = _make_closure(admin_client)
+    assert _closure_types(db, emp, closure_id) == [AbsenceType.VACATION] * 4
+
+    cr = _make_absence_cr(db, emp, ChangeRequestType.DELETE, absence_id=priv.id)
+    review_change_request(
+        request_id=str(cr.id),
+        review=ChangeRequestReview(action="approve"),
+        db=db, current_user=admin,
+    )
+    assert _closure_types(db, emp, closure_id) == [AbsenceType.VACATION] * 4


### PR DESCRIPTION
Behebt die 5 im Tiefenreview (Stundenzählung/Urlaub/Anträge) bestätigten Logiklücken (alle medium), je mit Test:

1. **Halbtags-Abwesenheit** reduzierte das **volle** Tagessoll statt 0,5× → Phantom-Überstunden / halber Urlaubstag für ganzen freien Tag. Jetzt half_day-bewusst in **allen 4 Soll-Schleifen** (gemeinsamer Helper `_day_soll_contribution`; Special-Day-Faktor dann ×0,5). Vollzeit-/Legacy-Verhalten unverändert.
2. **WorkingHoursChange** war für `use_daily_schedule`-MA wirkungslos (still falsche §16-Records) → jetzt **400-Ablehnung** mit Hinweis (Historisierung der Tagesspalten = separates Feature).
3. **Resplit `consumed`** zählte freie Sondertage/Privaturlaub ohne `dt_day>0`-Filter → Closure-Tag fälschlich OVERTIME. Jetzt gleiche Tagessoll-Prüfung wie `get_vacation_account`.
4. **CR-Absence-UPDATE→VACATION** ohne Budget-Check → Überziehung. Jetzt **net-new-consumption**-Budget-Check (reine Zeit-Edits bestehender Urlaubstage werden nicht fälschlich abgelehnt).
5. **CR-Absence-Genehmigung** (CREATE/UPDATE/DELETE) triggert jetzt `resplit_year_closures` (toggle-gated) → kein stale Betriebsferien-Split mehr.

**Tests:** 5 neue Test-Dateien + `test_edge_cases` angepasst (Halbtag −4h statt nur „<voll"); volle SQLite-Suite **1196 passed**; 151 betroffene grün. Keine Migration.
