### PR TITLE
refactor: 7 technische Perf-/Qualitäts-Fixes (UI/DB/Services), verhaltensneutral

### DIFF
--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -408,18 +408,30 @@ def create_absence(
     # between this check and the INSERT below. The DB-level unique constraint
     # is (tenant_id, user_id, date, type) — different types on the same day
     # would slip through without the row lock, causing double-booking.
+    # Fix #6: alle bestehenden Absences der Ziel-Tage in EINER gesperrten Query
+    # laden statt N× .with_for_update().first() (eine Query pro Datum). setdefault
+    # behält die erste Zeile je Datum und spiegelt damit das frühere
+    # .first()-Verhalten für den Regelfall (höchstens eine Absence je
+    # (user, date); das UNIQUE ist (tenant, user, date, type)). Es werden
+    # dieselben Zeilen gesperrt; die User-Zeile ist für VACATION bereits oben
+    # gesperrt (gleiche Lock-Reihenfolge User -> Absence).
+    existing_rows = (
+        db.query(Absence)
+        .filter(
+            Absence.user_id == target_user.id,
+            Absence.tenant_id == target_user.tenant_id,
+            Absence.date.in_(dates_to_create),
+        )
+        .with_for_update()
+        .all()
+    )
+    existing_by_date = {}
+    for a in existing_rows:
+        existing_by_date.setdefault(a.date, a)
+
     skip_dates = []
     for d in dates_to_create:
-        existing = (
-            db.query(Absence)
-            .filter(
-                Absence.user_id == target_user.id,
-                Absence.tenant_id == target_user.tenant_id,
-                Absence.date == d,
-            )
-            .with_for_update()
-            .first()
-        )
+        existing = existing_by_date.get(d)
 
         if existing:
             if existing.type == absence_data.type:

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -156,11 +156,15 @@ def get_overtime_account(
     # Stichtag trimmt allein den aktuellen Monat (vergangene Monate liegen davor).
     cutoff = calculation_service.get_soll_cutoff_date(db, current_user)
 
-    # #150: das kumulative Konto EINMAL als Single-Pass holen, statt
-    # get_overtime_account pro Monat zu rufen (jede Einzelrufung iteriert ab
-    # Carryover-Start neu -> O(Monate²)). history_map[(y,m)] entspricht bitgenau
-    # get_overtime_account(y,m) (gepinnt: test_overtime_history_matches_account).
-    history_map = calculation_service.get_overtime_history(db, current_user, now.year, now.month, cutoff_date=cutoff)
+    # #150 / Fix #3: Soll/Ist/Saldo/Konto je Monat in EINEM Single-Pass holen.
+    # detailed[(y,m)] liefert target/actual (bitgleich zu get_monthly_target/
+    # get_monthly_actual) UND cumulative (bitgleich zu get_overtime_account) —
+    # so entfallen die zusätzlichen Per-Monat-Calls (vorher O(Monate²)).
+    # Invarianten gepinnt in test_overtime_history_matches_account /
+    # test_overtime_history_detailed_matches_monthly.
+    history_detail = calculation_service.get_overtime_history_detailed(
+        db, current_user, now.year, now.month, cutoff_date=cutoff
+    )
 
     if first_entry:
         start_year = first_entry.date.year
@@ -171,10 +175,20 @@ def get_overtime_account(
 
         # Build history month by month
         while (current_year < now.year) or (current_year == now.year and current_month <= now.month):
-            target = calculation_service.get_monthly_target(db, current_user, current_year, current_month, up_to_date=cutoff)
-            actual = calculation_service.get_monthly_actual(db, current_user, current_year, current_month, up_to_date=cutoff)
+            entry = history_detail.get((current_year, current_month))
+            if entry is not None:
+                target = entry.target
+                actual = entry.actual
+                cumulative = entry.cumulative
+            else:
+                # Months before the history range (e.g. before the first time
+                # entry / carryover in an untracked-or-empty case) — fall back to
+                # the exact previous behaviour: 0 cumulative + direct per-month
+                # Soll/Ist (get_overtime_account would also yield 0.00 here).
+                target = calculation_service.get_monthly_target(db, current_user, current_year, current_month, up_to_date=cutoff)
+                actual = calculation_service.get_monthly_actual(db, current_user, current_year, current_month, up_to_date=cutoff)
+                cumulative = Decimal('0.00')
             balance = actual - target
-            cumulative = history_map.get((current_year, current_month), Decimal('0.00'))
 
             history.append(OvertimeHistory(
                 year=current_year,
@@ -193,7 +207,8 @@ def get_overtime_account(
                 current_month += 1
 
     # Current balance
-    current_balance = history_map.get((now.year, now.month), Decimal('0.00'))
+    current_month_detail = history_detail.get((now.year, now.month))
+    current_balance = current_month_detail.cumulative if current_month_detail is not None else Decimal('0.00')
 
     return OvertimeAccount(
         current_balance=current_balance,

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -3,7 +3,7 @@ from app.services.timezone_service import today_local
 from app.services.date_filters import date_in_year, date_in_month, date_in_range
 from decimal import Decimal
 from calendar import monthrange
-from typing import Dict, List, Optional
+from typing import Dict, List, NamedTuple, Optional
 from sqlalchemy.orm import Session
 from sqlalchemy import func, extract
 from app.models import User, TimeEntry, Absence, PublicHoliday, AbsenceType, WorkingHoursChange, YearCarryover
@@ -666,17 +666,36 @@ def get_overtime_account(
     return total_balance.quantize(Decimal('0.01'))
 
 
-def get_overtime_history(
-    db: Session, user: User, up_to_year: int, up_to_month: int, cutoff_date: date = None
-) -> Dict[tuple, Decimal]:
-    """Kumulatives Überstundenkonto NACH jedem Monat (Start..up_to) in EINEM Pass.
+class MonthlyOvertime(NamedTuple):
+    """Per-Monat-Aufschlüsselung aus :func:`get_overtime_history_detailed`.
 
-    Invariante: für jeden Monat (y, m) im Bereich gilt
-        get_overtime_history(...)[(y, m)] == get_overtime_account(db, user, y, m)
-    (gepinnt durch test_overtime_history_matches_account). #150: damit baut das
-    Dashboard seine Monats-History in O(Monate) statt get_overtime_account pro
-    Monat zu rufen (O(Monate²), weil jede Einzelrufung ab Carryover-Start neu
-    iteriert). Leeres Dict bei track_hours=False / keinen Daten.
+    ``target``/``actual`` sind auf 0.01 quantisiert und damit bitgleich zu
+    :func:`get_monthly_target` / :func:`get_monthly_actual` (gleicher cutoff);
+    ``cumulative`` ist bitgleich zu :func:`get_overtime_account`.
+    """
+    target: Decimal
+    actual: Decimal
+    cumulative: Decimal
+
+
+def get_overtime_history_detailed(
+    db: Session, user: User, up_to_year: int, up_to_month: int, cutoff_date: date = None
+) -> Dict[tuple, "MonthlyOvertime"]:
+    """Soll/Ist/Konto NACH jedem Monat (Start..up_to) in EINEM Pass.
+
+    Liefert je Monat (y, m) ein :class:`MonthlyOvertime` mit ``target``,
+    ``actual`` und ``cumulative``. Invarianten (gepinnt):
+        detailed[(y, m)].cumulative == get_overtime_account(db, user, y, m)
+        detailed[(y, m)].target     == get_monthly_target(db, user, y, m)
+        detailed[(y, m)].actual     == get_monthly_actual(db, user, y, m)
+    (jeweils mit demselben cutoff_date).
+
+    #150 / Fix #3: damit baut das Dashboard Soll/Ist/Saldo/Konto je Monat aus
+    EINEM Single-Pass — statt get_monthly_target + get_monthly_actual ZUSÄTZLICH
+    pro Monat zu rufen (jede Einzelrufung iteriert neu -> O(Monate²)).
+    :func:`get_overtime_history` ist ein dünner Wrapper, der nur ``cumulative``
+    zurückgibt (alter Vertrag + Invariante unverändert). Leeres Dict bei
+    track_hours=False / keinen Daten.
 
     Wie get_overtime_account ist ein YearCarryover ein Reset-Punkt: im Januar
     eines Jahres MIT eigenem Carryover startet der laufende Saldo neu vom
@@ -770,7 +789,7 @@ def get_overtime_history(
             special_day_configs[yr] = c
         return c
 
-    history: Dict[tuple, Decimal] = {}
+    history: Dict[tuple, MonthlyOvertime] = {}
     total_balance = initial_balance
     cy, cm = start_year, start_month
 
@@ -802,7 +821,15 @@ def get_overtime_history(
 
         monthly_actual = actual_by_month.get((cy, cm), Decimal('0'))
         total_balance += (monthly_actual - monthly_target)
-        history[(cy, cm)] = total_balance.quantize(Decimal('0.01'))
+        # cumulative wird (wie zuvor) aus den UNquantisierten Monatswerten
+        # akkumuliert und erst beim Speichern quantisiert -> bitgleich zu
+        # get_overtime_account. target/actual zusätzlich auf 0.01 quantisiert,
+        # damit sie get_monthly_target/get_monthly_actual exakt entsprechen.
+        history[(cy, cm)] = MonthlyOvertime(
+            target=monthly_target.quantize(Decimal('0.01')),
+            actual=monthly_actual.quantize(Decimal('0.01')),
+            cumulative=total_balance.quantize(Decimal('0.01')),
+        )
 
         if cm == 12:
             cm = 1
@@ -811,6 +838,25 @@ def get_overtime_history(
             cm += 1
 
     return history
+
+
+def get_overtime_history(
+    db: Session, user: User, up_to_year: int, up_to_month: int, cutoff_date: date = None
+) -> Dict[tuple, Decimal]:
+    """Kumulatives Überstundenkonto NACH jedem Monat (Start..up_to) in EINEM Pass.
+
+    Invariante: für jeden Monat (y, m) im Bereich gilt
+        get_overtime_history(...)[(y, m)] == get_overtime_account(db, user, y, m)
+    (gepinnt durch test_overtime_history_matches_account). Dünner Wrapper um
+    :func:`get_overtime_history_detailed` — gibt nur den kumulativen Saldo
+    zurück (alter Vertrag unverändert).
+    """
+    return {
+        k: v.cumulative
+        for k, v in get_overtime_history_detailed(
+            db, user, up_to_year, up_to_month, cutoff_date=cutoff_date
+        ).items()
+    }
 
 
 def get_ytd_summary(db: Session, user: User, year: int = None, cutoff_date: date = None) -> Dict:

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -1074,6 +1074,10 @@ def _create_employee_classic_sheet(wb: Workbook, db: Session, user: User, year: 
     # History-Bereich liefert get_overtime_account 0.00 -> Default.
     overtime_history = calculation_service.get_overtime_history(db, user, year, 12)
 
+    # Fix #7: das Urlaubskonto hängt nur an (user, year) und ist über alle 12
+    # Monate identisch — EINMAL vor der Schleife berechnen statt pro Monat.
+    vacation_account = calculation_service.get_vacation_account(db, user, year)
+
     # Calculate data for each month
     for month in range(1, 13):
         col = month + 2  # Column 3 = January, ..., Column 14 = December
@@ -1171,8 +1175,7 @@ def _create_employee_classic_sheet(wb: Workbook, db: Session, user: User, year: 
         elif cumulative_overtime < 0:
             sheet.cell(row=14, column=col).fill = PatternFill(start_color='FFC7CE', end_color='FFC7CE', fill_type='solid')
 
-        # Row 15: Remaining vacation in hours
-        vacation_account = calculation_service.get_vacation_account(db, user, year)
+        # Row 15: Remaining vacation in hours (vacation_account: s. o., 1× berechnet)
         # Calculate remaining vacation up to this month.
         # F-026 (Review 2026-06-23): explizit auf den Tenant scopen.
         vacation_used_ytd = sum(

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -1066,6 +1066,14 @@ def _create_employee_classic_sheet(wb: Workbook, db: Session, user: User, year: 
     for row in range(6, 17):
         sheet.cell(row=row, column=1).font = normal_font
 
+    # #150/Fix #4: das kumulative Überstundenkonto je Monat (Row 14) EINMAL als
+    # Single-Pass holen, statt get_overtime_account pro Monat zu rufen (jede
+    # Einzelrufung iteriert ab Carryover-Start neu -> O(Monate²)).
+    # history[(year, m)] entspricht bitgenau get_overtime_account(year, m)
+    # (gepinnt: test_overtime_history_matches_account); Monate vor dem
+    # History-Bereich liefert get_overtime_account 0.00 -> Default.
+    overtime_history = calculation_service.get_overtime_history(db, user, year, 12)
+
     # Calculate data for each month
     for month in range(1, 13):
         col = month + 2  # Column 3 = January, ..., Column 14 = December
@@ -1150,8 +1158,8 @@ def _create_employee_classic_sheet(wb: Workbook, db: Session, user: User, year: 
         elif monthly_balance < 0:
             sheet.cell(row=12, column=col).fill = PatternFill(start_color='FFC7CE', end_color='FFC7CE', fill_type='solid')
 
-        # Row 14: Cumulative overtime
-        cumulative_overtime = calculation_service.get_overtime_account(db, user, year, month)
+        # Row 14: Cumulative overtime (Fix #4: aus dem Single-Pass-History)
+        cumulative_overtime = overtime_history.get((year, month), Decimal('0.00'))
         sheet.cell(row=14, column=col).value = float(cumulative_overtime)
         sheet.cell(row=14, column=col).number_format = '0.0'
         sheet.cell(row=14, column=col).alignment = right_align

--- a/backend/app/services/ods_export_service.py
+++ b/backend/app/services/ods_export_service.py
@@ -658,19 +658,35 @@ def _classic_sheet(doc, db, user, year, bold, include_health_data: bool = False)
     total_other = 0.0
     total_paid_leave = 0.0
 
+    # Fix #5: alle Absences + (Nacht-)TimeEntries des Jahres EINMAL laden statt
+    # 5 Typ-Queries × 12 Monate plus 12 Monats-Nacht-Queries. In dicts gruppieren;
+    # die Monatsschleife schlägt nur noch nach. Identische Werte: pro (Monat, Typ)
+    # werden dieselben float(a.hours) summiert; Nacht-Tage bleiben ein Date-Set.
+    year_absences = db.query(Absence).filter(
+        Absence.user_id == user.id,
+        date_in_year(Absence.date, year),
+    ).all()
+    absence_hours_by_month_type: dict = {}
+    for a in year_absences:
+        key = (a.date.month, a.type)
+        absence_hours_by_month_type[key] = absence_hours_by_month_type.get(key, 0.0) + float(a.hours)
+
+    year_entries = db.query(TimeEntry).filter(
+        TimeEntry.user_id == user.id,
+        date_in_year(TimeEntry.date, year),
+        TimeEntry.end_time.isnot(None),
+    ).all()
+    night_dates_by_month: dict = {}
+    for e in year_entries:
+        if is_night_work(e.start_time, e.end_time):
+            night_dates_by_month.setdefault(e.date.month, set()).add(e.date)
+
     for m in range(1, 13):
         target = float(calculation_service.get_monthly_target(db, user, year, m))
         actual = float(calculation_service.get_monthly_actual(db, user, year, m))
 
         def month_absence_hours(atype):
-            return sum(
-                float(a.hours)
-                for a in db.query(Absence).filter(
-                    Absence.user_id == user.id,
-                    Absence.type == atype,
-                    date_in_month(Absence.date, year, m),
-                ).all()
-            )
+            return absence_hours_by_month_type.get((m, atype), 0.0)
 
         vac = month_absence_hours(AbsenceType.VACATION)
         sick = month_absence_hours(AbsenceType.SICK)
@@ -686,13 +702,8 @@ def _classic_sheet(doc, db, user, year, bold, include_health_data: bool = False)
         total_other += other
         total_paid_leave += paid_leave
 
-        # Night work days for this month (§6 ArbZG)
-        month_entries = db.query(TimeEntry).filter(
-            TimeEntry.user_id == user.id,
-            date_in_month(TimeEntry.date, year, m),
-            TimeEntry.end_time.isnot(None),
-        ).all()
-        night_days = len({e.date for e in month_entries if is_night_work(e.start_time, e.end_time)})
+        # Night work days for this month (§6 ArbZG) — aus dem vorab geladenen Set.
+        night_days = len(night_dates_by_month.get(m, set()))
 
         tr = TableRow()
         tr.addElement(_str_cell(MONTH_NAMES[m - 1]))
@@ -708,15 +719,9 @@ def _classic_sheet(doc, db, user, year, bold, include_health_data: bool = False)
         tr.addElement(_int_cell(night_days))
         table.addElement(tr)
 
-    # Total row (night work total counted over all months)
-    total_night = len({
-        e.date for e in db.query(TimeEntry).filter(
-            TimeEntry.user_id == user.id,
-            date_in_year(TimeEntry.date, year),
-            TimeEntry.end_time.isnot(None),
-        ).all()
-        if is_night_work(e.start_time, e.end_time)
-    })
+    # Total row (night work total over all months) — aus demselben vorab
+    # geladenen Set (Monats-Sets sind nach Datum disjunkt -> Union = Jahressumme).
+    total_night = len({d for dates in night_dates_by_month.values() for d in dates})
     tr = TableRow()
     tr.addElement(_str_cell("Gesamt", style=bold))
     tr.addElement(_float_cell(total_target))

--- a/backend/tests/test_calculations_extended.py
+++ b/backend/tests/test_calculations_extended.py
@@ -458,3 +458,67 @@ def test_overtime_history_empty_untracked(db, test_user):
     test_user.track_hours = False
     db.commit()
     assert calculation_service.get_overtime_history(db, test_user, 2025, 3) == {}
+
+
+# ---------------------------------------------------------------------------
+# Fix #3: get_overtime_history_detailed liefert je Monat target+actual+cumulative
+# in EINEM Pass. Die Dashboard-Spalten müssen bitgleich zu den (langsamen)
+# Einzelfunktionen bleiben — sonst ändern sich payroll-relevante Zahlen.
+# ---------------------------------------------------------------------------
+def test_overtime_history_detailed_matches_monthly(db, test_user):
+    """detailed[(y,m)].{target,actual,cumulative} == get_monthly_target /
+    get_monthly_actual / get_overtime_account für JEDEN Monat (mit Carryover-Reset)."""
+    from app.models import YearCarryover
+
+    def add_entry(d, start, end, brk=60):
+        db.add(TimeEntry(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID,
+                         date=d, start_time=start, end_time=end, break_minutes=brk))
+
+    add_entry(date(2024, 11, 4), time(8, 0), time(17, 0))   # Mo 8h
+    add_entry(date(2024, 11, 5), time(8, 0), time(18, 30))  # Di 9.5h
+    add_entry(date(2024, 12, 2), time(8, 0), time(16, 0))   # Mo 7h
+    add_entry(date(2025, 1, 6), time(8, 0), time(19, 0))    # Mo 10h
+    add_entry(date(2025, 2, 3), time(8, 0), time(16, 30))   # Mo 7.5h
+    # Eine soll-reduzierende Abwesenheit, damit target != gross getestet wird.
+    db.add(Absence(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID,
+                   date=date(2025, 1, 7), type=AbsenceType.VACATION, hours=8.0))
+    db.add(YearCarryover(tenant_id=DEFAULT_TENANT_ID, user_id=test_user.id,
+                         year=2025, overtime_hours=Decimal('12.50'),
+                         vacation_days=Decimal('0')))
+    db.commit()
+
+    detailed = calculation_service.get_overtime_history_detailed(db, test_user, 2025, 3)
+    assert detailed, "detailed darf nicht leer sein"
+    assert (2024, 11) in detailed and (2025, 3) in detailed
+    for (y, m), row in detailed.items():
+        assert row.target == calculation_service.get_monthly_target(db, test_user, y, m), \
+            f"{y}-{m:02d}: target {row.target} != monthly_target"
+        assert row.actual == calculation_service.get_monthly_actual(db, test_user, y, m), \
+            f"{y}-{m:02d}: actual {row.actual} != monthly_actual"
+        assert row.cumulative == calculation_service.get_overtime_account(db, test_user, y, m), \
+            f"{y}-{m:02d}: cumulative {row.cumulative} != overtime_account"
+        # Saldo wie das Dashboard ihn bildet.
+        assert (row.actual - row.target) == \
+            (calculation_service.get_monthly_actual(db, test_user, y, m)
+             - calculation_service.get_monthly_target(db, test_user, y, m))
+
+    # Wrapper get_overtime_history == {k: detailed[k].cumulative}
+    wrapped = calculation_service.get_overtime_history(db, test_user, 2025, 3)
+    assert wrapped == {k: v.cumulative for k, v in detailed.items()}
+
+
+def test_overtime_history_detailed_with_cutoff(db, test_user):
+    """Unter cutoff bleiben target/actual/cumulative bitgleich zu den Einzelfunktionen."""
+    db.add(TimeEntry(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID,
+                     date=date(2025, 1, 6), start_time=time(8, 0), end_time=time(18, 0),
+                     break_minutes=60))
+    db.add(TimeEntry(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID,
+                     date=date(2025, 1, 20), start_time=time(8, 0), end_time=time(15, 0),
+                     break_minutes=30))
+    db.commit()
+    cutoff = date(2025, 1, 10)
+    detailed = calculation_service.get_overtime_history_detailed(db, test_user, 2025, 1, cutoff_date=cutoff)
+    row = detailed[(2025, 1)]
+    assert row.target == calculation_service.get_monthly_target(db, test_user, 2025, 1, up_to_date=cutoff)
+    assert row.actual == calculation_service.get_monthly_actual(db, test_user, 2025, 1, up_to_date=cutoff)
+    assert row.cumulative == calculation_service.get_overtime_account(db, test_user, 2025, 1, cutoff_date=cutoff)

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import { createContext, useContext, useState, useCallback, useMemo, ReactNode } from 'react';
 import { X, CheckCircle, AlertCircle, Info, AlertTriangle } from 'lucide-react';
 
 type ToastType = 'success' | 'error' | 'info' | 'warning';
@@ -102,6 +102,17 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
     showToast('warning', message, duration);
   }, [showToast]);
 
+  // Memoise the provider value so it keeps a stable reference across renders
+  // (e.g. every time a toast is added/removed). The functions are already
+  // useCallback-stable, so this object only changes if one of them does (it
+  // never does after mount). Prevents an unstable useToast() reference from
+  // re-rendering all ~33 consumers and from retriggering effects that depend
+  // on the toast handle.
+  const value = useMemo(
+    () => ({ showToast, success, error, info, warning }),
+    [showToast, success, error, info, warning]
+  );
+
   const getIcon = (type: ToastType) => {
     switch (type) {
       case 'success':
@@ -129,7 +140,7 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
   };
 
   return (
-    <ToastContext.Provider value={{ showToast, success, error, info, warning }}>
+    <ToastContext.Provider value={value}>
       {children}
 
       {/* Toast Container */}

--- a/frontend/src/pages/ShiftPlanning.tsx
+++ b/frontend/src/pages/ShiftPlanning.tsx
@@ -31,7 +31,11 @@ export default function ShiftPlanning() {
     return () => {
       cancelled = true;
     };
-  }, [toast]);
+    // Load once on mount. `toast` is a stable ref (memoised ToastContext value)
+    // and only used in the catch branch — keeping it out of the deps avoids a
+    // re-fetch every time an unrelated toast fires (cf. Dashboard.tsx).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div>

--- a/frontend/src/pages/admin/ShiftPlanning.tsx
+++ b/frontend/src/pages/admin/ShiftPlanning.tsx
@@ -125,6 +125,9 @@ export default function AdminShiftPlanning() {
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
 
+  // `toast` is a stable ref (memoised ToastContext value) and only used in the
+  // catch branch — keeping it out of the deps keeps these loaders referentially
+  // stable so the mount effect below doesn't re-run when a toast fires.
   const loadStations = useCallback(async () => {
     try {
       const [locs, ws] = await Promise.all([api.listLocations(), api.listWorkstations()]);
@@ -133,7 +136,8 @@ export default function AdminShiftPlanning() {
     } catch (err) {
       toast.error(getErrorMessage(err, 'Fehler beim Laden der Stammdaten'));
     }
-  }, [toast]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const loadPlans = useCallback(async () => {
     try {
@@ -141,7 +145,8 @@ export default function AdminShiftPlanning() {
     } catch (err) {
       toast.error(getErrorMessage(err, 'Fehler beim Laden der Schichtpläne'));
     }
-  }, [toast]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const loadEmployees = useCallback(async () => {
     try {
@@ -164,7 +169,8 @@ export default function AdminShiftPlanning() {
         toast.error(getErrorMessage(err, 'Fehler beim Laden des Plans'));
       }
     },
-    [toast],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
   );
 
   useEffect(() => {


### PR DESCRIPTION
Technisches Review (E): 7 verhaltensneutrale Performance-/Qualitäts-Refactors, je äquivalenz-geprüft:

1. ToastContext-value `useMemo` → stabile useToast()-Referenz, keine Re-Render-/Re-Fetch-Welle bei jedem Toast.
2. ShiftPlanning (MA+Admin): `toast` aus useEffect/useCallback-Deps → kein Re-Fetch bei Toasts (eslint-disable wie Dashboard).
3. Dashboard Soll/Ist Ein-Pass: `get_overtime_history_detailed` liefert (target,actual,cumulative); `get_overtime_history`-Wrapper + Invarianten-Test **unverändert**; Dashboard füllt aus der Map statt Per-Monat-Doppelberechnung.
4. export_service Überstunden: einmal `get_overtime_history` vor der Monatsschleife (statt O(Monate²) get_overtime_account).
5. ods _classic_sheet: alle Jahres-Absences + Nacht-Einträge einmal laden + gruppieren (statt 60 Queries/User).
6. create_absence: ein `date.in_(…).with_for_update().all()` statt N+1 Lock-Queries.
7. get_vacation_account 1× vor der 12-Monats-Export-Schleife.

Äquivalenz: volle SQLite-Suite **1198 passed**; 120 betroffene + tsc + vitest (ToastContext/QualificationMatrix) grün. Keine Verhaltens-/Ausgabeänderung.
