### PR TITLE
Re-cut Release 1.13.1 → 1.14.0 (MINOR)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.13.1 (Stand 2026-07-09)
+**Aktuelle Version:** 1.14.0 (Stand 2026-07-09)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.13.1"
+APP_VERSION = "1.14.0"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.13.1",
+      "version": "1.14.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.13.1",
+  "version": "1.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.13.1"
+APP_VERSION="1.14.0"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
Umbenennung: der bereits reviewte + getestete 1.13.1-Inhalt (PR #384, MiLoG-`settlement_aging`-Stichtag-Fix + 3 Low) wird als **MINOR 1.14.0** ausgeliefert. **Inhaltlich identisch** — nur die Versionsnummer ändert sich (updater.py, build-release.sh, package.json+lock, CLAUDE.md).

`v1.13.1`-Tag + GitHub-Release werden zurückgezogen; alle Artefakte als 1.14.0 neu gebaut. Migration head unverändert 062 (keine neue Migration).

QA carry-over aus #384: Backend 1291 / Frontend 182 / validate 5/5 (PG 18.4) / .131-nativ-Update mit Daten-Erhalt + Login. Rebuild-Artefakte werden erneut integritätsgeprüft + ein echter Login auf 1.14.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
