### PR TITLE
feat(#383): Übertrag Urlaubstage im UserForm (neben Anfangssaldo Überstunden)

### DIFF
--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -182,6 +182,7 @@ Klicken Sie auf **„Neuer Mitarbeiter:in"** und füllen Sie das Formular aus:
 | **Individuelle Tagesstunden** | Abweichende Stundenverteilung Mo–Fr statt einheitlich (nur bei aktiver Stundenzählung) |
 | **Abteilung/Bereich** | Optionale Zuordnung (Freitext); ermöglicht Filterung im Abwesenheitskalender |
 | **Anfangssaldo Überstunden** | Übernommener Überstundensaldo zum Startjahr (kann +/- sein; nur bei aktiver Stundenzählung) |
+| **Übertrag Urlaubstage** | Alt-/Vorjahres-Resturlaub, der dem **Urlaubsbudget des Startjahres** zugerechnet wird (z. B. beim Systemwechsel bei unterjährigem Eintritt der Resturlaub aus den Monaten vor dem Eintritt). Minus und Kommastellen möglich; gilt für **alle** MA (auch ohne Stundenzählung). |
 | **Soll-Arbeitszeiten je Wochentag** | Optionaler Soll-Beginn / Soll-Ende pro Wochentag (Mo–Fr) – siehe eigener Abschnitt „Soll-Arbeitszeiten" unten. |
 
 > **Wichtig – zwei getrennte Einstellungen, bitte nicht verwechseln:**

--- a/docs/superpowers/specs/2026-07-13-vacation-carryover-userform-design.md
+++ b/docs/superpowers/specs/2026-07-13-vacation-carryover-userform-design.md
@@ -1,0 +1,121 @@
+# Design: „Übertrag Urlaubstage" im UserForm (#383)
+
+**Datum:** 2026-07-13
+**Issue:** [#383](https://github.com/phash/praxiszeit/issues/383) — „Neben ‚Anfangssaldo Überstunden' auch ‚Übertrag Urlaubstage'"
+**Typ:** Feature (klein, fast reiner Frontend-Change)
+
+## Problem
+
+Beim Wechsel auf PraxisZeit werden Mitarbeitende oft „zum Stichtag eingestellt"
+(Kundenfall: `first_work_day = 1.6.2026`). `get_vacation_account` rechnet den
+Jahresanspruch dann **anteilig** für die Beschäftigungsmonate (Jun–Dez = 7/12).
+Resturlaub aus dem laufenden Jahr **vor** dem Stichtag (Jan–Mai) oder aus dem
+Vorjahr geht so verloren — der Admin kann ihn nicht bequem nachtragen.
+
+Für **Überstunden** existiert dafür das Feld **„Anfangssaldo Überstunden"** in den
+Mitarbeitereigenschaften (UserForm). Ein **gleichwertiges Feld für Urlaubstage**
+fehlt an dieser Stelle. Vacation-Carryover ist heute nur über den separaten
+`CarryoverModal` (pro Jahr) setzbar — der Kunde wünscht es **neben** dem
+Überstunden-Feld im UserForm.
+
+## Bestehende Mechanik (Ausgangslage)
+
+Das Backend unterstützt Urlaubs-Carryover bereits vollständig:
+
+- **`YearCarryover`** (pro `(tenant_id, user_id, year)`) trägt `overtime_hours`
+  **und** `vacation_days`, plus `source` (`manual` | `year_closing`, Migration
+  058/Fix #7 — `manual` überlebt das Rückgängigmachen eines Jahresabschlusses).
+- **`upsert_carryover`** (`PUT /admin/users/{id}/carryovers/{year}`,
+  `admin_carryovers.py`) setzt beide Felder, `source=manual`.
+- **`get_vacation_account`** (`calculation_service.py`) addiert
+  `carryover.vacation_days` des Jahres auf das (ggf. anteilige) Budget.
+
+Das UserForm-Feld **„Anfangssaldo Überstunden"** (`overtime_carryover`) ist
+**kein** User-Feld:
+
+- **State:** `overtime_carryover: 0` (UserForm-lokal).
+- **Startjahr:** `first_work_day.year`, Fallback aktuelles Jahr
+  (`new Date().getFullYear()`).
+- **Prefill (Edit):** lädt die Carryover-Liste, findet die Startjahr-Zeile, setzt
+  `overtime_carryover = row.overtime_hours`, `hadCarryover = true`.
+- **Save (`writeCarryover`):** re-fetcht die Startjahr-Zeile, um `vacation_days`
+  **zu erhalten**, und schreibt `PUT /carryovers/{startYear}` mit
+  `{ overtime_hours: overtime_carryover, vacation_days: <erhalten> }`.
+- **Schreib-Gate:** nur wenn `overtime_carryover !== 0 || hadCarryover`
+  (verhindert leere 0/0-Zeilen für unberührte User).
+
+## Lösung
+
+Ein **paralleles Feld „Übertrag Urlaubstage"** im UserForm, das
+`YearCarryover.vacation_days` desselben Startjahres schreibt — exakt gespiegelt
+zum Überstunden-Feld.
+
+### Frontend (`frontend/src/pages/admin/users/UserForm.tsx`) — der gesamte Change
+
+1. **State:** neu `vacation_carryover: 0` neben `overtime_carryover` (im
+   `formData`-Init und im Reset-Pfad).
+2. **Prefill (Edit):** im bestehenden Carryover-`useEffect` zusätzlich
+   `vacation_carryover = row.vacation_days` aus derselben Startjahr-Zeile setzen.
+3. **Save (`writeCarryover`):** schreibt **beide** Werte aus dem Formular:
+   `PUT /carryovers/{startYear}` mit
+   `{ overtime_hours: overtime_carryover, vacation_days: vacation_carryover }`.
+   Die bisherige „`vacation_days` per Re-Fetch erhalten"-Logik **entfällt** — das
+   UserForm ist jetzt die Autorität für den Startjahr-Carryover (beide Felder).
+   `vacation_carryover` wird — wie `overtime_carryover` — via Destructuring aus
+   dem User-Payload ausgeschlossen (kein User-Feld).
+4. **Schreib-Gate:** erweitert auf
+   `overtime_carryover !== 0 || vacation_carryover !== 0 || hadCarryover`
+   (create-Pfad analog: schreiben, wenn einer der beiden ≠ 0).
+5. **Render:** zweites Number-Input **„Übertrag Urlaubstage"** direkt neben
+   „Anfangssaldo Überstunden":
+   - `type="number"`, `step="0.5"`, **kein `min`** (negativ erlaubt),
+     `onChange` via `parseFloat(e.target.value) || 0`.
+   - Hilfetext: „Alt-/Vorjahres-Resturlaub, der dem Urlaubsbudget des Startjahres
+     ({startYear}) zugerechnet wird. Minus und Kommastellen möglich."
+
+### Backend
+
+**Keine Änderung.** `upsert_carryover` akzeptiert `vacation_days` bereits,
+`get_vacation_account` addiert es aufs Budget, `source=manual` bleibt.
+**Keine Migration.**
+
+### Semantik / Randfälle
+
+- **Jahr-Bindung:** identisch zum Überstunden-Feld — Startjahr
+  (`first_work_day.year`, sonst aktuelles Jahr). Deckt den Kundenfall (Eintritt
+  1.6., Jan–Mai-Resturlaub) exakt ab.
+- **Negativ/Kommastellen:** ausdrücklich erlaubt (Kundenwunsch); `parseFloat`,
+  Backend-Schema akzeptiert Float. Keine Ober-/Untergrenze.
+- **CarryoverModal-Overlap:** `CarryoverModal` bleibt für Nicht-Startjahre /
+  Power-User. Der Startjahr-Overlap besteht **schon heute** für Überstunden; das
+  UserForm prefillt beim Öffnen frisch aus der DB, daher kein Datenverlust,
+  solange nicht beide UIs gleichzeitig offen sind. Neu ist lediglich, dass das
+  UserForm nun auch `vacation_days` des Startjahres **überschreibt** statt es zu
+  erhalten — gewollt, da das Feld genau dieses Wertes Herr wird.
+- **DSGVO / §16:** unberührt — Carryover ist bereits ein bestehendes,
+  admin-gesetztes Feld; keine neuen Daten.
+
+## Tests (Vitest, `UserForm.test.tsx`)
+
+1. Feld **rendert** (Label „Übertrag Urlaubstage") und **prefillt** aus der
+   Startjahr-`vacation_days` beim Edit.
+2. **Save** schickt `vacation_days` (aus dem Feld) an
+   `PUT /admin/users/{id}/carryovers/{startYear}` (zusammen mit `overtime_hours`).
+3. **Startjahr-Fallback**: ohne `first_work_day` bindet der Save aufs aktuelle
+   Jahr.
+4. **Gate**: unberührtes Feld (0/0, kein bestehender Carryover) schreibt **keine**
+   Carryover-Zeile.
+
+## Bewusst NICHT dabei (YAGNI)
+
+- Kein Jahr-Dropdown im UserForm (Nicht-Startjahre → CarryoverModal).
+- Kein neues User-DB-Feld, keine Migration.
+- Keine Änderung an `get_vacation_account`, Export, Journal.
+
+## Betroffene Dateien
+
+- `frontend/src/pages/admin/users/UserForm.tsx` (Feld + State + Prefill + Save).
+- `frontend/src/pages/admin/users/UserForm.test.tsx` (Tests).
+- Ggf. gemeinsamer Handbuch-Hinweis (`docs/handbuch/HANDBUCH-ADMIN.md` +
+  `DocViewer.tsx`) an der Stelle, die „Anfangssaldo Überstunden" erklärt — beide
+  synchron.

--- a/frontend/src/pages/admin/users/UserForm.test.tsx
+++ b/frontend/src/pages/admin/users/UserForm.test.tsx
@@ -1,13 +1,27 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ToastProvider } from '../../../contexts/ToastContext';
 import { useSystemStore } from '../../../stores/systemStore';
 import UserForm from './UserForm';
 
-// carryover-fetch (nur im Edit-Modus) neutralisieren
+// Exposed mocks so #383 tests can configure the /carryovers fetch and assert on
+// the PUT. Defaults keep the existing tests' carryover-useEffect a no-op.
+const getMock = vi.fn();
+const putMock = vi.fn();
+const postMock = vi.fn();
 vi.mock('../../../api/client', () => ({
-  default: { get: vi.fn().mockResolvedValue({ data: [] }), post: vi.fn(), put: vi.fn() },
+  default: {
+    get: (...a: unknown[]) => getMock(...a),
+    put: (...a: unknown[]) => putMock(...a),
+    post: (...a: unknown[]) => postMock(...a),
+  },
 }));
+
+beforeEach(() => {
+  getMock.mockReset().mockResolvedValue({ data: [] });
+  putMock.mockReset().mockResolvedValue({ data: {} });
+  postMock.mockReset().mockResolvedValue({ data: { user: { id: 'new-user-1' } } });
+});
 
 function renderForm(props: Record<string, unknown> = {}) {
   return render(
@@ -63,5 +77,116 @@ describe('#377 UserForm MiLoG checkbox', () => {
       },
     });
     expect((screen.getByLabelText(/Arbeitszeitkonto/i) as HTMLInputElement).checked).toBe(true);
+  });
+});
+
+describe('#383 Übertrag Urlaubstage', () => {
+  const editUser2026 = {
+    id: 'u1', username: 'mj', first_name: 'M', last_name: 'J', role: 'employee',
+    weekly_hours: 40, vacation_days: 30, work_days_per_week: 5, track_hours: true,
+    is_active: true, first_work_day: '2026-06-01',
+  };
+
+  it('renders the field and prefills it from the start-year vacation_days carryover', async () => {
+    getMock.mockResolvedValue({ data: [{ year: 2026, overtime_hours: 5, vacation_days: 8 }] });
+    render(
+      <ToastProvider>
+        <UserForm onSaved={() => {}} editUser={editUser2026 as never} />
+      </ToastProvider>,
+    );
+    const field = await screen.findByLabelText(/Übertrag Urlaubstage/i);
+    await waitFor(() => expect((field as HTMLInputElement).value).toBe('8'));
+  });
+
+  it('saves the field value to /carryovers/{startYear} as vacation_days', async () => {
+    getMock.mockResolvedValue({ data: [{ year: 2026, overtime_hours: 5, vacation_days: 8 }] });
+    render(
+      <ToastProvider>
+        <UserForm onSaved={() => {}} editUser={editUser2026 as never} />
+      </ToastProvider>,
+    );
+    const field = await screen.findByLabelText(/Übertrag Urlaubstage/i);
+    await waitFor(() => expect((field as HTMLInputElement).value).toBe('8'));
+    fireEvent.change(field, { target: { value: '10' } });
+    fireEvent.click(screen.getByRole('button', { name: /Speichern/i }));
+    await waitFor(() => {
+      const call = putMock.mock.calls.find((c) => String(c[0]).includes('/carryovers/'));
+      expect(call).toBeTruthy();
+      expect(String(call![0])).toContain('/carryovers/2026');
+      expect(call![1]).toMatchObject({ vacation_days: 10 });
+    });
+  });
+
+  it('falls back to the current year when first_work_day is unset', async () => {
+    const y = new Date().getFullYear();
+    getMock.mockResolvedValue({ data: [{ year: y, overtime_hours: 0, vacation_days: 2 }] });
+    render(
+      <ToastProvider>
+        <UserForm onSaved={() => {}} editUser={{ ...editUser2026, first_work_day: undefined } as never} />
+      </ToastProvider>,
+    );
+    const field = await screen.findByLabelText(/Übertrag Urlaubstage/i);
+    await waitFor(() => expect((field as HTMLInputElement).value).toBe('2')); // loaded for current year
+    fireEvent.change(field, { target: { value: '3.5' } });
+    fireEvent.click(screen.getByRole('button', { name: /Speichern/i }));
+    await waitFor(() => {
+      const call = putMock.mock.calls.find((c) => String(c[0]).includes('/carryovers/'));
+      expect(call).toBeTruthy();
+      expect(String(call![0])).toContain(`/carryovers/${y}`);
+      expect(call![1]).toMatchObject({ vacation_days: 3.5 });
+    });
+  });
+
+  it('does not write a carryover when the prefill load failed (no clobber of an unknown value)', async () => {
+    getMock.mockRejectedValue(new Error('network')); // /carryovers GET fails
+    render(
+      <ToastProvider>
+        <UserForm onSaved={() => {}} editUser={editUser2026 as never} />
+      </ToastProvider>,
+    );
+    const field = await screen.findByLabelText(/Übertrag Urlaubstage/i);
+    fireEvent.change(field, { target: { value: '7' } });
+    fireEvent.click(screen.getByRole('button', { name: /Speichern/i }));
+    await waitFor(() => expect(putMock).toHaveBeenCalled()); // the user PUT
+    // loadedCarryoverYear stayed null → carryover write is suppressed …
+    expect(putMock.mock.calls.find((c) => String(c[0]).includes('/carryovers/'))).toBeUndefined();
+    // … and the admin is warned (not silently told "erfolgreich").
+    await waitFor(() =>
+      expect(screen.getByText(/konnte nicht geladen werden und wurde NICHT gesetzt/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('re-prefills the carryover from the NEW start year when first_work_day is changed across a year (M-C1: no clobber)', async () => {
+    getMock.mockResolvedValue({
+      data: [
+        { year: 2026, overtime_hours: 5, vacation_days: 8 },
+        { year: 2027, overtime_hours: 9, vacation_days: 12 },
+      ],
+    });
+    render(
+      <ToastProvider>
+        <UserForm onSaved={() => {}} editUser={editUser2026 as never} />
+      </ToastProvider>,
+    );
+    const vac = await screen.findByLabelText(/Übertrag Urlaubstage/i);
+    await waitFor(() => expect((vac as HTMLInputElement).value).toBe('8')); // 2026 row
+    // Move first_work_day into 2027 → the field must reflect 2027's own carryover
+    // (12), NOT copy 2026's value (8) into 2027 on save.
+    fireEvent.change(screen.getByDisplayValue('2026-06-01'), { target: { value: '2027-03-01' } });
+    await waitFor(() => expect((vac as HTMLInputElement).value).toBe('12'));
+  });
+
+  it('writes NO carryover row for an untouched user (both values 0, none existing)', async () => {
+    getMock.mockResolvedValue({ data: [] }); // no existing carryover
+    render(
+      <ToastProvider>
+        <UserForm onSaved={() => {}} editUser={editUser2026 as never} />
+      </ToastProvider>,
+    );
+    await screen.findByLabelText(/Übertrag Urlaubstage/i);
+    fireEvent.click(screen.getByRole('button', { name: /Speichern/i }));
+    await waitFor(() => expect(putMock).toHaveBeenCalled()); // the user PUT itself
+    const carryoverCall = putMock.mock.calls.find((c) => String(c[0]).includes('/carryovers/'));
+    expect(carryoverCall).toBeUndefined();
   });
 });

--- a/frontend/src/pages/admin/users/UserForm.tsx
+++ b/frontend/src/pages/admin/users/UserForm.tsx
@@ -60,9 +60,16 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
     scheduled_start_friday: '',
     scheduled_end_friday: '',
     overtime_carryover: 0, // #158: Anfangssaldo Überstunden (kein User-Feld, separater Carryover-Call)
+    vacation_carryover: 0, // #383: Übertrag Urlaubstage (kein User-Feld, YearCarryover.vacation_days des Startjahres)
   });
   // #158: vorhandener Vortrag zum Startjahr — wird beim Speichern erhalten.
   const [hadCarryover, setHadCarryover] = useState(false);
+  // #383: das Jahr, für das die Carryover-Felder erfolgreich geladen wurden.
+  // Nur wenn es == carryoverYear ist, dürfen die Feldwerte beim Speichern (Edit)
+  // in dieses Jahr geschrieben werden — sonst (Ladefehler oder noch laufender
+  // Re-Fetch nach first_work_day-Wechsel) NICHT schreiben, um kein fremdes/
+  // altes Jahr zu clobbern.
+  const [loadedCarryoverYear, setLoadedCarryoverYear] = useState<number | null>(null);
 
   useEffect(() => {
     if (editUser) {
@@ -103,35 +110,59 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
         scheduled_start_friday: editUser.scheduled_start_friday?.substring(0, 5) || '',
         scheduled_end_friday: editUser.scheduled_end_friday?.substring(0, 5) || '',
         overtime_carryover: 0,
+        vacation_carryover: 0,
       });
     }
   }, [editUser]);
 
-  // #158: beim Bearbeiten den Anfangssaldo (Überstunden-Carryover des Startjahres)
-  // laden, damit das Feld den aktuellen Wert zeigt und der Urlaubs-Vortrag erhalten bleibt.
+  // #158/#383: das Carryover-Startjahr leitet sich aus dem LIVE-Formular ab
+  // (nicht aus editUser), damit ein Ändern von „Erster Arbeitstag" das Jahr
+  // mitzieht und die Felder für das neue Jahr neu geladen werden.
+  // String-Slice statt new Date(...).getFullYear() — ein 'YYYY-MM-DD' würde als
+  // UTC-Mitternacht geparst und in Zeitzonen hinter UTC aufs Vorjahr rutschen.
+  const carryoverYear = formData.first_work_day
+    ? parseInt(formData.first_work_day.slice(0, 4), 10)
+    : new Date().getFullYear();
+
+  // #158/#383: beim Bearbeiten den Anfangssaldo (Überstunden + Urlaub) des
+  // Startjahres laden. Kein Row → Felder auf 0 zurücksetzen (M-C1: ein Wechsel
+  // von first_work_day über eine Jahresgrenze darf NIE die Werte des alten
+  // Jahres ins neue Jahr kopieren/clobbern — die Felder spiegeln immer das
+  // aktuelle carryoverYear).
   useEffect(() => {
     if (!editUser) {
       setHadCarryover(false);
+      setLoadedCarryoverYear(null);
       return;
     }
-    const startYear = editUser.first_work_day
-      ? new Date(editUser.first_work_day).getFullYear()
-      : new Date().getFullYear();
+    let cancelled = false;
+    // #383: solange (neu) geladen wird, gilt das Jahr als NICHT geladen — ein
+    // Save in diesem Fenster darf die Feldwerte nicht in carryoverYear schreiben.
+    setLoadedCarryoverYear(null);
     (async () => {
       try {
         const res = await apiClient.get<Array<{ year: number; overtime_hours: number; vacation_days: number }>>(
           `/admin/users/${editUser.id}/carryovers`,
         );
-        const row = res.data.find((c) => c.year === startYear);
-        if (row) {
-          setFormData((prev) => ({ ...prev, overtime_carryover: row.overtime_hours }));
-          setHadCarryover(true);
-        }
+        if (cancelled) return;
+        const row = res.data.find((c) => c.year === carryoverYear);
+        setFormData((prev) => ({
+          ...prev,
+          overtime_carryover: row ? row.overtime_hours : 0,
+          vacation_carryover: row ? row.vacation_days : 0, // #383
+        }));
+        setHadCarryover(!!row);
+        setLoadedCarryoverYear(carryoverYear); // Felder repräsentieren jetzt carryoverYear
       } catch {
         /* Carryover optional — Fehler hier nicht blockierend */
+        if (!cancelled) {
+          setHadCarryover(false);
+          setLoadedCarryoverYear(null); // unbekannter Stand → beim Speichern nicht schreiben
+        }
       }
     })();
-  }, [editUser]);
+    return () => { cancelled = true; };
+  }, [editUser, carryoverYear]);
 
   useEffect(() => {
     if (formData.work_days_per_week > 0) {
@@ -145,9 +176,9 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
     if (submitting) return;
     setSubmitting(true);
     try {
-      // #158: overtime_carryover is NOT a user field — it goes to the carryover
-      // endpoint separately. Keep it out of the user payload.
-      const { overtime_carryover, ...userFields } = formData;
+      // #158/#383: overtime_carryover + vacation_carryover are NOT user fields —
+      // they go to the carryover endpoint separately. Keep them out of the payload.
+      const { overtime_carryover, vacation_carryover, ...userFields } = formData;
       const payload = {
         ...userFields,
         first_work_day: formData.first_work_day || null,
@@ -164,28 +195,16 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
         scheduled_start_friday: formData.scheduled_start_friday || null,
         scheduled_end_friday: formData.scheduled_end_friday || null,
       };
-      const startYear = formData.first_work_day
-        ? new Date(formData.first_work_day).getFullYear()
-        : new Date().getFullYear();
-
-      // Review M-C1: always preserve the *target year's* own vacation carryover
-      // (fetch it fresh) so editing first_work_day can never copy another year's
-      // value or clobber an existing one.
-      const writeCarryover = async (userId: string) => {
+      // #383: write overtime_hours AND vacation_days straight from the (prefilled)
+      // form. The write TARGET year is passed in — for the edit path it is the
+      // year the fields were actually loaded for (loadedCarryoverYear), NOT the
+      // live-form carryoverYear, so an in-flight re-fetch or a first_work_day
+      // change can never write stale values into a DIFFERENT year's row.
+      const writeCarryover = async (userId: string, year: number) => {
         try {
-          let vacationDays = 0;
-          try {
-            const res = await apiClient.get<Array<{ year: number; vacation_days: number }>>(
-              `/admin/users/${userId}/carryovers`,
-            );
-            const row = res.data.find((c) => c.year === startYear);
-            if (row) vacationDays = row.vacation_days ?? 0;
-          } catch {
-            /* no existing carryover for the target year — keep 0 */
-          }
-          await apiClient.put(`/admin/users/${userId}/carryovers/${startYear}`, {
+          await apiClient.put(`/admin/users/${userId}/carryovers/${year}`, {
             overtime_hours: overtime_carryover,
-            vacation_days: vacationDays,
+            vacation_days: vacation_carryover,
           });
         } catch (e: any) {
           // Primary save succeeded — surface a softer warning, don't abort.
@@ -197,10 +216,25 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
         // When editing, send only the fields that can be updated (exclude password)
         const { password, ...updateData } = payload;
         await apiClient.put(`/admin/users/${editUser.id}`, updateData);
-        // #158: nur schreiben, wenn ein Saldo gesetzt ist oder bereits einer existierte
-        // (verhindert leere 0/0-Carryover-Zeilen für unberührte User).
-        if (overtime_carryover !== 0 || hadCarryover) {
-          await writeCarryover(editUser.id);
+        // #158/#383: nur schreiben, wenn (a) die Felder erfolgreich für EIN Jahr
+        // geladen sind (loadedCarryoverYear !== null) — sonst würde ein Ladefehler
+        // die Felder auf 0 clobbern — UND (b) ein Saldo gesetzt ist oder bereits
+        // einer existierte. Ziel ist loadedCarryoverYear (das Jahr, das die Felder
+        // repräsentieren), nie das ggf. voreilige live carryoverYear.
+        if (
+          loadedCarryoverYear !== null &&
+          (overtime_carryover !== 0 || vacation_carryover !== 0 || hadCarryover)
+        ) {
+          await writeCarryover(editUser.id, loadedCarryoverYear);
+        } else if (
+          loadedCarryoverYear === null &&
+          (overtime_carryover !== 0 || vacation_carryover !== 0)
+        ) {
+          // #383: der Save-Skip (loadedCarryoverYear===null) ist die richtige
+          // Clobber-Schutz-Wahl — aber nicht schweigend: sonst glaubt der Admin,
+          // der eingegebene Übertrag sei gespeichert (stiller Datenverlust genau
+          // im Onboarding-Fall). Klar melden.
+          toast.error('Benutzer gespeichert, aber der Übertrag/Anfangssaldo konnte nicht geladen werden und wurde NICHT gesetzt — bitte den Benutzer erneut öffnen und erneut speichern.');
         }
         // If the admin edited themselves, refresh the auth store so Dashboard/Layout update
         if (currentUser && editUser.id === currentUser.id) {
@@ -211,8 +245,9 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
       } else {
         const res = await apiClient.post('/admin/users', payload);
         const newId: string | undefined = res.data?.user?.id;
-        if (newId && overtime_carryover !== 0) {
-          await writeCarryover(newId);
+        // Create: kein bestehender Row zu clobbern → live carryoverYear ist korrekt.
+        if (newId && (overtime_carryover !== 0 || vacation_carryover !== 0)) {
+          await writeCarryover(newId, carryoverYear);
         }
         toast.success('Benutzer erfolgreich erstellt');
       }
@@ -406,11 +441,34 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
               />
               <p className="text-xs text-gray-500 mt-1">
                 Übernommener Überstundensaldo zum Startjahr
-                ({formData.first_work_day ? new Date(formData.first_work_day).getFullYear() : new Date().getFullYear()}).
+                ({carryoverYear}).
                 Negativ = Minusstunden.
               </p>
             </div>
           )}
+
+          {/* #383: Übertrag Urlaubstage — gilt für ALLE MA (auch track_hours=false),
+              daher NICHT hinter der Überstunden-track_hours-Gate. */}
+          <div>
+            <label htmlFor="f-vacation-carryover" className="block text-sm font-medium text-gray-700 mb-1">
+              Übertrag Urlaubstage
+            </label>
+            <input
+              id="f-vacation-carryover"
+              type="number"
+              step="0.5"
+              min="-50"
+              max="50"
+              value={formData.vacation_carryover}
+              onChange={(e) => setFormData({ ...formData, vacation_carryover: parseFloat(e.target.value) || 0 })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              Alt-/Vorjahres-Resturlaub, der dem Urlaubsbudget des Startjahres
+              ({carryoverYear})
+              zugerechnet wird. Minus und Kommastellen möglich.
+            </p>
+          </div>
 
           <div className="md:col-span-2 flex items-center space-x-2 p-3 bg-gray-50 rounded-lg">
             <input


### PR DESCRIPTION
Behebt #383.

## Problem
Beim Systemwechsel werden MA oft unterjährig „zum Stichtag eingestellt" (`first_work_day`). `get_vacation_account` rechnet das Urlaubsbudget dann **anteilig** (z. B. Jun–Dez = 7/12) — Alt-/Vorjahres-Resturlaub (Jan–Mai bzw. Vorjahr) fehlt. Für **Überstunden** gibt es „Anfangssaldo Überstunden"; ein **gleichwertiges Feld für Urlaub** fehlte an dieser Stelle.

## Lösung
Neues Feld **„Übertrag Urlaubstage"** in den Mitarbeitereigenschaften (UserForm), das `YearCarryover.vacation_days` des Startjahres setzt.

- **Backend unverändert** — `upsert_carryover` akzeptiert `vacation_days` schon, `get_vacation_account` addiert es aufs (anteilige) Budget, `source=manual`. Keine Migration.
- Feld ist **NICHT** `track_hours`-gated (Urlaub gilt auch für leitende MA), min/max ±50 (= Backend-Schema).
- Carryover-Startjahr aus dem **Live-Formular** (String-Slice → keine UTC-Jahr-Verschiebung).

## Robustheit (adversariale Multi-Agent-Review, 3 Runden)
Der Review fand eine reale **Clobber-/Race-Klasse** beim Entfernen der alten „preserve-fetch"-Logik (M-C1): ein `first_work_day`-Jahreswechsel, ein laufender Re-Fetch oder ein Ladefehler konnten alte/fremde Werte in ein **anderes Jahr** schreiben. Behoben:
- Prefill-Effekt re-lädt beide Felder beim Jahreswechsel und setzt `loadedCarryoverYear` **nur bei Erfolg**.
- Edit-Save schreibt **nur** bei `loadedCarryoverYear !== null` und **in** `loadedCarryoverYear` (das Jahr, das die Felder repräsentieren) — nie ins voreilige Live-Jahr.
- Wird der Write übersprungen, obwohl ein Wert gesetzt war → **klare Warnung** statt stillem Datenverlust.

Konvergiert auf **0 High/Medium**. (1 verbleibendes Low = zwei Editoren gleichzeitig offen → „last save wins", konsistent zum Überstunden-Feld = by-design.)

## QA
**207** Frontend-Tests (6 neue #383-Tests: Prefill/Save/Fallback-Jahr/M-C1-Jahreswechsel/Ladefehler-Warnung/kein-Write-unberührt), `tsc` sauber. Spec: `docs/superpowers/specs/2026-07-13-vacation-carryover-userform-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
