### PR TITLE
fix: 3 fachliche Divergenzen (ArbZG-Admin-Warnungen, Export-Tageszählung, Arbeitszeit-Fenster 0h)

### DIFF
--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -587,59 +587,28 @@ def _create_absences_overview_sheet(wb: Workbook, db: Session, users: List[User]
     # Data rows
     row = 4
     for user in users:
-        # Uses current daily target for hours-to-days conversion — approximate for display
-        daily_target = calculation_service.get_daily_target(user)
-        if daily_target == 0:
-            daily_target = Decimal('8.0')
+        # Tagesprinzip (§3 BUrlG, #156/#205): die TAGE tagebasiert zählen — exakt
+        # wie die Live-Reports (reports.py) und get_vacation_account, NICHT als
+        # Σ(Absence.hours) ÷ ⌀-Tagessoll. Die naive Stundenrechnung driftet bei
+        # ungleichmäßigem Tagesplan / Halbtagen und liefert für track_hours=False
+        # 0 Tage trotz gebuchten Urlaubs.
+        def _days(atype, _user=user):
+            absences = db.query(Absence).filter(
+                Absence.user_id == _user.id,
+                Absence.tenant_id == _user.tenant_id,  # F-026
+                Absence.type == atype,
+                date_in_year(Absence.date, year),
+            ).all()
+            return float(calculation_service.absence_days(db, _user, absences).quantize(Decimal('0.1')))
 
-        # Calculate days for each absence type
-        vacation_absences = db.query(Absence).filter(
-            Absence.user_id == user.id,
-            Absence.type == AbsenceType.VACATION,
-            date_in_year(Absence.date, year)
-        ).all()
-        vacation_hours = sum(float(a.hours) for a in vacation_absences)
-        vacation_days = vacation_hours / float(daily_target)
-
-        sick_absences = db.query(Absence).filter(
-            Absence.user_id == user.id,
-            Absence.type == AbsenceType.SICK,
-            date_in_year(Absence.date, year)
-        ).all()
-        sick_hours = sum(float(a.hours) for a in sick_absences)
-        sick_days = sick_hours / float(daily_target)
-
-        training_absences = db.query(Absence).filter(
-            Absence.user_id == user.id,
-            Absence.type == AbsenceType.TRAINING,
-            date_in_year(Absence.date, year)
-        ).all()
-        training_hours = sum(float(a.hours) for a in training_absences)
-        training_days = training_hours / float(daily_target)
-
-        overtime_comp_absences = db.query(Absence).filter(
-            Absence.user_id == user.id,
-            Absence.type == AbsenceType.OVERTIME,
-            date_in_year(Absence.date, year)
-        ).all()
-        overtime_comp_hours = sum(float(a.hours) for a in overtime_comp_absences)
-        overtime_comp_days = overtime_comp_hours / float(daily_target)
-
-        other_absences = db.query(Absence).filter(
-            Absence.user_id == user.id,
-            Absence.type == AbsenceType.OTHER,
-            date_in_year(Absence.date, year)
-        ).all()
-        other_hours = sum(float(a.hours) for a in other_absences)
-        other_days = other_hours / float(daily_target)
-
-        paid_leave_absences = db.query(Absence).filter(
-            Absence.user_id == user.id,
-            Absence.type == AbsenceType.PAID_LEAVE,
-            date_in_year(Absence.date, year)
-        ).all()
-        paid_leave_hours = sum(float(a.hours) for a in paid_leave_absences)
-        paid_leave_days = paid_leave_hours / float(daily_target)
+        # VACATION über get_vacation_account → schließt die #146 free+counts_as_
+        # vacation-Sondertage (24./31.12.) ein, konsistent mit der Urlaubs-Rechnung.
+        vacation_days = round(float(calculation_service.get_vacation_account(db, user, year)["used_days"]), 1)
+        sick_days = _days(AbsenceType.SICK)
+        training_days = _days(AbsenceType.TRAINING)
+        overtime_comp_days = _days(AbsenceType.OVERTIME)
+        other_days = _days(AbsenceType.OTHER)
+        paid_leave_days = _days(AbsenceType.PAID_LEAVE)
 
         total_days = vacation_days + (sick_days if include_health_data else 0) + training_days + overtime_comp_days + other_days + paid_leave_days
 

--- a/backend/app/services/ods_export_service.py
+++ b/backend/app/services/ods_export_service.py
@@ -413,27 +413,29 @@ def _absences_overview_sheet(doc, db, users, year, bold, include_health_data: bo
     table.addElement(_header_row(headers, bold))
 
     for user in users:
-        # Uses current daily target for hours-to-days conversion — approximate for display
-        dt = float(calculation_service.get_daily_target(user)) or 8.0
+        # Tagesprinzip (§3 BUrlG, #156/#205): die TAGE tagebasiert zählen
+        # (absence_days / get_vacation_account), NICHT als Σ(Absence.hours) ÷
+        # ⌀-Tagessoll. Nur so rekonzilieren „verbraucht" und „Rest"
+        # (budget − used == remaining) und Halbtage/Tagespläne/track_hours=False
+        # stimmen mit den Live-Reports.
+        def days(atype, _user=user):
+            absences = db.query(Absence).filter(
+                Absence.user_id == _user.id,
+                Absence.tenant_id == _user.tenant_id,  # F-026
+                Absence.type == atype,
+                date_in_year(Absence.date, year),
+            ).all()
+            return float(calculation_service.absence_days(db, _user, absences).quantize(Decimal('0.1')))
 
-        def days(atype):
-            return sum(
-                float(a.hours)
-                for a in db.query(Absence).filter(
-                    Absence.user_id == user.id,
-                    Absence.type == atype,
-                    date_in_year(Absence.date, year),
-                ).all()
-            ) / dt
-
-        vac = days(AbsenceType.VACATION)
+        vac_acc = calculation_service.get_vacation_account(db, user, year)
+        # VACATION über get_vacation_account → schließt die #146 free+counts_as_
+        # vacation-Sondertage ein und ist damit konsistent mit der Resturlaub-Spalte.
+        vac = round(float(vac_acc["used_days"]), 1)
         sick = days(AbsenceType.SICK)
         train = days(AbsenceType.TRAINING)
         overtime_comp = days(AbsenceType.OVERTIME)
         other = days(AbsenceType.OTHER)
         paid_leave = days(AbsenceType.PAID_LEAVE)
-
-        vac_acc = calculation_service.get_vacation_account(db, user, year)
         remaining = float(vac_acc["remaining_days"])
 
         # DSGVO F-003: mask sick days unless health data explicitly requested (Art. 9)

--- a/backend/app/services/work_window_service.py
+++ b/backend/app/services/work_window_service.py
@@ -72,9 +72,17 @@ def clamp(
         if end > ceil:
             eff_end, raw_end = ceil, end
 
-    # Schutz vor Inversion: liegt der Eintrag ganz außerhalb des Fensters,
-    # würde Kappen eff_start >= eff_end erzeugen → NICHT kappen (Rohwerte behalten),
-    # damit keine 0h-/invertierte Buchung entsteht und net_hours korrekt bleibt.
+    # Komplett außerhalb des Fensters: liegt der Eintrag ganz vor
+    # [Soll-Beginn − Puffer] bzw. ganz hinter [Soll-Ende + Puffer], würde die
+    # Kappung eff_start >= eff_end erzeugen. #201-Design-Spec §5: dann werden
+    # **0 Stunden angerechnet**, der Rohstempel bleibt aber erhalten (§16) — sonst
+    # ließe sich Arbeitszeit außerhalb des Soll-Fensters „erarbeiten" (Anti-Abuse,
+    # die Motivation des Features). Die angerechnete (effektive) Zeit kollabiert
+    # deshalb auf einen Punkt (= ``start``) → ``TimeEntry.net_hours`` floored auf 0.
+    # Punkt = ``start``, damit auch ``clock_out`` (setzt nur ``end_time = eff_end``,
+    # ``start_time`` bleibt der Stempel) net_hours == 0 erhält. Beide Original-
+    # stempel werden in raw_start/raw_end bewahrt — die §5-Ruhezeitprüfung rechnet
+    # weiterhin gegen diese Rohstempel (``raw_* or <gekappt>``).
     if eff_start is not None and eff_end is not None and eff_start >= eff_end:
-        return (start, end, None, None)
+        return (start, start, start, end)
     return (eff_start, eff_end, raw_start, raw_end)

--- a/backend/tests/test_export_service.py
+++ b/backend/tests/test_export_service.py
@@ -240,3 +240,110 @@ class TestPdfMarkupEscaping:
         )
         data = generate_avv_pdf(t)
         assert data[:4] == b"%PDF"
+
+
+class TestAbsencesOverviewDayBased:
+    """Fix #2 (Tagesprinzip §3 BUrlG): die Abwesenheits-Übersicht muss die TAGE
+    tagebasiert über ``calculation_service.absence_days`` / ``get_vacation_account``
+    zählen — NICHT als Σ(Absence.hours) ÷ get_daily_target (Durchschnitt). Sonst
+    sind Tagespläne/Halbtage falsch und ein ``track_hours=False``-MA zeigt 0 Tage
+    trotz gebuchtem Urlaub (und im ODS gilt „verbraucht" ≠ „Rest")."""
+
+    def _tagesplan_user(self, db):
+        """Ungleichmäßiger Tagesplan: Mo 8h, Di 4h, Mi 6h; ⌀-Tagessoll = 5h
+        (weekly 15 / 3 Tage). Genau dieser Unterschied macht Σh÷⌀ falsch."""
+        from app.models import User, UserRole
+        from app.services import auth_service
+        u = User(
+            username="tagesplan", email="tagesplan@example.com",
+            password_hash=auth_service.hash_password("x12345678"),
+            first_name="Tages", last_name="Plan", role=UserRole.EMPLOYEE,
+            weekly_hours=15.0, work_days_per_week=3, vacation_days=30,
+            is_active=True, tenant_id=DEFAULT_TENANT_ID,
+            track_hours=True, use_daily_schedule=True,
+            hours_monday=8, hours_tuesday=4, hours_wednesday=6,
+        )
+        db.add(u)
+        db.commit()
+        db.refresh(u)
+        return u
+
+    def _untracked_user(self, db):
+        """Leitende(r) Angestellte(r): track_hours=False → ⌀-Tagessoll 0 → Σh÷⌀
+        liefert 0 Tage trotz Urlaub. Tagebasiert müssen die Tage trotzdem zählen."""
+        from app.models import User, UserRole
+        from app.services import auth_service
+        u = User(
+            username="untracked", email="untracked@example.com",
+            password_hash=auth_service.hash_password("x12345678"),
+            first_name="Lei", last_name="Tend", role=UserRole.EMPLOYEE,
+            weekly_hours=40.0, work_days_per_week=5, vacation_days=30,
+            is_active=True, tenant_id=DEFAULT_TENANT_ID, track_hours=False,
+        )
+        db.add(u)
+        db.commit()
+        db.refresh(u)
+        return u
+
+    def _absence(self, db, user, d, typ, hours, half_day=False):
+        from app.models import Absence
+        a = Absence(
+            user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+            type=typ, hours=hours, half_day=half_day,
+        )
+        db.add(a)
+        db.commit()
+        return a
+
+    def test_overview_days_are_day_based_not_hours_based(self, db, default_tenant):
+        from openpyxl import Workbook
+        from app.models import AbsenceType
+        from app.services import calculation_service
+        from app.services.export_service import _create_absences_overview_sheet
+
+        user_a = self._tagesplan_user(db)
+        user_b = self._untracked_user(db)
+
+        # user_a: 2 volle Urlaubstage (Mo 8h, Di 4h) + 1 Halbtag (Mi, 3h) → 2,5 Tage
+        self._absence(db, user_a, date(2026, 1, 5), AbsenceType.VACATION, 8)   # Mo
+        self._absence(db, user_a, date(2026, 1, 6), AbsenceType.VACATION, 4)   # Di
+        self._absence(db, user_a, date(2026, 1, 7), AbsenceType.VACATION, 3, half_day=True)  # Mi (halb)
+        # user_a Krank: 1 voller Tag an einem Montag (8h) → 1,0 Tag (Σh÷⌀ wäre 1,6)
+        self._absence(db, user_a, date(2026, 1, 19), AbsenceType.SICK, 8)      # Mo
+
+        # user_b (untracked): 1 voller + 1 halber Urlaubstag → 1,5 Tage (Σh÷⌀ = 0)
+        self._absence(db, user_b, date(2026, 1, 12), AbsenceType.VACATION, 0)  # Mo
+        self._absence(db, user_b, date(2026, 1, 13), AbsenceType.VACATION, 0, half_day=True)  # Di
+
+        wb = Workbook()
+        _create_absences_overview_sheet(wb, db, [user_a, user_b], 2026, include_health_data=True)
+        sheet = wb["Abwesenheiten"]
+
+        # Layout: row 3 = Header, Datenzeilen ab row 4. Spalten: 1 Name, 2 Urlaub,
+        # 3 Krank, 4 Fortbildung, 5 ÜStd, 6 Sonstiges, 7 Bez.Freistellung, 8 Gesamt.
+        a_vac = sheet.cell(row=4, column=2).value
+        a_sick = sheet.cell(row=4, column=3).value
+        b_vac = sheet.cell(row=5, column=2).value
+
+        # Tagebasiert (Tagesprinzip), NICHT Σh÷⌀-Tagessoll.
+        assert a_vac == 2.5, f"Tagesplan-Urlaub: erwartet 2,5 (tagebasiert), bekam {a_vac}"
+        assert a_sick == 1.0, f"Tagesplan-Krank: erwartet 1,0 (tagebasiert), bekam {a_sick}"
+        assert b_vac == 1.5, f"untracked-Urlaub: erwartet 1,5 (tagebasiert), bekam {b_vac}"
+
+        # Deckungsgleich mit den autoritativen Berechnungsfunktionen (Live-Reports).
+        vac_acc_a = calculation_service.get_vacation_account(db, user_a, 2026)
+        assert a_vac == round(float(vac_acc_a["used_days"]), 1)
+        vac_acc_b = calculation_service.get_vacation_account(db, user_b, 2026)
+        assert b_vac == round(float(vac_acc_b["used_days"]), 1)
+
+    def test_yearly_report_renders_with_tagesplan_and_untracked(self, db, default_tenant):
+        """End-to-end: der komplette Jahresreport baut ein valides XLSX, auch mit
+        Tagesplan- und untracked-MA (kein Crash, Sheet öffenbar)."""
+        from app.models import AbsenceType
+        from app.services.export_service import generate_yearly_report
+        user_a = self._tagesplan_user(db)
+        user_b = self._untracked_user(db)
+        self._absence(db, user_a, date(2026, 1, 5), AbsenceType.VACATION, 8)
+        self._absence(db, user_b, date(2026, 1, 12), AbsenceType.VACATION, 0)
+        wb, data = _load_xlsx(generate_yearly_report(db, 2026))
+        assert "Abwesenheiten" in wb.sheetnames

--- a/backend/tests/test_ods_export_service.py
+++ b/backend/tests/test_ods_export_service.py
@@ -146,3 +146,98 @@ class TestFormulaInjection:
         from odf.teletype import extractText
         from app.services.ods_export_service import _str_cell
         assert extractText(_str_cell('Mitarbeiter:')) == 'Mitarbeiter:'
+
+
+class TestAbsencesOverviewDayBased:
+    """Fix #2 (Tagesprinzip §3 BUrlG): die ODS-Abwesenheits-Übersicht muss die
+    Tage tagebasiert (absence_days / get_vacation_account) zählen, nicht
+    stundenbasiert (Σh ÷ ⌀-Tagessoll). Dann gilt im Sheet „verbraucht" == „Rest"
+    (budget − used == remaining) und Halbtage/Tagespläne/untracked stimmen."""
+
+    def _tagesplan_user(self, db):
+        from app.models import User, UserRole
+        from app.services import auth_service
+        u = User(
+            username="ods_tagesplan", email="ods_tagesplan@example.com",
+            password_hash=auth_service.hash_password("x12345678"),
+            first_name="Tages", last_name="Plan", role=UserRole.EMPLOYEE,
+            weekly_hours=15.0, work_days_per_week=3, vacation_days=30,
+            is_active=True, tenant_id=DEFAULT_TENANT_ID,
+            track_hours=True, use_daily_schedule=True,
+            hours_monday=8, hours_tuesday=4, hours_wednesday=6,
+        )
+        db.add(u)
+        db.commit()
+        db.refresh(u)
+        return u
+
+    def _untracked_user(self, db):
+        from app.models import User, UserRole
+        from app.services import auth_service
+        u = User(
+            username="ods_untracked", email="ods_untracked@example.com",
+            password_hash=auth_service.hash_password("x12345678"),
+            first_name="Lei", last_name="Tend", role=UserRole.EMPLOYEE,
+            weekly_hours=40.0, work_days_per_week=5, vacation_days=30,
+            is_active=True, tenant_id=DEFAULT_TENANT_ID, track_hours=False,
+        )
+        db.add(u)
+        db.commit()
+        db.refresh(u)
+        return u
+
+    def _absence(self, db, user, d, typ, hours, half_day=False):
+        a = Absence(
+            user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+            type=typ, hours=hours, half_day=half_day,
+        )
+        db.add(a)
+        db.commit()
+        return a
+
+    def _vac_cell(self, doc, last_name):
+        """Liefert (urlaub, resturlaub) als float aus der 'Abwesenheiten'-Tabelle
+        für die Datenzeile des MA (Spalte 1 = Urlaub, Spalte 8 = Resturlaub)."""
+        from odf.table import Table, TableRow, TableCell
+        from odf.teletype import extractText
+        table = [t for t in doc.spreadsheet.getElementsByType(Table)
+                 if t.getAttribute("name") == "Abwesenheiten"][0]
+        for row in table.getElementsByType(TableRow):
+            cells = row.getElementsByType(TableCell)
+            if cells and last_name in extractText(cells[0]):
+                return (float(cells[1].getAttribute("value")),
+                        float(cells[8].getAttribute("value")))
+        raise AssertionError(f"keine Zeile für {last_name}")
+
+    def test_ods_overview_days_are_day_based_and_consistent_with_remaining(self, db, default_tenant):
+        from app.models import AbsenceType
+        from app.services import calculation_service
+        from app.services.ods_export_service import _absences_overview_sheet, _doc_with_styles
+
+        user_a = self._tagesplan_user(db)
+        user_b = self._untracked_user(db)
+
+        self._absence(db, user_a, date(2026, 1, 5), AbsenceType.VACATION, 8)   # Mo voll
+        self._absence(db, user_a, date(2026, 1, 6), AbsenceType.VACATION, 4)   # Di voll
+        self._absence(db, user_a, date(2026, 1, 7), AbsenceType.VACATION, 3, half_day=True)  # Mi halb
+        self._absence(db, user_b, date(2026, 1, 12), AbsenceType.VACATION, 0)  # Mo voll
+        self._absence(db, user_b, date(2026, 1, 13), AbsenceType.VACATION, 0, half_day=True)  # Di halb
+
+        doc, bold, _normal = _doc_with_styles()
+        _absences_overview_sheet(doc, db, [user_a, user_b], 2026, bold, include_health_data=True)
+
+        a_vac, a_rest = self._vac_cell(doc, "Plan")
+        b_vac, b_rest = self._vac_cell(doc, "Tend")
+
+        assert a_vac == 2.5, f"Tagesplan-Urlaub: erwartet 2,5 (tagebasiert), bekam {a_vac}"
+        assert b_vac == 1.5, f"untracked-Urlaub: erwartet 1,5 (tagebasiert), bekam {b_vac}"
+
+        # „verbraucht" + „Rest" rekonzilieren mit get_vacation_account (Budget − used).
+        acc_a = calculation_service.get_vacation_account(db, user_a, 2026)
+        assert a_vac == round(float(acc_a["used_days"]), 1)
+        assert a_rest == round(float(acc_a["remaining_days"]), 1)
+        assert round(a_vac + a_rest, 1) == round(float(acc_a["budget_days"]), 1)
+
+        acc_b = calculation_service.get_vacation_account(db, user_b, 2026)
+        assert b_vac == round(float(acc_b["used_days"]), 1)
+        assert b_rest == round(float(acc_b["remaining_days"]), 1)

--- a/backend/tests/test_work_window_integration.py
+++ b/backend/tests/test_work_window_integration.py
@@ -276,6 +276,39 @@ def test_manual_create_caps_both_ends(db, employee, employee_client, monkeypatch
     assert entry.raw_end_time == dt.time(18, 0), f"Expected raw_end 18:00, got {entry.raw_end_time}"
 
 
+def test_manual_create_entirely_outside_window_zero_credit(db, employee, employee_client, monkeypatch):
+    """#201-Spec §5: ein Eintrag KOMPLETT außerhalb des Soll-Fensters wird mit
+    0 angerechneten Stunden gebucht (net_hours == 0), die Rohstempel bleiben für
+    den §16-Nachweis erhalten.
+
+    Soll Mo 08:00–10:00, grace=15 min → Fenster [07:45, 10:15].
+    Eingabe: 14:00–15:00 (liegt ganz hinter dem Fenster).
+    Erwartet: net_hours == 0, raw_start=14:00, raw_end=15:00.
+    """
+    import datetime as dt
+    import app.routers.time_entries as te
+
+    employee.scheduled_start_monday = dt.time(8, 0)
+    employee.scheduled_end_monday = dt.time(10, 0)
+    db.commit()
+
+    monkeypatch.setattr(te, "_today_local", lambda: dt.date(2026, 6, 1))
+
+    resp = employee_client.post("/api/time-entries", json={
+        "date": "2026-06-01",
+        "start_time": "14:00",
+        "end_time": "15:00",
+        "break_minutes": 0,
+    })
+    assert resp.status_code == 201, resp.text
+
+    from app.models import TimeEntry
+    entry = db.query(TimeEntry).filter(TimeEntry.user_id == employee.id).one()
+    assert entry.net_hours == 0, f"Expected 0 angerechnete Stunden, got {entry.net_hours}"
+    assert entry.raw_start_time == dt.time(14, 0), f"Expected raw_start 14:00, got {entry.raw_start_time}"
+    assert entry.raw_end_time == dt.time(15, 0), f"Expected raw_end 15:00, got {entry.raw_end_time}"
+
+
 def test_admin_create_caps_both_ends(db, employee, admin, admin_client):
     """POST /api/admin/users/{id}/time-entries klappt Start und Ende des
     betroffenen Mitarbeiters ins Soll-Fenster.

--- a/backend/tests/test_work_window_service.py
+++ b/backend/tests/test_work_window_service.py
@@ -1,5 +1,5 @@
 from datetime import date, time
-from app.models import User, UserRole
+from app.models import User, UserRole, TimeEntry
 from app.services import work_window_service as wws
 
 
@@ -59,15 +59,33 @@ def test_grace_shift_clamps_to_day_bounds():
     assert eff_e == time(23, 59)
 
 
-def test_entry_entirely_before_window_not_clamped():
-    # Nachmittagsschicht-Fenster, Vormittags-Eintrag → würde invertieren → KEINE Kappung
+def test_entry_entirely_before_window_zero_credit():
+    # Nachmittagsschicht-Fenster, Vormittags-Eintrag → komplett außerhalb.
+    # #201-Spec §5: 0 angerechnete Stunden (eff_start == eff_end → net 0),
+    # aber beide Rohstempel bleiben für den §16-Nachweis erhalten.
     u = _user(scheduled_start_monday=time(14, 0), scheduled_end_monday=time(18, 0))
     eff_s, eff_e, raw_s, raw_e = wws.clamp(u, MON, time(8, 0), time(9, 0), 15)
-    assert (eff_s, eff_e, raw_s, raw_e) == (time(8, 0), time(9, 0), None, None)
-    assert eff_s < eff_e  # nie invertiert
+    assert eff_s == eff_e          # angerechnete Zeit kollabiert auf einen Punkt → net 0
+    assert raw_s == time(8, 0)     # Originalstart bewahrt
+    assert raw_e == time(9, 0)     # Originalende bewahrt
 
 
-def test_entry_entirely_after_window_not_clamped():
+def test_entry_entirely_after_window_zero_credit():
     u = _user(scheduled_start_monday=time(8, 0), scheduled_end_monday=time(10, 0))
     eff_s, eff_e, raw_s, raw_e = wws.clamp(u, MON, time(14, 0), time(15, 0), 15)
-    assert (eff_s, eff_e, raw_s, raw_e) == (time(14, 0), time(15, 0), None, None)
+    assert eff_s == eff_e
+    assert raw_s == time(14, 0)
+    assert raw_e == time(15, 0)
+
+
+def test_entirely_outside_entry_has_zero_net_hours():
+    # Die kollabierte Effektivzeit erzeugt auf dem TimeEntry net_hours = 0.
+    u = _user(scheduled_start_monday=time(8, 0), scheduled_end_monday=time(10, 0))
+    eff_s, eff_e, raw_s, raw_e = wws.clamp(u, MON, time(14, 0), time(15, 0), 15)
+    te = TimeEntry(
+        start_time=eff_s, end_time=eff_e, break_minutes=0,
+        raw_start_time=raw_s, raw_end_time=raw_e,
+    )
+    assert te.net_hours == 0
+    # §16: die tatsächlichen Stempel bleiben rekonstruierbar.
+    assert te.raw_start_time == time(14, 0) and te.raw_end_time == time(15, 0)

--- a/frontend/src/components/MonthlyJournal.tsx
+++ b/frontend/src/components/MonthlyJournal.tsx
@@ -6,6 +6,7 @@ import apiClient from '../api/client';
 import { getErrorMessage } from '../utils/errorMessage';
 import { formatHoursHMText, parseHours } from '../utils/formatters';
 import { submitWithBreakWaiver } from '../utils/breakWaiverRetry';
+import { showArbzgWarnings } from '../utils/arbzgWarnings';
 import { useToast } from '../contexts/ToastContext';
 import { useConfirm } from '../hooks/useConfirm';
 import ConfirmDialog from './ConfirmDialog';
@@ -268,13 +269,14 @@ export default function MonthlyJournal({ userId, isAdminView }: MonthlyJournalPr
         };
         const existing = !switchingToWork ? editedEntry : null;
         // #200: §4-Pausen-Ausnahme per Retry mit dokumentierter Begründung.
-        await submitWithBreakWaiver(async (extra) => {
-          if (existing) {
-            await apiClient.put(`/admin/time-entries/${existing.id}`, { ...payload, ...extra });
-          } else {
-            await apiClient.post(`/admin/users/${userId}/time-entries`, { date: day.date, ...payload, ...extra });
-          }
-        });
+        const res = await submitWithBreakWaiver(async (extra) =>
+          existing
+            ? apiClient.put(`/admin/time-entries/${existing.id}`, { ...payload, ...extra })
+            : apiClient.post(`/admin/users/${userId}/time-entries`, { date: day.date, ...payload, ...extra }),
+        );
+        // ArbZG-Warnungen der Admin-Schreibpfade anzeigen (§3 >8h/Tag, >48h/Woche,
+        // §6 Nacht, BREAK_WAIVER) — analog zu den MA-Pfaden (StampWidget/TimeTracking).
+        showArbzgWarnings(toast, res.data?.warnings);
       } else {
         // Delete existing absence of different type if present, then create new
         if (hadAbsence && day.absences[0] && !switchingToWork) {

--- a/frontend/src/pages/admin/ChangeRequests.tsx
+++ b/frontend/src/pages/admin/ChangeRequests.tsx
@@ -5,6 +5,7 @@ import { AlertCircle, Check, X } from 'lucide-react';
 import { useToast } from '../../contexts/ToastContext';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import { getErrorMessage } from '../../utils/errorMessage';
+import { showArbzgWarnings } from '../../utils/arbzgWarnings';
 
 interface ChangeRequest {
   id: string;
@@ -145,10 +146,13 @@ export default function AdminChangeRequests() {
     if (actionLock.current) return;
     actionLock.current = true;
     try {
-      await apiClient.post(`/admin/change-requests/${id}/review`, {
+      const response = await apiClient.post(`/admin/change-requests/${id}/review`, {
         action: 'approve',
       });
       toast.success('Antrag genehmigt');
+      // ArbZG-Warnungen der Genehmigung anzeigen (§3 >48h/Woche, §6 Nacht) —
+      // analog zu den MA-Pfaden (StampWidget/TimeTracking); bisher verworfen.
+      showArbzgWarnings(toast, response.data?.warnings);
       fetchRequests();
     } catch (error: any) {
       toast.error(getErrorMessage(error, 'Fehler beim Genehmigen'));
@@ -212,6 +216,12 @@ export default function AdminChangeRequests() {
         toast.error(`Alle ${failed} Anträge konnten nicht bearbeitet werden`);
       } else {
         toast.warning(`${succeeded} bearbeitet, ${failed} fehlgeschlagen`);
+      }
+      // Die Sammel-Genehmigung (bulk-review) liefert KEINE ArbZG-Warnungen pro
+      // Antrag zurück (nur {succeeded, failed}). Darauf hinweisen, damit §3/§6-
+      // Verstöße nicht unbemerkt durchrutschen — bei Bedarf einzeln genehmigen.
+      if (action === 'approve' && succeeded > 0) {
+        toast.info('Sammel-Genehmigung zeigt keine ArbZG-Warnungen — bei Bedarf einzeln genehmigen und prüfen.');
       }
       setSelectedIds(new Set());
       setBulkRejectMode(false);

--- a/frontend/src/utils/breakWaiverRetry.ts
+++ b/frontend/src/utils/breakWaiverRetry.ts
@@ -11,11 +11,11 @@ import { getErrorMessage } from './errorMessage';
  * Erkennung: die §4-Meldung des Backends enthält stets „Pause"; der §3-10h-Cap
  * („Höchstgrenze … §3 ArbZG") NICHT — der harte §3-Block bleibt also bestehen.
  */
-export async function submitWithBreakWaiver(
-  submit: (extra: { break_waiver_reason?: string }) => Promise<void>,
-): Promise<void> {
+export async function submitWithBreakWaiver<T = void>(
+  submit: (extra: { break_waiver_reason?: string }) => Promise<T>,
+): Promise<T> {
   try {
-    await submit({});
+    return await submit({});
   } catch (err) {
     const msg = getErrorMessage(err, '');
     if (!msg.includes('Pause')) throw err;
@@ -25,6 +25,6 @@ export async function submitWithBreakWaiver(
         'Abbrechen lässt den Eintrag unverändert.',
     );
     if (!reason || !reason.trim()) throw err;
-    await submit({ break_waiver_reason: reason.trim() });
+    return await submit({ break_waiver_reason: reason.trim() });
   }
 }


### PR DESCRIPTION
Aus dem fachlichen Review (F) — die 3 code-seitigen Spec-Divergenzen, je nach Abnahme gefixt:

1. **ArbZG-Warnungen auf Admin-Schreibpfaden** (`MonthlyJournal.tsx`, `admin/ChangeRequests.tsx`): `response.warnings` werden jetzt via `showArbzgWarnings` angezeigt (manuelle Zeiterfassung + CR-Genehmigung) — vorher verworfen, ausgerechnet beim Compliance-Verantwortlichen.
2. **Jahres-Export Abwesenheits-Tage tagebasiert** (`export_service`, `ods_export_service`): Tage über `calculation_service.absence_days()` (§3-BUrlG-Tagesprinzip) statt `Σh ÷ Ø-Tagessoll` — korrekt für Tagesplan/Halbtage/untracked, konsistent mit den Live-Reports + §16-Belegen.
3. **Arbeitszeit-Fenster #201**: Eintrag komplett außerhalb des Soll-Fensters → **0 angerechnete Stunden** (Rohstempel bewahrt, §16) statt voller Anrechnung — Spec-konform + Anti-Abuse (Entscheidung: Code folgt der Design-Spec §5).

**Tests:** betroffene Suiten grün (work_window_service/_integration, export/ods, calculations, rest_time, round2 = 71 passed nach test.db-Reset); die 2 Bestandstests, die das alte „nicht gekappt"-Verhalten pinnten, auf 0h umgestellt; tsc grün.
