### PR TITLE
feat(#375): Admin kann Abwesenheit für den laufenden Tag (heute) eintragen

### DIFF
--- a/backend/app/routers/admin_time_entries.py
+++ b/backend/app/routers/admin_time_entries.py
@@ -57,6 +57,25 @@ def admin_create_time_entry(
         user, entry_data.date, entry_data.start_time, entry_data.end_time, _grace,
     )
 
+    # #375-Review: mirror the employee path's duplicate-start guard, BEFORE the
+    # ArbZG aggregate checks. The admin per-day journal add is now available for
+    # TODAY, where a manual entry can collide with an existing/open clock-in
+    # sharing the (clamped) start minute. Without this the (tenant, user, date,
+    # start_time) UNIQUE constraint raises an IntegrityError on commit → HTTP 500;
+    # return a clean 409 instead (SQLite ignores the constraint, so this app-level
+    # check is what actually protects both engines).
+    duplicate = db.query(TimeEntry).filter(
+        TimeEntry.user_id == user.id,
+        TimeEntry.tenant_id == current_user.tenant_id,  # F-026
+        TimeEntry.date == entry_data.date,
+        TimeEntry.start_time == eff_start,
+    ).first()
+    if duplicate:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Es existiert bereits ein Eintrag mit dieser Startzeit an diesem Datum",
+        )
+
     admin_create_warnings: list[str] = []
     waiver_reason = (entry_data.break_waiver_reason or "").strip()
     break_waiver_active = False

--- a/backend/tests/test_work_window_integration.py
+++ b/backend/tests/test_work_window_integration.py
@@ -341,6 +341,23 @@ def test_admin_create_caps_both_ends(db, employee, admin, admin_client):
     assert entry.raw_end_time == dt.time(18, 0), f"Expected raw_end 18:00, got {entry.raw_end_time}"
 
 
+def test_admin_create_duplicate_start_returns_409(db, employee, admin, admin_client):
+    """#375-Review: the admin per-day journal add (now available for TODAY) can
+    collide with an existing entry sharing the start minute. A second entry with
+    the same (date, start_time) must return a clean 409 — not the unhandled
+    IntegrityError → HTTP 500 the UNIQUE constraint would raise on Postgres
+    (SQLite ignores the constraint, so the app-level guard is what protects it)."""
+    payload = {"date": "2026-06-02", "start_time": "09:00", "end_time": "12:00", "break_minutes": 0}
+    r1 = admin_client.post(f"/api/admin/users/{employee.id}/time-entries", json=payload)
+    assert r1.status_code == 201, r1.text
+    r2 = admin_client.post(
+        f"/api/admin/users/{employee.id}/time-entries",
+        json={**payload, "end_time": "13:00"},
+    )
+    assert r2.status_code == 409, r2.text
+    assert "Startzeit" in r2.json()["detail"]
+
+
 def test_cr_approval_create_clamps_to_soll_window(db, employee, admin, admin_client):
     """CR-Genehmigung (request_type=create, entry_kind=time_entry) klappt
     start_time ins Soll-Fenster und speichert den Rohwert in raw_start_time.

--- a/frontend/src/components/MonthlyJournal.test.tsx
+++ b/frontend/src/components/MonthlyJournal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import { format } from 'date-fns';
 import MonthlyJournal, { isJournalData } from './MonthlyJournal';
 
 // #382: clicking a user opens the journal. A non-journal 200 body (e.g. an HTML
@@ -103,6 +104,33 @@ describe('<MonthlyJournal /> malformed-response hardening (#382)', () => {
     render(<MonthlyJournal userId="u1" isAdminView />);
     // Renders the raw date fallback rather than throwing RangeError from format().
     await waitFor(() => expect(screen.getByText('not-a-date')).toBeInTheDocument());
+  });
+
+  it('#375: admin can add an entry/absence for TODAY (not only past days), future stays excluded', async () => {
+    // Local calendar date (match the component's startOfDay(new Date()) notion of
+    // "today"); toISOString() would be UTC and flake in the Berlin post-midnight window.
+    const localToday = format(new Date(), 'yyyy-MM-dd');
+    const past = { ...validDay, date: '2020-01-06', type: 'empty' as const };
+    const today = { ...validDay, date: localToday, type: 'empty' as const };
+    const future = { ...validDay, date: '2099-01-06', type: 'empty' as const };
+    const journal = { ...validJournal, days: [past, today, future] };
+    getMock.mockImplementation((url: string) =>
+      url.includes('/journal')
+        ? Promise.resolve({ data: journal })
+        : Promise.resolve({ data: [] }),
+    );
+    const { unmount } = render(<MonthlyJournal userId="u1" isAdminView />);
+    await waitFor(() =>
+      expect(screen.getAllByTitle('Weiteren Eintrag hinzufügen').length).toBe(2),
+    );
+    // past + today offer the add "+", the future day does not.
+    unmount();
+
+    // Employee self-view stays past-only (today not editable — they use clock-in/out).
+    render(<MonthlyJournal userId="u1" />);
+    await waitFor(() =>
+      expect(screen.getAllByTitle('Eintrag anlegen').length).toBe(1),
+    );
   });
 
   it('does not crash when a day.date is null (date-fns v3 parseISO throws on non-string)', async () => {

--- a/frontend/src/components/MonthlyJournal.tsx
+++ b/frontend/src/components/MonthlyJournal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { format, parseISO, isBefore, startOfDay } from 'date-fns';
+import { format, parseISO, isBefore, isAfter, startOfDay } from 'date-fns';
 import { de } from 'date-fns/locale';
 import { Pencil, Plus, Trash2, Check, X } from 'lucide-react';
 import apiClient from '../api/client';
@@ -143,7 +143,18 @@ function isPastDay(dateStr: unknown): boolean {
   if (typeof dateStr !== 'string') return false; // #382: parseISO v3 throws on non-string
   const d = parseISO(dateStr);
   if (isNaN(d.getTime())) return false; // #382: malformed date → not "past"
-  return isBefore(d, startOfDay(new Date()));
+  return isBefore(startOfDay(d), startOfDay(new Date()));
+}
+
+// #375: a future day is NOT editable in the journal (planned future absences go
+// through the vacation/absence request flow). Admins may edit past AND today
+// (an employee calling in sick today must be bookable immediately); the employee
+// self-view stays past-only (they use clock-in/out for the current day).
+function isFutureDay(dateStr: unknown): boolean {
+  if (typeof dateStr !== 'string') return false; // #382: parseISO v3 throws on non-string
+  const d = parseISO(dateStr);
+  if (isNaN(d.getTime())) return false; // #382: malformed date → treat as not future
+  return isAfter(startOfDay(d), startOfDay(new Date()));
 }
 
 // ---- Main component -------------------------------------------------------
@@ -724,7 +735,7 @@ export default function MonthlyJournal({ userId, isAdminView }: MonthlyJournalPr
                                 </button>
                               )}
                             </div>
-                          ) : !isGray && isPastDay(day.date) ? (
+                          ) : !isGray && (isAdminView ? !isFutureDay(day.date) : isPastDay(day.date)) ? (
                             <div className="flex flex-col items-end">
                               {(day.time_entries.length > 0 || day.absences.length > 0) ? (
                                 <div className="space-y-0.5">


### PR DESCRIPTION
Behebt #375.

## Problem
Im Monats-Journal war die per-Tag **„+"/Bearbeiten**-Aktion auf `isPastDay(day.date)` gegated — **strikt vor heute**. Meldet sich jemand für **heute** krank, konnte der Admin das im Journal nicht direkt eintragen (erst rückwirkend am Folgetag). Der Screenshot im Issue zeigt genau diese Journal-Tabelle mit dem „+" nur bei vergangenen Tagen.

## Fix (Frontend)
`MonthlyJournal.tsx` unterscheidet jetzt `isPastDay` (vor heute) und `isFutureDay` (nach heute). Gate: `!isGray && (isAdminView ? !isFutureDay(day.date) : isPastDay(day.date))`
- **Admin:** Vergangenheit **und heute** buchbar; **Zukunft weiter gesperrt** (geplante Abwesenheiten → Antragsweg).
- **MA-Eigenansicht:** unverändert vergangenheits-only (für heute dient das Stempeln).

Backend erlaubt `create_absence` für heute bereits — reiner Frontend-Gate-Fix.

## Review-Folgefixes (adversarial, 2 Low)
- **`admin_create_time_entry`** spiegelt jetzt den **409-Duplicate-Start-Guard** des MA-Pfads (vor den ArbZG-Checks). Der neu für heute verfügbare „+" kann mit einem offenen Clock-in derselben Startminute kollidieren → sonst UNIQUE-Constraint-`IntegrityError` → **HTTP 500**; jetzt sauberes **409**. (SQLite ignoriert den Constraint → App-Guard schützt beide Engines.)
- Test-Datum lokal statt UTC → keine Berlin-Mitternachts-Flakiness.

## QA
**201** Frontend-Tests (neu: Admin-heute-buchbar=2 / MA-past-only=1) · **1292** Backend-Tests (neu: Admin-409-Duplicate) · `tsc` sauber. Adversariale Multi-Agent-Review: 0 High/Medium, beide Lows gefixt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
