### PR TITLE
Release 1.14.1: Review-Fixes + Version-Bump

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.14.0 (Stand 2026-07-09)
+**Aktuelle Version:** 1.14.1 (Stand 2026-07-13)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.14.0"
+APP_VERSION = "1.14.1"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/routers/admin_time_entries.py
+++ b/backend/app/routers/admin_time_entries.py
@@ -209,6 +209,23 @@ def admin_update_time_entry(
     else:
         eff_start, eff_end, raw_start, raw_end = update_start_time, update_end_time, None, None
 
+    # #375-Review: mirror the create-path duplicate-start guard (exclude self) —
+    # editing start_time/date onto an existing sibling entry would otherwise hit
+    # the (tenant, user, date, start_time) UNIQUE constraint → IntegrityError →
+    # HTTP 500 on Postgres. Return a clean 409 instead.
+    dup = db.query(TimeEntry).filter(
+        TimeEntry.user_id == entry.user_id,
+        TimeEntry.tenant_id == current_user.tenant_id,  # F-026
+        TimeEntry.date == update_date,
+        TimeEntry.start_time == eff_start,
+        TimeEntry.id != entry.id,
+    ).first()
+    if dup:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Es existiert bereits ein Eintrag mit dieser Startzeit an diesem Datum",
+        )
+
     admin_update_warnings: list[str] = []
     waiver_reason = (entry_data.break_waiver_reason or "").strip()
     break_waiver_active = False

--- a/backend/tests/test_work_window_integration.py
+++ b/backend/tests/test_work_window_integration.py
@@ -358,6 +358,25 @@ def test_admin_create_duplicate_start_returns_409(db, employee, admin, admin_cli
     assert "Startzeit" in r2.json()["detail"]
 
 
+def test_admin_update_duplicate_start_returns_409(db, employee, admin, admin_client):
+    """#375-Review: editing an entry's start onto an existing sibling's start
+    returns a clean 409, not a 500 from the UNIQUE constraint. Self-edit (same
+    start) must NOT 409 (id-excluded)."""
+    a = admin_client.post(f"/api/admin/users/{employee.id}/time-entries",
+                          json={"date": "2026-06-02", "start_time": "08:00", "end_time": "10:00", "break_minutes": 0})
+    assert a.status_code == 201, a.text
+    b = admin_client.post(f"/api/admin/users/{employee.id}/time-entries",
+                          json={"date": "2026-06-02", "start_time": "13:00", "end_time": "15:00", "break_minutes": 0})
+    assert b.status_code == 201, b.text
+    bid = b.json()["id"]
+    # Move b's start onto a's start (08:00) → 409.
+    coll = admin_client.put(f"/api/admin/time-entries/{bid}", json={"start_time": "08:00"})
+    assert coll.status_code == 409, coll.text
+    # Self-edit (only end_time) must still succeed (id excluded from the dup check).
+    ok = admin_client.put(f"/api/admin/time-entries/{bid}", json={"end_time": "16:00"})
+    assert ok.status_code == 200, ok.text
+
+
 def test_cr_approval_create_clamps_to_soll_window(db, employee, admin, admin_client):
     """CR-Genehmigung (request_type=create, entry_kind=time_entry) klappt
     start_time ins Soll-Fenster und speichert den Rohwert in raw_start_time.

--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -641,7 +641,7 @@ Für Minijobber:innen, die **auf Arbeitszeitkonto** geführt werden („sonstige
 
 Der **aktuelle gesetzliche Mindestlohn** (§ 1 MiLoG) wird unter **Einstellungen → „Gesetzlicher Mindestlohn"** angezeigt.
 
-> **Wichtig:** Die 50-%-Grenze bindet nur die **mindestlohnwirksamen** Stunden. Wird über dem Mindestlohn vergütet, sind mehr Stunden möglich — der Hinweis ist dann ggf. unkritisch, bitte prüfen. PraxisZeit speichert **keine Lohndaten** und prüft daher **nicht** die 603-€-Verdienstgrenze; das bleibt der Lohnbuchhaltung vorbehalten. Die vereinbarte **Monatsarbeitszeit** kann im Feld „Vereinbarte Monatsarbeitszeit (h)" direkt eingegeben werden (siehe oben); sie gilt dann für beide MiLoG-Prüfungen.
+> **Wichtig:** Die 50-%-Grenze bindet nur die **mindestlohnwirksamen** Stunden. Wird über dem Mindestlohn vergütet, sind mehr Stunden möglich — der Hinweis ist dann ggf. unkritisch, bitte prüfen. PraxisZeit speichert **keine Lohndaten** und prüft daher **nicht** die 603-€-Verdienstgrenze; das bleibt der Lohnbuchhaltung vorbehalten. Die vereinbarte **Monatsarbeitszeit** kann im Feld „Vereinbarte Monatsarbeitszeit (h)" direkt eingegeben werden (siehe oben); sie ist die vertragliche Bezugsgröße für die **50-%-Prüfung**. Das **12-Monats-Aging** bleibt bewusst Soll-basiert (siehe oben) und ändert sich dadurch nicht.
 
 ---
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.14.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.14.0"
+APP_VERSION="1.14.1"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
## Release 1.14.1 (PATCH)

Bündelt die seit v1.14.0 gemergten, je einzeln adversarial-reviewten Features: **#382** Whitescreen-Härtung, **#375** Admin-Abwesenheit-für-heute, **#383** Übertrag Urlaubstage, **#377 Baustein 2a** MiLoG-Monatsarbeitszeit (**Migration 063**), **#387** Build-Cache-Fix.

### Release-Level-Review (Multi-Agent, Integrations-Fokus)
0 High/Medium — die Features komponieren sauber (UserForm.tsx trägt #382+#383+#377, admin_users.py #382+#375). 2 Low gefixt:
- **HANDBUCH-ADMIN** MiLoG-Notiz sagte fälschlich, die eingegebene Monatszeit gelte „für beide Prüfungen" → korrigiert (nur 50-%-Prüfung; Aging bleibt Soll-basiert, konsistent zum #377-Entscheid + Code).
- **`admin_update_time_entry`**: fehlender Duplicate-Start-Guard (spiegelt jetzt den #375-create-Guard, self-excluded) → sauberes **409** statt UNIQUE-**500** beim Edit. +Test.

### QA
- Backend-Suite **1297 passed** / 49 skipped; Migration **063 up→down→up auf PG18**.
- Build: alle 6 Artefakte; Windows-ZIP-Integrität (kein setup.exe im Tree, PG-SHA == 18.4-Pin, Bundle 1.14.1).
- `validate-release` **5/5** (PG 18.4).
- **Lokaler Docker 1.14.1:** Login 200, `users-overview` 200, #377 e2e (User mit agreed_monthly_hours=33 anlegen + auslesen).
- **.131 nativ Update 1.14.0 → 1.14.1** (echtes PG, Live-Daten): alembic 062→063, untouched Tabellen md5-identisch, **Login 200**.

Win-Emulator + Native-Fresh übersprungen: **0 `installer/`-Änderungen seit v1.13.0** (Artefakte integritätsgeprüft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
