### PR TITLE
fix(export): Korrektheits- + DSGVO-Fixes aus Export-Prozess-Review

### DIFF
--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -328,7 +328,7 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
                 if show_note and absence.note:
                     note_parts.append(absence.note)
                 abw_parts.append(f"{type_name} ({float(absence.hours)}h)")
-            sheet.cell(row=row, column=9).value = " | ".join(abw_parts)
+            sheet.cell(row=row, column=9).value = neutralize_spreadsheet_formula(" | ".join(abw_parts))  # custom-reason label = user text → neutralisieren
             if note_parts:
                 sheet.cell(row=row, column=10).value = neutralize_spreadsheet_formula(" | ".join(note_parts))
         else:
@@ -507,18 +507,16 @@ def _create_yearly_overview_sheet(wb: Workbook, db: Session, users: List[User], 
         # Vacation account
         vacation_account = calculation_service.get_vacation_account(db, user, year)
 
-        # Sick days (uses current daily target for hours-to-days conversion — approximate)
-        daily_target = calculation_service.get_daily_target(user)
-        if daily_target == 0:
-            daily_target = Decimal('8.0')
-
+        # Krankheitstage TAGEBASIERT (GLOSSAR-Tagesprinzip) — identisch zum
+        # Abwesenheiten-Sheet; NICHT die frühere naive Σh÷Tagessoll-Methode
+        # (falsch bei Tagesplan/Halbtagen/track_hours=False). F-026: tenant-Filter.
         sick_absences = db.query(Absence).filter(
             Absence.user_id == user.id,
+            Absence.tenant_id == user.tenant_id,
             Absence.type == AbsenceType.SICK,
             date_in_year(Absence.date, year)
         ).all()
-        sick_hours = sum(float(a.hours) for a in sick_absences)
-        sick_days = sick_hours / float(daily_target)
+        sick_days = float(calculation_service.absence_days(db, user, sick_absences).quantize(Decimal('0.1')))
 
         # Write data
         sheet.cell(row=row, column=1).value = neutralize_spreadsheet_formula(f"{user.last_name}, {user.first_name}")
@@ -834,7 +832,7 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
                 if show_note and absence.note:
                     note_parts.append(absence.note)
                 abw_parts.append(f"{type_name} ({float(absence.hours)}h)")
-            sheet.cell(row=row, column=9).value = " | ".join(abw_parts)
+            sheet.cell(row=row, column=9).value = neutralize_spreadsheet_formula(" | ".join(abw_parts))  # custom-reason label = user text → neutralisieren
             if note_parts:
                 sheet.cell(row=row, column=10).value = neutralize_spreadsheet_formula(" | ".join(note_parts))
         else:

--- a/backend/app/services/journal_service.py
+++ b/backend/app/services/journal_service.py
@@ -16,6 +16,7 @@ _ABSENCE_TYPE_MAP = {
     AbsenceType.TRAINING: "training",
     AbsenceType.OVERTIME: "overtime",
     AbsenceType.OTHER: "other",
+    AbsenceType.PAID_LEAVE: "paid_leave",  # Fix: sonst als "other" typisiert
 }
 
 
@@ -32,9 +33,27 @@ def get_journal(
     """
     _, last_day = monthrange(year, month)
 
+    # #312/#376 DSGVO: eigene Abwesenheitsgründe können sensibel sein (z. B.
+    # „Kind krank"/„Reha") — jede Absence mit reason_id wird (wie SICK) maskiert,
+    # wenn keine Gesundheitsdaten angefordert sind. Bei angeforderten Daten zeigt
+    # das Label den eigenen Grund-Namen (Parität zu export_/ods_export_service).
+    reason_names: Dict[str, str] = {}
+    if include_health_data:
+        from app.models import AbsenceReason
+        reason_names = {
+            str(r.id): r.name for r in db.query(AbsenceReason).filter(
+                AbsenceReason.tenant_id == user.tenant_id
+            ).all()
+        }
+
+    def _is_masked(a: Absence) -> bool:
+        return not include_health_data and (a.type == AbsenceType.SICK or a.reason_id is not None)
+
     def _abs_type_label(a: Absence) -> str:
-        if not include_health_data and a.type == AbsenceType.SICK:
+        if _is_masked(a):
             return "absent"
+        if a.reason_id is not None:
+            return reason_names.get(str(a.reason_id)) or a.type.value
         return a.type.value
 
     entries = db.query(TimeEntry).filter(
@@ -97,8 +116,9 @@ def get_journal(
         elif day_entries and day_absences:
             day_type = "mixed"
         elif day_absences:
-            # Fix #6: mask a SICK day type when health data is not requested.
-            if not include_health_data and day_absences[0].type == AbsenceType.SICK:
+            # Fix #6 + #312/#376: mask a SICK OR custom-reason day type when health
+            # data is not requested. Sonst zeigt das Tages-Farb-/Label die base-type.
+            if _is_masked(day_absences[0]):
                 day_type = "absent"
             else:
                 day_type = _ABSENCE_TYPE_MAP.get(day_absences[0].type, "other")

--- a/backend/app/services/ods_export_service.py
+++ b/backend/app/services/ods_export_service.py
@@ -20,7 +20,7 @@ from app.models import User, TimeEntry, Absence, PublicHoliday, AbsenceType
 from app.services import calculation_service, special_days_service
 from app.services.arbzg_utils import is_night_work
 from app.services.date_filters import date_in_month, date_in_year
-from app.services.export_service import neutralize_spreadsheet_formula, _load_reason_names, _absence_export_label
+from app.services.export_service import neutralize_spreadsheet_formula, _load_reason_names, _absence_export_label, _group_by_date
 
 
 # ---------------------------------------------------------------------------
@@ -76,6 +76,18 @@ def _int_cell(value: int, style=None) -> TableCell:
     cell = TableCell(valuetype="float", value=str(value), stylename=style)
     cell.addElement(P(text=str(value)))
     return cell
+
+
+def _absence_cell_parts(day_absences, reason_names, include_health_data):
+    """Kombiniertes Label + Note für ALLE Abwesenheiten eines Tages (Misch-Tage
+    mit 2 Typen). Masking/Custom-Reason über _absence_export_label."""
+    labels, notes = [], []
+    for a in day_absences:
+        label, show_note = _absence_export_label(a, ABSENCE_LABELS, reason_names, include_health_data)
+        labels.append(f"{label} ({float(a.hours):.1f}h)")
+        if show_note and a.note:
+            notes.append(a.note)
+    return " | ".join(labels), " | ".join(notes)
 
 
 def _empty_cell() -> TableCell:
@@ -167,13 +179,13 @@ def _monthly_sheet(doc, db, user, year, month, bold, normal, include_health_data
         date_in_month(TimeEntry.date, year, month),
     ).order_by(TimeEntry.start_time).all():
         entries_by_date.setdefault(e.date, []).append(e)
-    absences_by_date = {
-        a.date: a
-        for a in db.query(Absence).filter(
-            Absence.user_id == user.id,
-            date_in_month(Absence.date, year, month),
-        ).all()
-    }
+    # per-Tag LISTE (nicht dict-by-date) — sonst geht der 2. Eintrag eines
+    # Misch-Tags (z. B. ½ Urlaub + ½ Sonstiges) verloren.
+    absences_by_date = _group_by_date(db.query(Absence).filter(
+        Absence.user_id == user.id,
+        Absence.tenant_id == user.tenant_id,  # F-026
+        date_in_month(Absence.date, year, month),
+    ).all())
     holidays_by_date = {
         h.date: h
         for h in db.query(PublicHoliday).filter(
@@ -195,7 +207,8 @@ def _monthly_sheet(doc, db, user, year, month, bold, normal, include_health_data
         is_sunday = weekday == 6
         is_weekend = weekday >= 5
         is_holiday = current_date in holidays_by_date
-        absence = absences_by_date.get(current_date)
+        day_absences = absences_by_date.get(current_date, [])
+        absence = day_absences[0] if day_absences else None
         day_entries = entries_by_date.get(current_date, [])
 
         # Night work check (§6 / §2 Abs. 4 ArbZG)
@@ -212,7 +225,7 @@ def _monthly_sheet(doc, db, user, year, month, bold, normal, include_health_data
 
         if day_entries:
             first_start = day_entries[0].start_time
-            last_end = day_entries[-1].end_time
+            last_end = max((e.end_time for e in day_entries if e.end_time), default=None)  # §16: echtes Tagesende
             total_break = sum(e.break_minutes or 0 for e in day_entries)
             total_day_net = sum(e.net_hours for e in day_entries)
             tr.addElement(_str_cell(first_start.strftime("%H:%M")))
@@ -276,17 +289,15 @@ def _monthly_sheet(doc, db, user, year, month, bold, normal, include_health_data
                 if e.note:
                     bem_parts.append(e.note)
             tr.addElement(_str_cell(" | ".join(bem_parts) if bem_parts else ""))
-        elif absence:
+        elif day_absences:
             target = Decimal("0.00")
-            # DSGVO F-003: mask sick absences unless health data explicitly requested
-            # #312: sick AND custom-reason absences are masked (label + note)
-            # unless health data is explicitly requested — a custom reason can be
-            # health-sensitive. Otherwise a custom reason shows its own name.
-            label, _show_note = _absence_export_label(absence, ABSENCE_LABELS, reason_names, include_health_data)
-            note_str = (absence.note or "") if _show_note else ""
+            # DSGVO F-003 / #312: sick + custom-reason absences maskiert (Label +
+            # Note) außer bei explizit angeforderten Gesundheitsdaten. ALLE
+            # Abwesenheiten des Tages (Misch-Tag) werden gerendert.
+            label, note_str = _absence_cell_parts(day_absences, reason_names, include_health_data)
             tr.addElement(_float_cell(0.0))
             tr.addElement(_float_cell(0.0))
-            tr.addElement(_str_cell(f"{label} ({float(absence.hours):.1f}h)"))
+            tr.addElement(_str_cell(label))
             tr.addElement(_str_cell(note_str))
         else:
             target = daily_target
@@ -482,13 +493,12 @@ def _yearly_employee_sheet(doc, db, user, year, bold, include_health_data: bool 
         date_in_year(TimeEntry.date, year),
     ).order_by(TimeEntry.start_time).all():
         entries_by_date.setdefault(e.date, []).append(e)
-    absences_by_date = {
-        a.date: a
-        for a in db.query(Absence).filter(
-            Absence.user_id == user.id,
-            date_in_year(Absence.date, year),
-        ).all()
-    }
+    # per-Tag LISTE (Misch-Tage nicht verlieren) — wie im Monats-Sheet.
+    absences_by_date = _group_by_date(db.query(Absence).filter(
+        Absence.user_id == user.id,
+        Absence.tenant_id == user.tenant_id,  # F-026
+        date_in_year(Absence.date, year),
+    ).all())
     holidays_by_date = {
         h.date: h
         for h in db.query(PublicHoliday).filter(
@@ -509,7 +519,8 @@ def _yearly_employee_sheet(doc, db, user, year, bold, include_health_data: bool 
         is_sunday = weekday == 6
         is_weekend = weekday >= 5
         is_holiday = current_date in holidays_by_date
-        absence = absences_by_date.get(current_date)
+        day_absences = absences_by_date.get(current_date, [])
+        absence = day_absences[0] if day_absences else None
         day_entries = entries_by_date.get(current_date, [])
         weekly_hours = calculation_service.get_weekly_hours_for_date(db, user, current_date)
         daily_target = calculation_service.get_daily_target_for_date(user, current_date, weekly_hours=weekly_hours)
@@ -531,7 +542,7 @@ def _yearly_employee_sheet(doc, db, user, year, bold, include_health_data: bool 
 
         if day_entries:
             first_start = day_entries[0].start_time
-            last_end = day_entries[-1].end_time
+            last_end = max((e.end_time for e in day_entries if e.end_time), default=None)  # §16: echtes Tagesende
             total_break = sum(e.break_minutes or 0 for e in day_entries)
             total_day_net = sum(float(e.net_hours) for e in day_entries)
             tr.addElement(_str_cell(first_start.strftime("%H:%M")))
@@ -583,17 +594,13 @@ def _yearly_employee_sheet(doc, db, user, year, bold, include_health_data: bool 
                 if e.note:
                     bem_parts.append(e.note)
             tr.addElement(_str_cell(" | ".join(bem_parts) if bem_parts else ""))
-        elif absence:
-            # DSGVO F-003/Art. 9: mask sick absences (label + note) unless health
-            # data is explicitly requested — mirrors _monthly_sheet.
-            # #312: sick AND custom-reason absences are masked (label + note)
-            # unless health data is explicitly requested — a custom reason can be
-            # health-sensitive. Otherwise a custom reason shows its own name.
-            label, _show_note = _absence_export_label(absence, ABSENCE_LABELS, reason_names, include_health_data)
-            note_str = (absence.note or "") if _show_note else ""
+        elif day_absences:
+            # DSGVO F-003/Art. 9 / #312: sick + custom-reason maskiert außer bei
+            # angeforderten Gesundheitsdaten; ALLE Abwesenheiten des Tages (Misch-Tag).
+            label, note_str = _absence_cell_parts(day_absences, reason_names, include_health_data)
             tr.addElement(_float_cell(0.0))
             tr.addElement(_float_cell(0.0))
-            tr.addElement(_str_cell(f"{label} ({float(absence.hours):.1f}h)"))
+            tr.addElement(_str_cell(label))
             tr.addElement(_str_cell(note_str))
         else:
             target = float(daily_target)
@@ -648,7 +655,8 @@ def _classic_sheet(doc, db, user, year, bold, include_health_data: bool = False)
 
     headers = [
         "Monat", "Soll (Std)", "Ist (Std)", "Saldo (Std)",
-        "Urlaub (Std)", "Krank (Std)", "Fortbildung (Std)", "Sonstiges (Std)", "Bez. Freistellung (Std)", "Nachtarbeit-Tage (§6)",
+        "Urlaub (Std)", "Krank (Std)", "Fortbildung (Std)", "ÜStd.-Ausgleich (Std)",
+        "Sonstiges (Std)", "Bez. Freistellung (Std)", "Nachtarbeit-Tage (§6)",
     ]
     table.addElement(_header_row(headers, bold))
 
@@ -657,6 +665,7 @@ def _classic_sheet(doc, db, user, year, bold, include_health_data: bool = False)
     total_vac = 0.0
     total_sick = 0.0
     total_train = 0.0
+    total_overtime = 0.0
     total_other = 0.0
     total_paid_leave = 0.0
 
@@ -693,6 +702,7 @@ def _classic_sheet(doc, db, user, year, bold, include_health_data: bool = False)
         vac = month_absence_hours(AbsenceType.VACATION)
         sick = month_absence_hours(AbsenceType.SICK)
         train = month_absence_hours(AbsenceType.TRAINING)
+        overtime_comp = month_absence_hours(AbsenceType.OVERTIME)
         other = month_absence_hours(AbsenceType.OTHER)
         paid_leave = month_absence_hours(AbsenceType.PAID_LEAVE)
 
@@ -701,6 +711,7 @@ def _classic_sheet(doc, db, user, year, bold, include_health_data: bool = False)
         total_vac += vac
         total_sick += sick
         total_train += train
+        total_overtime += overtime_comp
         total_other += other
         total_paid_leave += paid_leave
 
@@ -716,6 +727,7 @@ def _classic_sheet(doc, db, user, year, bold, include_health_data: bool = False)
         # DSGVO F-003: mask sick hours unless health data explicitly requested (Art. 9)
         tr.addElement(_float_cell(sick) if include_health_data else _str_cell("–"))
         tr.addElement(_float_cell(train))
+        tr.addElement(_float_cell(overtime_comp))
         tr.addElement(_float_cell(other))
         tr.addElement(_float_cell(paid_leave))
         tr.addElement(_int_cell(night_days))
@@ -733,6 +745,7 @@ def _classic_sheet(doc, db, user, year, bold, include_health_data: bool = False)
     # DSGVO F-003: mask sick total unless health data explicitly requested (Art. 9)
     tr.addElement(_float_cell(total_sick) if include_health_data else _str_cell("–"))
     tr.addElement(_float_cell(total_train))
+    tr.addElement(_float_cell(total_overtime))
     tr.addElement(_float_cell(total_other))
     tr.addElement(_float_cell(total_paid_leave))
     tr.addElement(_int_cell(total_night))

--- a/backend/tests/test_journal_service.py
+++ b/backend/tests/test_journal_service.py
@@ -132,3 +132,33 @@ def test_journal_day_actuals_windowed_match_monthly_actual(db, test_user):
     assert mar9["actual_hours"] == 0.0   # out-of-window -> kein Ist
     mar23 = next(d for d in result["days"] if d["date"] == "2026-03-23")
     assert mar23["actual_hours"] == 8.0  # in-window -> zaehlt
+
+
+def test_journal_paid_leave_day_type(db, test_user):
+    # Fix: PAID_LEAVE war nicht in _ABSENCE_TYPE_MAP → wurde als "other" typisiert.
+    _make_absence(db, test_user, date(2026, 3, 4), AbsenceType.PAID_LEAVE)
+    result = journal_service.get_journal(db, test_user, 2026, 3)
+    day = next(d for d in result["days"] if d["date"] == "2026-03-04")
+    assert day["type"] == "paid_leave"
+
+
+def test_journal_masks_custom_reason_absence_without_health_data(db, test_user):
+    # #312/#376 DSGVO: eine Absence mit reason_id (z. B. Kind krank) muss ohne
+    # angeforderte Gesundheitsdaten maskiert werden (Tagestyp + Label → "absent").
+    from app.models import AbsenceReason
+    r = AbsenceReason(tenant_id=DEFAULT_TENANT_ID, name="Kind krank",
+                      base_behavior="unpaid_free", is_active=True, tracks_child_sick_limit=True)
+    db.add(r); db.commit(); db.refresh(r)
+    a = Absence(tenant_id=DEFAULT_TENANT_ID, user_id=test_user.id, date=date(2026, 3, 5),
+                type=AbsenceType.OTHER, hours=Decimal("8"), reason_id=r.id)
+    db.add(a); db.commit()
+
+    masked = journal_service.get_journal(db, test_user, 2026, 3, include_health_data=False)
+    day_m = next(d for d in masked["days"] if d["date"] == "2026-03-05")
+    assert day_m["type"] == "absent"
+    assert day_m["absences"][0]["type"] == "absent"
+    assert "Kind krank" not in str(day_m)
+
+    shown = journal_service.get_journal(db, test_user, 2026, 3, include_health_data=True)
+    day_s = next(d for d in shown["days"] if d["date"] == "2026-03-05")
+    assert day_s["absences"][0]["type"] == "Kind krank"  # eigener Grund-Name sichtbar

--- a/backend/tests/test_ods_export_service.py
+++ b/backend/tests/test_ods_export_service.py
@@ -241,3 +241,24 @@ class TestAbsencesOverviewDayBased:
         acc_b = calculation_service.get_vacation_account(db, user_b, 2026)
         assert b_vac == round(float(acc_b["used_days"]), 1)
         assert b_rest == round(float(acc_b["remaining_days"]), 1)
+
+
+class TestOdsMultiAbsenceDay:
+    def test_monthly_renders_both_absences_on_multitype_day(self, db, test_user):
+        # Regression: die ODS-Detailsheets keyten Absences per date-dict → der 2.
+        # Eintrag eines Misch-Tags (½ Urlaub + ½ Sonstiges) ging verloren.
+        import zipfile
+        _mk_absence(db, test_user, date(2026, 3, 4), AbsenceType.VACATION, hours=4)
+        _mk_absence(db, test_user, date(2026, 3, 4), AbsenceType.OTHER, hours=4)
+        out = generate_monthly_report(db, test_user, 2026, 3, include_health_data=True)
+        with zipfile.ZipFile(out) as zf:
+            content = zf.read("content.xml").decode("utf-8", errors="replace")
+        assert "Urlaub" in content and "Sonstiges" in content
+
+    def test_classic_has_overtime_column(self, db, test_user):
+        import zipfile
+        _mk_absence(db, test_user, date(2026, 3, 4), AbsenceType.OVERTIME, hours=8)
+        out = generate_yearly_report_classic(db, test_user, 2026, include_health_data=True)
+        with zipfile.ZipFile(out) as zf:
+            content = zf.read("content.xml").decode("utf-8", errors="replace")
+        assert "ÜStd.-Ausgleich" in content

--- a/backend/tests/test_ods_export_service.py
+++ b/backend/tests/test_ods_export_service.py
@@ -250,7 +250,7 @@ class TestOdsMultiAbsenceDay:
         import zipfile
         _mk_absence(db, test_user, date(2026, 3, 4), AbsenceType.VACATION, hours=4)
         _mk_absence(db, test_user, date(2026, 3, 4), AbsenceType.OTHER, hours=4)
-        out = generate_monthly_report(db, test_user, 2026, 3, include_health_data=True)
+        out = generate_monthly_report(db, 2026, 3, include_health_data=True)
         with zipfile.ZipFile(out) as zf:
             content = zf.read("content.xml").decode("utf-8", errors="replace")
         assert "Urlaub" in content and "Sonstiges" in content
@@ -258,7 +258,7 @@ class TestOdsMultiAbsenceDay:
     def test_classic_has_overtime_column(self, db, test_user):
         import zipfile
         _mk_absence(db, test_user, date(2026, 3, 4), AbsenceType.OVERTIME, hours=8)
-        out = generate_yearly_report_classic(db, test_user, 2026, include_health_data=True)
+        out = generate_yearly_report_classic(db, 2026, include_health_data=True)
         with zipfile.ZipFile(out) as zf:
             content = zf.read("content.xml").decode("utf-8", errors="replace")
         assert "ÜStd.-Ausgleich" in content

--- a/frontend/src/components/MonthlyJournal.tsx
+++ b/frontend/src/components/MonthlyJournal.tsx
@@ -38,7 +38,7 @@ interface AbsenceItem {
 interface JournalDay {
   date: string;
   weekday: string;
-  type: 'work' | 'vacation' | 'sick' | 'overtime' | 'training' | 'other' | 'holiday' | 'weekend' | 'empty' | 'mixed';
+  type: 'work' | 'vacation' | 'sick' | 'overtime' | 'training' | 'other' | 'paid_leave' | 'absent' | 'holiday' | 'weekend' | 'empty' | 'mixed';
   is_holiday: boolean;
   holiday_name: string | null;
   time_entries: TimeEntryItem[];
@@ -75,6 +75,8 @@ const TYPE_LABELS: Record<string, string> = {
   overtime: 'Überstundenausgleich',
   training: 'Fortbildung',
   other: 'Sonstiges',
+  paid_leave: 'Bezahlte Freistellung',
+  absent: 'Abwesend',
   holiday: 'Feiertag',
   weekend: '',
   empty: '–',
@@ -88,6 +90,8 @@ const TYPE_COLORS: Record<string, string> = {
   overtime: 'text-purple-600',
   training: 'text-green-600',
   other: 'text-gray-600',
+  paid_leave: 'text-teal-600',
+  absent: 'text-gray-500',
   holiday: 'text-red-600',
   weekend: 'text-gray-400',
   empty: 'text-gray-400',


### PR DESCRIPTION
Ergebnis eines adversarialen 4-Dimensionen-Reviews der Export-Funktionen (`export_service` XLSX/PDF, `ods_export_service` ODS, `journal_service` §16). 18 verifizierte Findings; **7 Bugs gefixt**, Rest = optionale Verbesserungen (unten).

## Gefixte Bugs

| Sev | Datei | Problem → Fix |
|---|---|---|
| **HIGH** | ods_export_service | Detail-Sheets keyten Absences per Datum-Dict → **2. Eintrag eines Misch-Tags** (½ Urlaub + ½ Sonstiges) ging verloren → `_group_by_date`-Liste, rendert alle. |
| MED | journal_service | §16-Journal ignorierte `reason_id` → **keine DSGVO-Maskierung** (leakte „Kind krank"/„Reha" in der Admin-Default-Ansicht) → `reason_id` wie SICK maskiert, Grund-Name bei angeforderten Gesundheitsdaten. |
| MED | export_service | XLSX-Jahresübersicht „Krankheitstage" **nicht tagebasiert** (`Σh÷Tagessoll`) → `absence_days` (+ F-026). |
| MED | ods_export_service | „Bis"-Zeit = letzter-nach-Start `end_time` statt `max(end)`. |
| MED | ods_export_service | Classic-Sheet: fehlende **OVERTIME-Spalte** (ÜStd.-Ausgleich) ergänzt. |
| LOW | journal_service (+FE) | `_ABSENCE_TYPE_MAP` fehlte **PAID_LEAVE** → „Bezahlte Freistellung" (Label/Farbe/Union in `MonthlyJournal.tsx`). |
| LOW | export_service | XLSX Spalte-9 Custom-Reason-Label **nicht formel-neutralisiert** (Injection-Sink). |

## Bewusst NICHT geändert (optionale Verbesserungen)
- Minijob/§2-MiLoG-Status im Export (§16-korrekt weggelassen); per-workday-Soll vs. flat-MiLoG = Baustein-2-Gap (kein falscher Wert).
- Kind-krank/Custom-Reason-Aufschlüsselung in den Summen-Sheets (heute in Basistyp gebündelt).
- Teiltags-Abwesenheiten zeigen Stunden statt Zeitfenster.
- Die 4 identischen Label-Maps dedupen.

## Tests
+4 Regressionstests (Journal-Masking/PAID_LEAVE, ODS Multi-Absence/OVERTIME-Spalte); 114 export/journal/report grün, tsc sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
