### PR TITLE
Release 1.12.3

### DIFF
--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.12.2"
+APP_VERSION = "1.12.3"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.12.2",
+      "version": "1.12.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.12.2",
+  "version": "1.12.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.12.2"
+APP_VERSION="1.12.3"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
PATCH-Release — große Review-Härtung dieser Session (technisches + fachliches Review + Spec-Abgleich + mehrere Logiklücken-Runden, ~30 Fixes, bereits via #357–#364 auf master; hier der Version-Bump).

**Migrationen:** 058 (`year_carryovers.source`) + 059 (`change_requests.absence_id` ON DELETE SET NULL).

**Highlights:** Betriebsferien-Urlaub kalenderchronologisch (#314), Halbtags-Soll korrekt, Export-Tage tagebasiert (§16), ArbZG-Warnungen auf Admin-Pfaden, Arbeitszeit-Fenster „außerhalb→0h", FK-Crash/Art.17-Blocker behoben, Auth/Journal/Schichtplan-Security, 7 Perf-Fixes, Spec ergänzt (#314 + SaaS).

**QA:** Backend-Suite 1203 passed · validate-release 5/5 (PG 18.4) · **Migrationen 058/059 up/down/up auf PG18 grün** · **.131 native Update 1.12.2→1.12.3: Migration 057→059 auf echtem PG, Daten erhalten, echter Login** · lokaler Docker-Login · Artefakt-Integrität verifiziert. Windows-Emulator übersprungen (0 Installer-Änderungen seit v1.12.0).
