### PR TITLE
Release 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-07-02
+
+Feature-Release mit zwei Kundenwünschen, je adversarial multi-agent-reviewt
+(alle Findings bis Low-Severity gefixt). Eine additive Migration (060).
+
+### ✨ Neu
+- **„Login als …" — read-only Ansicht als Mitarbeiter:in (#370).** Admins können
+  die App aus der Sicht einer:s aktiven Mitarbeitenden ansehen (Dashboard prüfen,
+  Probleme nachstellen) — über das Anmelde-Symbol in der Benutzerübersicht. Die
+  Sitzung ist **strikt nur lesend** (jede Schreib-Aktion wird serverseitig
+  blockiert), ein Banner „… – nur Lesen" mit **„Zurück zu Admin"** ist dauerhaft
+  sichtbar. Jede Sitzung wird protokolliert (DSGVO-Rechenschaftspflicht,
+  Art. 5 Abs. 2); da nichts geschrieben werden kann, ist keine Aktion je fälschlich
+  der/dem Mitarbeitenden zurechenbar (§ 16 ArbZG). Nur Mitarbeitende (keine Admins)
+  sind ansehbar. Neue Tabelle `impersonation_sessions` (Migration 060).
+- **Konfigurierbare Wochentage im Schichtplaner (#371).** Unter
+  **Einstellungen → Schichtplanung** wählbar, welche Wochentage der Planer anzeigt
+  und plant — Standard **Mo–Fr**, Sa/So oder ein Schließtag einzeln zu-/abschaltbar
+  (mind. ein Tag). Ein abgeschalteter Tag verschwindet aus der Wochenansicht, nimmt
+  keine Slots auf und wird von der Auto-Generierung, Plan-Validierung und der
+  MA-Karte „Deine Einteilung heute" übersprungen. Bestehende Slots bleiben erhalten
+  und kehren beim Reaktivieren zurück (kein Datenverlust).
+
 ## [1.12.3] - 2026-06-28
 
 Härtungs-Release aus einer mehrtägigen Multi-Agenten-Review-Kampagne (rund 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.12.3 (Stand 2026-06-28)
+**Aktuelle Version:** 1.13.0 (Stand 2026-07-02)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.12.3"
+APP_VERSION = "1.13.0"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.12.3",
+      "version": "1.13.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.12.3",
+  "version": "1.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.12.3"
+APP_VERSION="1.13.0"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
Release **1.13.0** (MINOR) — bündelt #370 + #371 (bereits via #372/#373 auf master) mit Version-Bump, CHANGELOG und Doku.

## Enthalten
- **#370 Read-only Impersonation „Login als …"** (Migration 060, `impersonation_sessions`)
- **#371 Konfigurierbare Schichtplaner-Wochentage** (keine Migration)

## QA (vor diesem PR)
- Multi-Agenten-Review beider Features + finaler Adversarial-Re-Check der Impersonation: **0 Medium+-Findings** offen.
- Kombinierte Backend-Unit-Suite **1270 passed** / 49 skipped; Vitest grün; tsc + eslint sauber.
- **validate-release 5/5** Distros (PG 18.4).
- **Migration 060 up→down→up auf Wegwerf-PG18** verifiziert.
- **Local Docker 1.13.0**: echter Login + beide Features end-to-end (impersonate read 200 / write **403** / end 200 / nach end **401** revoziert / Accountability-Log; Wochentage-Setting 200 gültig / 400 ungültig).
- **.131 (realer Host, echtes `docker.tar.gz`-Artefakt)**: HEALTHY, 1.13.0, echter Login + Impersonation end-to-end.
- **Windows-ZIP-Integrität**: PG-Installer-SHA = 18.4-Pin, kein setup.exe im ZIP, gebündelte Version 1.13.0. Windows-Emulator + Native-Installer: **0 Installer-Änderungen** seit v1.12.3 (nur `build-release.sh`-Versionsdefault) → Präzedenzfall + Artefakt-Integrität.

## Dependencies
0 offene Dependabot-Alerts, `npm audit` sauber (high+). Keine Dep-Bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
