### PR TITLE
Release 1.13.1: MiLoG-Stichtag-Fix + Review-Härtung

### DIFF
--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.13.0"
+APP_VERSION = "1.13.1"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -8,12 +8,12 @@ from typing import List
 from datetime import datetime, timezone, timedelta
 from app.services.timezone_service import today_local
 from app.database import get_db
-from app.models import User, TimeEntry, Absence, WorkingHoursChange, ChangeRequest, TimeEntryAuditLog, UserRole
+from app.models import User, TimeEntry, Absence, AbsenceReason, WorkingHoursChange, ChangeRequest, TimeEntryAuditLog, UserRole
 from app.middleware.auth import require_admin
 from app.schemas.user import UserCreate, UserUpdate, UserResponse, UserCreateResponse, AdminSetPassword, UserListResponse
 from app.schemas.working_hours_change import WorkingHoursChangeCreate, WorkingHoursChangeResponse
 from app.schemas.reports import AdminUserOverview, VacationAccount, YtdOvertime
-from app.services import auth_service, calculation_service, milog_service
+from app.services import auth_service, calculation_service, milog_service, settings_service
 from app.core.license import check_employee_limit
 
 router = APIRouter(prefix="/api/admin", tags=["admin"], dependencies=[Depends(require_admin)])
@@ -164,6 +164,16 @@ def users_overview(
     ).all()
 
     is_current_year = (year == today_local().year)
+    # #376 N+1-Vermeidung: der Tenant-Default wird EINMAL aufgelöst; die
+    # per-User Absence⋈AbsenceReason-Verbrauchsquery entfällt komplett, solange
+    # der Tenant keinen Grund mit tracks_child_sick_limit führt (der Regelfall).
+    _cs_default = settings_service.get_int_setting(
+        db, "child_sick_days_default", current_user.tenant_id, 15
+    )
+    _cs_tenant_tracks = db.query(AbsenceReason.id).filter(
+        AbsenceReason.tenant_id == current_user.tenant_id,  # F-026
+        AbsenceReason.tracks_child_sick_limit.is_(True),
+    ).first() is not None
     result = []
     for u in users:
         vac = calculation_service.get_vacation_account(db, u, year)
@@ -178,7 +188,14 @@ def users_overview(
         _milog_w: list[str] = []
         if is_current_year and u.milog_working_time_account and u.track_hours:
             _t = today_local()
-            _detailed = calculation_service.get_overtime_history_detailed(db, u, _t.year, _t.month)
+            # #313 Saldo-Stichtag: den Stichtag durchreichen (Parität zum
+            # MA-Dashboard, dashboard.py). Ohne cutoff trägt der laufende Monat
+            # ein VOLLES Monats-Soll gegen einen nur monats-bis-heute-Ist → ein
+            # Phantom-Defizit, das im FIFO die älteste (überfällige) Einlage
+            # aufzehrt und die MILOG_SETTLEMENT_DUE-Warnung unterdrückt.
+            _detailed = calculation_service.get_overtime_history_detailed(
+                db, u, _t.year, _t.month, cutoff_date=cutoff
+            )
             if _detailed:
                 _cur = _detailed.get((_t.year, _t.month))
                 _actual = _cur.actual if _cur is not None else 0.0
@@ -203,8 +220,14 @@ def users_overview(
                 remaining_days=vac["remaining_days"],
             ),
             overtime=YtdOvertime(year=year, **ytd),
-            child_sick_used=float(calculation_service.child_sick_days_used(db, u, year)),  # #376
-            child_sick_cap=calculation_service.child_sick_cap(db, u),  # #376
+            child_sick_used=(
+                float(calculation_service.child_sick_days_used(db, u, year))
+                if _cs_tenant_tracks else 0.0
+            ),  # #376
+            child_sick_cap=(
+                int(u.child_sick_days_per_year)
+                if u.child_sick_days_per_year is not None else _cs_default
+            ),  # #376
             milog_warnings=_milog_w,  # #377
         ))
     return result

--- a/backend/tests/test_milog.py
+++ b/backend/tests/test_milog.py
@@ -345,6 +345,54 @@ def test_settlement_aging_real_history(db, employee):
     assert res["overdue"] is True and res["hours"] > 50  # ~30 Monate alt, kaum aufgezehrt
 
 
+def test_settlement_aging_full_current_month_soll_eats_seed(db, employee, monkeypatch):
+    """#377 Regression (admin-overview Stichtag): der LAUFENDE (unvollständige)
+    Monat darf NICHT mit vollem Monats-Soll gegen einen nur monats-bis-heute-Ist
+    ins Aging fließen — das fabriziert ein Phantom-Defizit, das im FIFO die
+    älteste überfällige Einlage aufzehrt und MILOG_SETTLEMENT_DUE unterdrückt.
+    Der Stichtag-getrimmte Detail-Pass (aktueller Monat ~0) erhält den Bestand."""
+    employee.milog_working_time_account = True
+    db.commit()
+    db.add(YearCarryover(tenant_id=DEFAULT_TENANT_ID, user_id=employee.id, year=2025,
+                         overtime_hours=Decimal("8"), vacation_days=Decimal("0")))
+    db.commit()
+    # OHNE Stichtag: laufender Monat (2026,6) trägt volles Soll (40h) gegen 0 Ist
+    # → −40 → verzehrt den 8h-Seed komplett → deposits leer → None (Warnung weg).
+    monkeypatch.setattr(milog_service.calculation_service, "get_overtime_history_detailed",
+                        lambda *a, **k: {(2026, 6): _MO(40, 0)})
+    assert milog_service.settlement_aging(db, employee, date(2026, 6, 15)) is None
+    # MIT Stichtag: laufender Monat auf monats-bis-heute getrimmt (~0 Soll) → Seed
+    # überlebt, sichtbar + überfällig.
+    monkeypatch.setattr(milog_service.calculation_service, "get_overtime_history_detailed",
+                        lambda *a, **k: {(2026, 6): _MO(0, 0)})
+    res = milog_service.settlement_aging(db, employee, date(2026, 6, 15))
+    assert res is not None and res["overdue"] is True and abs(res["hours"] - 8.0) < 0.01
+
+
+def test_users_overview_feeds_settlement_cutoff_trimmed_detail(db, admin, employee, monkeypatch):
+    """#377 Regression: die Admin-Benutzerübersicht MUSS get_overtime_history_detailed
+    MIT dem Saldo-Stichtag aufrufen (Parität zum MA-Dashboard, #313). Ohne cutoff
+    verschwindet die MILOG_SETTLEMENT_DUE-Warnung des laufenden Monats aus der
+    compliance-relevanten Arbeitgeber-Ansicht."""
+    from app.services import calculation_service
+    employee.milog_working_time_account = True
+    db.commit()
+    captured = {}
+
+    def _spy(db_, u, y, m, **kwargs):
+        if u.id == employee.id:
+            captured["cutoff_date"] = kwargs.get("cutoff_date", "MISSING")
+        return {(2025, 1): _MO(0, 0)}
+
+    monkeypatch.setattr(calculation_service, "get_overtime_history_detailed", _spy)
+    client = _client_as(db, admin, admin)
+    client.get(f"{USERS}-overview")
+    expected = calculation_service.get_soll_cutoff_date(db, employee)
+    assert captured.get("cutoff_date") == expected  # Stichtag durchgereicht
+    assert captured["cutoff_date"] is not None       # im laufenden Jahr nie None
+    app.dependency_overrides.clear()
+
+
 def test_create_time_entry_emits_milog_for_flagged_user(db, admin, employee, monkeypatch):
     from app.services.timezone_service import today_local
     employee.milog_working_time_account = True

--- a/docs/handbuch/CHEATSHEET-ADMIN.md
+++ b/docs/handbuch/CHEATSHEET-ADMIN.md
@@ -174,9 +174,13 @@ Frei benannte Gründe (z. B. „Schule" für Azubis) mit Farbe + **Basis-Verhalt
 |-----------------|---------|
 | **zählt als gearbeitet** | Stunden als Arbeitszeit gutgeschrieben (wie Fortbildung) |
 | **bezahlt frei** | Tagessoll 0, **kein** Urlaubsabzug |
+| **unbezahlt frei** | Tagessoll 0, **kein** Urlaubsabzug, aber **unbezahlt** (Lohn gekürzt) – z. B. Kind krank (§45 SGB V) |
 | **Überstundenabbau** | Überstundenkonto sinkt um Tagessoll |
 
 Erscheinen beim Buchen unter „Eigene Gründe". Im Team-Kalender für Kolleg:innen als **„abwesend"** maskiert (Datenschutz); nur Admins sehen die Bezeichnung. Deaktivierbar.
+
+**Kind krank (#376):** Ein „unbezahlt frei"-Grund mit gesetztem **Kind-krank-Limit** zählt gegen den §45-SGB-V-Jahresanspruch (Default 15 Tage, pro MA überschreibbar). Überschreitung → **weiche Warnung** beim Buchen (nie blockierend). Verbrauch je MA in der **Benutzerübersicht**.
+**Minijob/MiLoG (#377):** Opt-in „Arbeitszeitkonto (§2 Abs.2 MiLoG)" je MA → weiche Warnungen bei >50 % Monats-Plus + 12-Monats-Ausgleichsfrist. Mindestlohn 13,90 €/h (2026), 14,60 €/h (2027).
 
 ---
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.13.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/admin/Users.tsx
+++ b/frontend/src/pages/admin/Users.tsx
@@ -47,6 +47,7 @@ export default function Users() {
   const [vacationInfo, setVacationInfo] = useState<Record<string, VacationInfo>>({});
   const [overtimeInfo, setOvertimeInfo] = useState<Record<string, OvertimeInfo>>({}); // #194
   const [milogInfo, setMilogInfo] = useState<Record<string, string[]>>({}); // #377 §2 Abs.2 MiLoG
+  const [childSickInfo, setChildSickInfo] = useState<Record<string, { used: number; cap: number }>>({}); // #376 Kind krank §45 SGB V
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editingUser, setEditingUser] = useState<User | null>(null);
@@ -86,20 +87,24 @@ export default function Users() {
         const vMap: Record<string, VacationInfo> = {};
         const oMap: Record<string, OvertimeInfo> = {};
         const mMap: Record<string, string[]> = {};
+        const csMap: Record<string, { used: number; cap: number }> = {};
         overview.data.forEach((row: {
           user_id: string; track_hours: boolean;
           vacation: VacationInfo; overtime: { overtime: number };
           milog_warnings?: string[]; // #377
+          child_sick_used?: number; child_sick_cap?: number; // #376
         }) => {
           vMap[row.user_id] = row.vacation;
           // Review R3: defensive — a missing overtime object must not throw
           // here and wedge the whole overview into "Lädt…" forever.
           oMap[row.user_id] = { overtime: row.overtime?.overtime ?? 0, track_hours: row.track_hours };
           mMap[row.user_id] = row.milog_warnings ?? []; // #377
+          csMap[row.user_id] = { used: row.child_sick_used ?? 0, cap: row.child_sick_cap ?? 0 }; // #376
         });
         setVacationInfo(vMap);
         setOvertimeInfo(oMap);
         setMilogInfo(mMap);
+        setChildSickInfo(csMap);
       } catch {
         // overview optional — the user list still renders without it
       }
@@ -542,6 +547,19 @@ export default function Users() {
                         >
                           <Badge variant="warning">MiLoG</Badge>
                         </span>
+                      )}
+                      {/* #376 Kind krank §45 SGB V: Jahresverbrauch je MA */}
+                      {childSickInfo[user.id]?.used > 0 && (
+                        <div
+                          className={`mt-1 text-xs ${
+                            childSickInfo[user.id].used > childSickInfo[user.id].cap
+                              ? 'text-red-600 font-medium'
+                              : 'text-gray-500'
+                          }`}
+                          title={`Kind krank (§45 SGB V): ${childSickInfo[user.id].used.toFixed(1)} von ${childSickInfo[user.id].cap} Tagen ${new Date().getFullYear()} verbraucht`}
+                        >
+                          Kind krank: {childSickInfo[user.id].used.toFixed(1)}/{childSickInfo[user.id].cap}
+                        </div>
                       )}
                     </td>
                     <td className="px-6 py-4 text-sm">

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.13.0"
+APP_VERSION="1.13.1"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
## Release 1.13.1 (PATCH)

Pre-Release-Multi-Agent-Review der seit v1.13.0 gemergten Änderungen (#376 Kind krank, #377 Minijob/MiLoG, #380 Export-Fixes). 1 bestätigtes Medium-Finding + 3 Low aus demselben Umfeld gefixt.

### Fixes
- **MEDIUM (correctness):** `admin_users.users_overview` reichte den Saldo-Stichtag (#313) NICHT an `get_overtime_history_detailed` durch (anders als das MA-Dashboard). Der laufende, unvollständige Monat trug so ein VOLLES Monats-Soll gegen einen nur monats-bis-heute-Ist → Phantom-Defizit, das im FIFO-Aging die älteste überfällige Einlage aufzehrte und die `MILOG_SETTLEMENT_DUE`-Warnung in der compliance-relevanten Admin-Übersicht unterdrückte, während die MA-Eigenansicht sie zeigte. Fix: `cutoff_date=cutoff` durchreichen (Parität). +2 Regressionstests.
- **LOW (efficiency):** child_sick N+1 in derselben Overview-Schleife entfernt (Tenant-Default einmal aufgelöst, per-User Absence⋈AbsenceReason-Query nur bei aktivem Kind-krank-Grund).
- **LOW (docs/UI):** #376-Kind-krank-Verbrauch je MA jetzt in der Benutzerübersicht (`Users.tsx`) angezeigt — Backend lieferte die Felder bereits; macht Handbuch + In-App-Hilfe wahr.
- **LOW (docs):** `CHEATSHEET-ADMIN` um „unbezahlt frei" + Kind-krank/MiLoG-Kurzhinweise ergänzt.

### QA
- Backend-Suite **1291 passed / 49 skipped**; Frontend **182 passed**; `tsc` clean.
- Migrationen 061+062 (keine neue in diesem PR) **up→down→up auf PG18** verifiziert.
- Build: alle 6 Artefakte; Windows-ZIP-Integrität (kein `setup.exe` im Tree, PG-Installer-SHA == 18.4-Pin, gebündelter `updater.py` == 1.13.1).
- `validate-release` **5/5** (Ubuntu 22/24, Debian 12, Rocky 9, Arch), PG 18.4.
- **Lokaler Docker:** Login 200 + `users-overview` (geänderter Endpoint) 200.
- **.131 nativ Update 1.12.3 → 1.13.1** (echtes PG, live Daten): alembic 059→062, Daten erhalten (untouched Tabellen md5-identisch), Login 200 + `users-overview` 200.

Windows-Emulator + lokaler Native-Fresh übersprungen: **0 `installer/`-Änderungen seit v1.13.0** (Artefakt-Integrität verifiziert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
