### PR TITLE
perf(#204): users_overview Preload — Holidays + WHChanges (byte-identisch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 ## [Unreleased]
 
+## [1.14.1] - 2026-07-13
+
+Feature- und Härtungs-Release, adversarial multi-agent-reviewt (0 High/Medium,
+2 Low gefixt). Eine additive Migration (063).
+
+### ✨ Neu
+- **Abwesenheit/Eintrag für den laufenden Tag (heute) buchen (#375).** Die per-Tag
+  „+"/Bearbeiten-Aktion im Monatsjournal war auf `isPastDay` gegated (strikt vor
+  heute) — meldete sich jemand für HEUTE krank, konnte der Admin das nicht direkt
+  eintragen. `MonthlyJournal.tsx` unterscheidet jetzt `isPastDay`/`isFutureDay`:
+  Admins buchen Vergangenheit **und** heute (Zukunft weiter über den Antragsweg
+  gesperrt); die MA-Eigenansicht bleibt unverändert vergangenheits-only.
+- **„Übertrag Urlaubstage" im UserForm (#383).** Analog zum „Anfangssaldo
+  Überstunden" gibt es in den Mitarbeitereigenschaften ein Feld, das
+  `YearCarryover.vacation_days` des Startjahres setzt. Bei unterjährigem Start
+  („zum Stichtag eingestellt", `first_work_day`) bleibt so Vorjahres-Resturlaub
+  erhalten statt nur anteilig gerechnet zu werden. Reiner Frontend-Change (Backend
+  `upsert_carryover` bestand bereits), keine Migration.
+- **Minijob-Prüfung: vereinbarte Monatsarbeitszeit (#377 Baustein 2a).** Opt-in
+  `User.agreed_monthly_hours` (nullable, Migration 063): ist es gesetzt, nutzt
+  `milog_service.agreed_monthly_hours()` exakt diese Zahl für die 50-%-Prüfung nach
+  § 2 Abs. 2 MiLoG statt der bisherigen flachen Ableitung aus den Wochenstunden
+  (× 13/3). Das Aging bleibt Soll-basiert (unverändert). Ohne Eingabe wie bisher.
+
+### 🐞 Behoben
+- **Whitescreen-Härtung — Render-Crash bei „Etwas ist schiefgelaufen" (#382).**
+  Systemischer Root-Fix: Der Response-Interceptor in `api/client.ts` rejected jetzt
+  jede 200-Antwort mit HTML-String-Body (SPA-`index.html` statt JSON, wie sie im
+  Auth-/Proxy-/SPA-Fallback-Grenzfall nach einer `token_version`-Invalidierung
+  auftreten kann) → Aufrufer landen in ihrem `.catch` statt die App zu
+  white-screenen. Schließt die erreichbare Crash-Klasse überall auf einmal.
+- **Duplicate-Start-Guards für Admin-Schreibpfade (Review-Low, #389/#393).**
+  `admin_create_time_entry` und `admin_update_time_entry` spiegeln jetzt den
+  409-Duplicate-Start-Guard des MA-Pfads (self-excluded beim Edit) → sauberes
+  HTTP 409 statt UNIQUE-Constraint-500, wenn das neue Journal-„+" für heute mit
+  einem offenen Clock-in derselben Startminute kollidiert.
+
+## [1.14.0] - 2026-07-09
+
+Feature-Release (MINOR — inhaltlich das reviewte/getestete 1.13.1, als MINOR
+umbenannt wegen neuer nutzersichtbarer Fläche; #386). Zwei additive Migrationen
+(061, 062).
+
+### ✨ Neu
+- **„Kind krank" + Sonderurlaub-Gründe (#376).** Baut auf den Custom Absence
+  Reasons (#312) auf: neues Verhalten `unpaid_free` → `AbsenceType.OTHER`
+  (entschuldigt unbezahlt), ein Preset-Katalog gängiger Gründe (1-Klick aktivieren,
+  kein DB-Seed) sowie ein „Kind krank"-Zähler je Mitarbeiter:in mit weicher
+  Warnung, wenn die üblichen Grenztage nach § 45 SGB V erreicht sind (per-MA-Cap +
+  Tenant-Default). Migration 061.
+- **Minijob-Compliance: Mindestlohn + § 2 Abs. 2 MiLoG (#377, Baustein 1+3).**
+  Baustein 1 blendet den gültigen gesetzlichen Mindestlohn ein (datumsabhängige
+  Konstante 13,90 € → 14,60 € ab 2027). Baustein 3 prüft für Minijobber auf
+  Arbeitszeitkonto die 50-%-Arbeitszeitgrenze: month-to-date beim Ausstempeln sowie
+  im Monatsreport/Konto, mit 12-Monats-Ausgleichsfrist via FIFO-Aging. Per-User-
+  Opt-in-Flag (Migration 062), weiche Warnungen, keine Lohndaten. Baustein 2
+  (Monatsmodus) folgte in 1.14.1.
+
+### 🐞 Behoben
+- **MiLoG `settlement_aging`-Stichtag-Fix + Review-Härtung (#384).**
+- **Export-Korrektheit + DSGVO-Fixes aus dem Export-Prozess-Review (#380).**
+
 ## [1.13.0] - 2026-07-02
 
 Feature-Release mit zwei Kundenwünschen, je adversarial multi-agent-reviewt

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -8,7 +8,8 @@ from typing import List
 from datetime import datetime, timezone, timedelta
 from app.services.timezone_service import today_local
 from app.database import get_db
-from app.models import User, TimeEntry, Absence, AbsenceReason, WorkingHoursChange, ChangeRequest, TimeEntryAuditLog, UserRole
+from app.models import User, TimeEntry, Absence, AbsenceReason, WorkingHoursChange, ChangeRequest, TimeEntryAuditLog, UserRole, PublicHoliday
+from app.services.date_filters import date_in_year
 from app.middleware.auth import require_admin
 from app.schemas.user import UserCreate, UserUpdate, UserResponse, UserCreateResponse, AdminSetPassword, UserListResponse
 from app.schemas.working_hours_change import WorkingHoursChangeCreate, WorkingHoursChangeResponse
@@ -174,14 +175,30 @@ def users_overview(
         AbsenceReason.tenant_id == current_user.tenant_id,  # F-026
         AbsenceReason.tracks_child_sick_limit.is_(True),
     ).first() is not None
+    # #204: Referenzdaten EINMAL vorladen statt pro User (× ~9 Queries) — Feiertage
+    # (tenant+year, geteilt) + alle WorkingHoursChange (tenant, nach user_id
+    # gruppiert) → an die Calc-Helfer durchreichen (Default-None-Pfad byte-identisch).
+    # date_in_year (DATE-basiert, wie get_vacation_account/get_ytd_summary intern)
+    # statt PublicHoliday.year — garantiert byte-identisch, unabhängig von der
+    # year-Spalte.
+    _holidays = {h.date for h in db.query(PublicHoliday).filter(
+        PublicHoliday.tenant_id == current_user.tenant_id,  # F-026
+        date_in_year(PublicHoliday.date, year),
+    ).all()}
+    _wh_by_user: dict = {}
+    for _c in db.query(WorkingHoursChange).filter(
+        WorkingHoursChange.tenant_id == current_user.tenant_id,  # F-026
+    ).order_by(WorkingHoursChange.effective_from).all():
+        _wh_by_user.setdefault(_c.user_id, []).append(_c)
     result = []
     for u in users:
-        vac = calculation_service.get_vacation_account(db, u, year)
+        _uwh = _wh_by_user.get(u.id, [])
+        vac = calculation_service.get_vacation_account(db, u, year, holidays=_holidays, wh_changes=_uwh)
         # #313: YTD-Überstunden bis zum letzten abgeschlossenen Arbeitstag — der
         # Stichtag ist nur im LAUFENDEN Jahr relevant; für vergangene Jahre voller
         # Jahresumfang (spart die per-User-Stichtag-Query). (round-2 N+1-Fix)
         cutoff = calculation_service.get_soll_cutoff_date(db, u) if is_current_year else None
-        ytd = calculation_service.get_ytd_summary(db, u, year, cutoff_date=cutoff)
+        ytd = calculation_service.get_ytd_summary(db, u, year, cutoff_date=cutoff, holidays=_holidays, wh_changes=_uwh)
         # #377 § 2 Abs. 2 MiLoG: weiche Warnungen je MA. Nur in der LAUFENDEN-Jahr-
         # Ansicht (die Prüfung ist immer aktueller Monat / Aging bis heute). Perf:
         # EIN Overtime-Pass je Flag-MA — beide Signale aus demselben `detailed`.
@@ -221,7 +238,7 @@ def users_overview(
             ),
             overtime=YtdOvertime(year=year, **ytd),
             child_sick_used=(
-                float(calculation_service.child_sick_days_used(db, u, year))
+                float(calculation_service.child_sick_days_used(db, u, year, wh_changes=_uwh))
                 if _cs_tenant_tracks else 0.0
             ),  # #376
             child_sick_cap=(

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -859,9 +859,22 @@ def get_overtime_history(
     }
 
 
-def get_ytd_summary(db: Session, user: User, year: int = None, cutoff_date: date = None) -> Dict:
+def get_ytd_summary(
+    db: Session,
+    user: User,
+    year: int = None,
+    cutoff_date: date = None,
+    holidays: Optional[set] = None,
+    wh_changes: Optional[List[WorkingHoursChange]] = None,
+) -> Dict:
     """
     Calculate year-to-date summary from Jan 1 to today.
+
+    #204: ``holidays`` (tenant+year-Set) und ``wh_changes`` (dieses Users) sind
+    optionale Preloads für den users-overview-Hot-Loop; Default ``None`` = wie
+    bisher querien (byte-identisch, Test ``test_calc_preload``). Der YTD-Range
+    liegt immer im Jahr ``year`` → das Jahres-Holiday-Set ist ein deckungsgleicher
+    Superset für die Membership-Tests.
 
     Sums daily targets and actual hours for all working days from Jan 1
     of the given year up to and including today.
@@ -894,13 +907,17 @@ def get_ytd_summary(db: Session, user: User, year: int = None, cutoff_date: date
     if start > end:
         return {"target_hours": 0.0, "actual_hours": 0.0, "overtime": 0.0}
 
-    # Fetch holidays in range
-    holidays = db.query(PublicHoliday).filter(
-        PublicHoliday.date >= start,
-        PublicHoliday.date <= end,
-        PublicHoliday.tenant_id == user.tenant_id,
-    ).all()
-    holiday_dates: set = {h.date for h in holidays}
+    # Fetch holidays in range (#204: use the preloaded tenant+year set if given).
+    if holidays is not None:
+        holiday_dates: set = holidays
+    else:
+        holiday_dates = {
+            h.date for h in db.query(PublicHoliday).filter(
+                PublicHoliday.date >= start,
+                PublicHoliday.date <= end,
+                PublicHoliday.tenant_id == user.tenant_id,
+            ).all()
+        }
 
     # Fetch absences in range (exclude TRAINING, SICK, OVERTIME - same as
     # get_monthly_target). PAID_LEAVE (#145) is treated like OTHER and falls
@@ -915,10 +932,12 @@ def get_ytd_summary(db: Session, user: User, year: int = None, cutoff_date: date
     absence_half_map: Dict[date, bool] = _soll_reducing_absence_half_map(absences)
 
     # Fetch working hours changes (pre-loaded for the per-day loop).
-    # F-027: routed through get_weekly_hours_for_date() with in-memory path
-    wh_changes = db.query(WorkingHoursChange).filter(
-        WorkingHoursChange.user_id == user.id,
-    ).order_by(WorkingHoursChange.effective_from).all()
+    # F-027: routed through get_weekly_hours_for_date() with in-memory path.
+    # #204: use the passed-in list if given (users-overview preload).
+    if wh_changes is None:
+        wh_changes = db.query(WorkingHoursChange).filter(
+            WorkingHoursChange.user_id == user.id,
+        ).order_by(WorkingHoursChange.effective_from).all()
 
     # #146: special-day config for the YTD year (24./31.12. always fall in
     # the same `year`, so a single lookup suffices).
@@ -980,7 +999,8 @@ def get_ytd_summary(db: Session, user: User, year: int = None, cutoff_date: date
     }
 
 
-def absence_days(db: Session, user: User, absences: list) -> Decimal:
+def absence_days(db: Session, user: User, absences: list,
+                 wh_changes: Optional[List[WorkingHoursChange]] = None) -> Decimal:
     """Zähle Abwesenheiten TAGEBASIERT (Tagesprinzip §3 BUrlG, #156/#205) — exakt
     nach derselben Regel wie ``used_days`` in ``get_vacation_account``: voller Tag
     = 1,0, ``half_day=True`` = 0,5, Legacy-Row (``half_day=None``) = Stunden ÷
@@ -995,7 +1015,7 @@ def absence_days(db: Session, user: User, absences: list) -> Decimal:
         if not tracked:
             total += Decimal('0.5') if a.half_day else Decimal('1')
             continue
-        dt_day = get_daily_target_for_date(user, a.date, get_weekly_hours_for_date(db, user, a.date))
+        dt_day = get_daily_target_for_date(user, a.date, get_weekly_hours_for_date(db, user, a.date, wh_changes=wh_changes))
         if dt_day > 0:
             if a.half_day is None:
                 total += Decimal(str(a.hours)) / Decimal(str(dt_day))
@@ -1012,7 +1032,8 @@ def child_sick_cap(db: Session, user: User) -> int:
     return settings_service.get_int_setting(db, "child_sick_days_default", user.tenant_id, 15)
 
 
-def child_sick_days_used(db: Session, user: User, year: int) -> Decimal:
+def child_sick_days_used(db: Session, user: User, year: int,
+                         wh_changes: Optional[List[WorkingHoursChange]] = None) -> Decimal:
     """#376: tagebasierte Summe (Tagesprinzip) der Kind-krank-Absencen im
     Kalenderjahr — nur Absencen, deren Grund tracks_child_sick_limit trägt.
     Beschäftigungsfenster wird respektiert; Zählregel identisch zu absence_days."""
@@ -1030,12 +1051,23 @@ def child_sick_days_used(db: Session, user: User, year: int) -> Decimal:
         .all()
     )
     windowed = [a for a in rows if _within_employment_window(user, a.date)]
-    return absence_days(db, user, windowed)
+    return absence_days(db, user, windowed, wh_changes=wh_changes)
 
 
-def get_vacation_account(db: Session, user: User, year: int) -> Dict:
+def get_vacation_account(
+    db: Session,
+    user: User,
+    year: int,
+    holidays: Optional[set] = None,
+    wh_changes: Optional[List[WorkingHoursChange]] = None,
+) -> Dict:
     """
     Calculate vacation account for a given year.
+
+    #204: ``holidays`` (das tenant+year-PublicHoliday-Datumsset) und ``wh_changes``
+    (die WorkingHoursChange-Liste DIESES Users) sind optionale Preloads für den
+    users-overview-Hot-Loop. Default ``None`` = wie bisher pro Aufruf querien →
+    byte-identische Ergebnisse (Test ``test_calc_preload``).
 
     Returns:
         budget_hours: Total vacation budget in hours (vacation_days × daily_target)
@@ -1145,7 +1177,7 @@ def get_vacation_account(db: Session, user: User, year: int) -> Dict:
     for a in vacation_absences:
         h = Decimal(str(a.hours))
         used_hours += h
-        dt_day = get_daily_target_for_date(user, a.date, get_weekly_hours_for_date(db, user, a.date))
+        dt_day = get_daily_target_for_date(user, a.date, get_weekly_hours_for_date(db, user, a.date, wh_changes=wh_changes))
         # §3 BUrlG / Tagesprinzip: Urlaub an einem NICHT-Arbeitstag des MA
         # (dt_day == 0, z. B. Di/Do bei einer Mo/Mi/Fr-Kraft) verbraucht 0 Urlaubs-
         # tage — das Überspringen ist gewollt, KEIN Buchungsverlust (Funktions-
@@ -1169,7 +1201,7 @@ def get_vacation_account(db: Session, user: User, year: int) -> Dict:
     # unless the employee already has a real VACATION absence on that day
     # (already counted above) or it falls outside their employment window.
     # Weekends / existing holidays are excluded inside the helper.
-    holiday_dates_year = {
+    holiday_dates_year = holidays if holidays is not None else {
         h.date for h in db.query(PublicHoliday).filter(
             date_in_year(PublicHoliday.date, year),
             PublicHoliday.tenant_id == user.tenant_id,
@@ -1219,7 +1251,7 @@ def get_vacation_account(db: Session, user: User, year: int) -> Dict:
             continue
         if user.last_work_day and d > user.last_work_day:
             continue
-        weekly_hours = get_weekly_hours_for_date(db, user, d)
+        weekly_hours = get_weekly_hours_for_date(db, user, d, wh_changes=wh_changes)
         dt_day = get_daily_target_for_date(user, d, weekly_hours)
         if dt_day <= 0:
             continue

--- a/backend/tests/test_calc_preload.py
+++ b/backend/tests/test_calc_preload.py
@@ -1,0 +1,156 @@
+"""#204 Item 1: die optionalen Preload-Parameter (holidays=/wh_changes=) an
+get_vacation_account / get_ytd_summary / absence_days / child_sick_days_used
+müssen BYTE-IDENTISCHE Ergebnisse liefern wie der re-querying-Default-Pfad.
+Sonst wäre der Perf-Refactor eine (verbotene) Änderung am auditierten Calc.
+"""
+from datetime import date, time
+from decimal import Decimal
+
+from app.models import User, TimeEntry, Absence, AbsenceType, PublicHoliday, WorkingHoursChange, AbsenceReason
+from app.services import calculation_service as calc
+from app.services.date_filters import date_in_year
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _seed(db):
+    """Nicht-trivialer Datensatz: WHChange mitten im Jahr, Urlaub nach der
+    Änderung, Feiertage im Zeitraum, Zeiteinträge vor/nach der Änderung."""
+    u = User(username="pl", email="pl@x.de", password_hash="x", first_name="P",
+             last_name="L", role="employee", weekly_hours=Decimal("40"),
+             vacation_days=30, work_days_per_week=5, is_active=True,
+             tenant_id=DEFAULT_TENANT_ID)
+    db.add(u); db.commit(); db.refresh(u)
+    # Wochenstunden 40 → ab 01.04. auf 20.
+    db.add(WorkingHoursChange(user_id=u.id, tenant_id=DEFAULT_TENANT_ID,
+                              effective_from=date(2026, 4, 1), weekly_hours=Decimal("20")))
+    # Urlaub am Mo 11.05. (nach der Änderung → Tagessoll aus weekly=20).
+    db.add(Absence(user_id=u.id, tenant_id=DEFAULT_TENANT_ID, date=date(2026, 5, 11),
+                   type=AbsenceType.VACATION, hours=Decimal("4"), half_day=False))
+    # Feiertage im Zeitraum.
+    db.add(PublicHoliday(date=date(2026, 1, 1), name="Neujahr", year=2026, tenant_id=DEFAULT_TENANT_ID))
+    db.add(PublicHoliday(date=date(2026, 5, 1), name="Tag der Arbeit", year=2026, tenant_id=DEFAULT_TENANT_ID))
+    # Zeiteinträge vor/nach der Änderung (für YTD-Ist).
+    db.add(TimeEntry(user_id=u.id, tenant_id=DEFAULT_TENANT_ID, date=date(2026, 2, 2),
+                     start_time=time(8, 0), end_time=time(16, 0), break_minutes=0))
+    db.add(TimeEntry(user_id=u.id, tenant_id=DEFAULT_TENANT_ID, date=date(2026, 5, 5),
+                     start_time=time(9, 0), end_time=time(13, 0), break_minutes=0))
+    db.commit(); db.refresh(u)
+    return u
+
+
+def _preloads(db, user, year):
+    holidays = {h.date for h in db.query(PublicHoliday).filter(
+        PublicHoliday.tenant_id == user.tenant_id,
+        date_in_year(PublicHoliday.date, year),
+    ).all()}
+    wh = db.query(WorkingHoursChange).filter(
+        WorkingHoursChange.tenant_id == user.tenant_id,
+        WorkingHoursChange.user_id == user.id,
+    ).order_by(WorkingHoursChange.effective_from).all()
+    return holidays, wh
+
+
+def test_get_vacation_account_preload_byte_identical(db, default_tenant):
+    u = _seed(db)
+    holidays, wh = _preloads(db, u, 2026)
+    plain = calc.get_vacation_account(db, u, 2026)
+    pre = calc.get_vacation_account(db, u, 2026, holidays=holidays, wh_changes=wh)
+    assert plain == pre
+
+
+def test_get_ytd_summary_preload_byte_identical(db, default_tenant):
+    u = _seed(db)
+    holidays, wh = _preloads(db, u, 2026)
+    cutoff = date(2026, 6, 30)  # Range Jan–Jun umspannt die WHChange (01.04.)
+    plain = calc.get_ytd_summary(db, u, 2026, cutoff_date=cutoff)
+    pre = calc.get_ytd_summary(db, u, 2026, cutoff_date=cutoff, holidays=holidays, wh_changes=wh)
+    assert plain == pre
+
+
+def test_absence_days_preload_byte_identical(db, default_tenant):
+    u = _seed(db)
+    _, wh = _preloads(db, u, 2026)
+    absences = db.query(Absence).filter(Absence.user_id == u.id).all()
+    assert calc.absence_days(db, u, absences) == calc.absence_days(db, u, absences, wh_changes=wh)
+
+
+def test_child_sick_days_used_preload_byte_identical(db, default_tenant):
+    u = _seed(db)
+    # Kind-krank-Grund + eine Absence darauf.
+    r = AbsenceReason(tenant_id=DEFAULT_TENANT_ID, name="Kind krank", color="#f00",
+                      base_behavior="unpaid_free", tracks_child_sick_limit=True, is_active=True)
+    db.add(r); db.commit(); db.refresh(r)
+    db.add(Absence(user_id=u.id, tenant_id=DEFAULT_TENANT_ID, date=date(2026, 5, 12),
+                   type=AbsenceType.OTHER, hours=Decimal("4"), half_day=False, reason_id=r.id))
+    db.commit()
+    _, wh = _preloads(db, u, 2026)
+    assert calc.child_sick_days_used(db, u, 2026) == calc.child_sick_days_used(db, u, 2026, wh_changes=wh)
+
+
+def test_users_overview_matches_per_user_compute(db, default_tenant):
+    """#204 Integration: der Endpoint mit Preload liefert je User EXAKT die
+    per-User-berechneten Zahlen — beweist, dass die WHChange-Gruppierung dem
+    richtigen User zugeordnet wird (kein Grouping-Bug)."""
+    from app.routers.admin_users import users_overview
+    admin = User(username="adm", email="adm@x.de", password_hash="x", first_name="A",
+                 last_name="D", role="admin", weekly_hours=Decimal("40"), vacation_days=30,
+                 work_days_per_week=5, is_active=True, tenant_id=DEFAULT_TENANT_ID)
+    db.add(admin); db.commit(); db.refresh(admin)
+    u1 = _seed(db)  # weekly 40 → ab 01.04. 20, Urlaub 11.05.
+    # u2: anderer Verlauf (weekly 30 → ab 01.06. 10, Urlaub 20.02. VOR der Änderung).
+    u2 = User(username="u2", email="u2@x.de", password_hash="x", first_name="U",
+              last_name="2", role="employee", weekly_hours=Decimal("30"), vacation_days=25,
+              work_days_per_week=5, is_active=True, tenant_id=DEFAULT_TENANT_ID)
+    db.add(u2); db.commit(); db.refresh(u2)
+    db.add(WorkingHoursChange(user_id=u2.id, tenant_id=DEFAULT_TENANT_ID,
+                              effective_from=date(2026, 6, 1), weekly_hours=Decimal("10")))
+    db.add(Absence(user_id=u2.id, tenant_id=DEFAULT_TENANT_ID, date=date(2026, 2, 20),
+                   type=AbsenceType.VACATION, hours=Decimal("6"), half_day=False))
+    db.commit()
+
+    rows = users_overview(db=db, current_user=admin, year=2026)
+    by_id = {r.user_id: r for r in rows}
+    for u in (u1, u2):
+        expected = calc.get_vacation_account(db, u, 2026)  # Default-Pfad, kein Preload
+        row = by_id[str(u.id)]
+        assert row.vacation.remaining_days == expected["remaining_days"]
+        assert row.vacation.used_days == expected["used_days"]
+
+
+def test_users_overview_preload_constant_query_count(db, default_tenant):
+    """#204: die Feiertags- und WorkingHoursChange-Queries sind KONSTANT (je 1
+    Preload) — unabhängig von der User-Zahl. Der eigentliche N+1-Beweis."""
+    from sqlalchemy import event
+    from app.routers.admin_users import users_overview
+    from tests.conftest import engine
+    admin = User(username="adm", email="adm@x.de", password_hash="x", first_name="A",
+                 last_name="D", role="admin", weekly_hours=Decimal("40"), vacation_days=30,
+                 work_days_per_week=5, is_active=True, tenant_id=DEFAULT_TENANT_ID)
+    db.add(admin); db.commit(); db.refresh(admin)
+    db.add(PublicHoliday(date=date(2026, 1, 1), name="Neujahr", year=2026, tenant_id=DEFAULT_TENANT_ID))
+    for i in range(5):
+        u = User(username=f"e{i}", email=f"e{i}@x.de", password_hash="x", first_name="E",
+                 last_name=str(i), role="employee", weekly_hours=Decimal("40"), vacation_days=30,
+                 work_days_per_week=5, is_active=True, tenant_id=DEFAULT_TENANT_ID)
+        db.add(u); db.commit(); db.refresh(u)
+        db.add(WorkingHoursChange(user_id=u.id, tenant_id=DEFAULT_TENANT_ID,
+                                  effective_from=date(2026, 4, 1), weekly_hours=Decimal("20")))
+    db.commit()
+
+    counts = {"holidays": 0, "wh": 0}
+
+    def _count(conn, cursor, statement, parameters, context, executemany):
+        s = statement.lower()
+        if "from public_holidays" in s:
+            counts["holidays"] += 1
+        if "from working_hours_changes" in s:
+            counts["wh"] += 1
+
+    event.listen(engine, "before_cursor_execute", _count)
+    try:
+        rows = users_overview(db=db, current_user=admin, year=2026)
+    finally:
+        event.remove(engine, "before_cursor_execute", _count)
+    assert len(rows) == 6  # admin + 5
+    assert counts["holidays"] == 1, counts  # 1 Preload statt 6×
+    assert counts["wh"] == 1, counts        # 1 Preload statt 6×

--- a/docs/superpowers/specs/2026-07-13-users-overview-preload-design.md
+++ b/docs/superpowers/specs/2026-07-13-users-overview-preload-design.md
@@ -1,0 +1,125 @@
+# Design: #204 Item 1 — users_overview Preload (Holidays + WHChanges)
+
+**Datum:** 2026-07-13
+**Issue:** [#204](https://github.com/phash/praxiszeit/issues/204) — Perf O(N)/Bulk-Queries in `users-overview`
+**Typ:** Perf-Refactor am **auditierten Calc** — Ergebnisse MÜSSEN byte-identisch bleiben.
+
+## Kontext / Stand
+
+`GET /api/admin/users-overview` (`admin_users.users_overview`) ruft **pro User**
+`get_vacation_account` + `get_soll_cutoff_date` + `get_ytd_summary` (+ bei
+Konto-MA `get_overtime_history_detailed`, + bei Tenant-mit-Kind-krank
+`child_sick_days_used`). Jede dieser Funktionen queriet ihre eigenen
+`PublicHoliday`- und `WorkingHoursChange`-Zeilen → **O(N × ~9 Queries)**.
+
+Bereits gefixt: #204 Item 2 (`_create_closure_absences` bulk preload) + Item 3
+(`list_closures` gehoisted) + der child_sick-N+1 (Settings/Join) in #382. **Offen:
+Item 1** — die per-User-Wiederhol-Queries in den Calc-Helfern.
+
+**Scope-Entscheid (mit User):** GEZIELT — nur `PublicHoliday` (tenant+year) und
+`WorkingHoursChange` (alle User) einmal vorladen und via **optionale** Parameter
+durchreichen. `Absence`/`TimeEntry` bleiben per-User (inhärent). **Der auditierte
+Calc bleibt semantisch eingefroren** — nur Query-Vermeidung, keine
+Ergebnis-Änderung.
+
+## Ausgangslage (verifizierte Call-Graph-Map)
+
+Alle Zeilen `backend/app/services/calculation_service.py`.
+
+- **`get_weekly_hours_for_date`** (L13) hat bereits `wh_changes: Optional[List] = None`
+  (In-Memory-Scan bei Vorgabe, sonst DB-Query L43) — der **Präzedenzfall**.
+- **`get_vacation_account`** (L1036): `PublicHoliday` ganzes Jahr (L1173, gefüttert
+  in `vacation_deduction_dates_for_year` L1178); `WorkingHoursChange` **per-Urlaubs-
+  Absence-N+1** (L1148 → `get_weekly_hours_for_date`) + per-Abzugstag (L1222, ≤2×).
+  Nimmt heute KEIN `wh_changes`.
+- **`get_ytd_summary`** (L862): `PublicHoliday` Range (L898, ⊆ Jahr); `WorkingHoursChange`
+  einmal (L919) → bereits in `_day_soll_contribution` (L211, hat `wh_changes`)
+  durchgereicht.
+- **`get_soll_cutoff_date`** (L247): NUR `TimeEntry` (L257) — kein Holiday/WHChange,
+  **kein Preload nötig**.
+- **`child_sick_days_used`** (L1015) → `absence_days` (L983): `get_weekly_hours_for_date`
+  **per-Absence-N+1** (L998), kein `wh_changes`.
+- **milog `get_overtime_history_detailed`** (L681): `PublicHoliday` L773 (Range kann
+  **multi-year** sein), `WorkingHoursChange` L779 → **außerhalb dieses Scopes** (nur
+  Konto-MA + multi-year-Holiday-Range, das Jahres-Set greift nicht).
+
+**Korrektheits-Note:** Holidays werden überall NUR als Membership-Set konsumiert
+(`d in holiday_dates`, `d` im eigenen `[start,end]`). Ein (tenant, year)-Set ist
+für `get_vacation_account` (ganzes Jahr = exakt) und `get_ytd_summary` (Range ⊆
+Jahr = deckungsgleicher Superset) byte-identisch. Die `wh_changes`-Liste pro User
+= genau das, was L43/L1148/L998 sonst querien würden.
+
+## Lösung
+
+### Router (`admin_users.users_overview`) — Preload vor der Schleife
+
+```
+_holidays = {h.date for h in db.query(PublicHoliday).filter(
+    PublicHoliday.tenant_id == current_user.tenant_id,   # F-026
+    PublicHoliday.year == year,
+).all()}
+_wh_rows = db.query(WorkingHoursChange).filter(
+    WorkingHoursChange.tenant_id == current_user.tenant_id,  # F-026
+).order_by(WorkingHoursChange.effective_from).all()
+_wh_by_user: dict = {}
+for c in _wh_rows:
+    _wh_by_user.setdefault(c.user_id, []).append(c)
+```
+
+In der Schleife pro `u`: `_uwh = _wh_by_user.get(u.id, [])` und an die Calls
+durchreichen (`holidays=_holidays, wh_changes=_uwh`).
+
+### Calc-Signaturen (alle neuen Params **optional, Default `None`** → Bestandsaufrufer identisch)
+
+- **`get_vacation_account(db, user, year, holidays=None, wh_changes=None)`**
+  - Wenn `holidays is not None`: L1173-Query überspringen, `holidays` als
+    `holiday_dates_year` nutzen (weiter in `vacation_deduction_dates_for_year`).
+  - `wh_changes` in die `get_weekly_hours_for_date`-Calls L1148 + L1222 reichen.
+- **`get_ytd_summary(db, user, year=None, cutoff_date=None, holidays=None, wh_changes=None)`**
+  - `holidays` statt L898-Query (Range ⊆ Jahr, Superset ok).
+  - `wh_changes` statt L919-Query (dieselbe Liste, weiter in `_day_soll_contribution`).
+- **`absence_days(db, user, absences, wh_changes=None)`** + **`child_sick_days_used(db, user, year, wh_changes=None)`**
+  - `wh_changes` in `get_weekly_hours_for_date` L998 reichen; `child_sick_days_used`
+    gibt seinen Param an `absence_days` weiter.
+
+**`_day_soll_contribution`, `get_weekly_hours_for_date`** — keine Signatur-Änderung
+(haben `wh_changes` bereits).
+
+### Backend-Verhalten
+
+Keine Migration, keine Schema-/Response-Änderung. Reine Query-Reduktion; der
+`response_model=List[AdminUserOverview]` bleibt identisch. F-026 (tenant-scope) bei
+beiden Preload-Queries.
+
+## Tests
+
+1. **Byte-identisch (der Kern):** je ein Test, der `get_vacation_account` und
+   `get_ytd_summary` für denselben User einmal MIT `holidays=`/`wh_changes=` und
+   einmal OHNE aufruft und **exakt gleiche Dicts** asserted — mit nicht-trivialen
+   Daten (Urlaub, Feiertag im Zeitraum, ein `WorkingHoursChange` mitten im Jahr,
+   24./31.12.-Abzugstag). Analog für `absence_days`/`child_sick_days_used`.
+2. **`users_overview`-Integration:** ein Test mit ≥2 Usern (einer mit
+   WHChange/Urlaub) → Response gleich wie zuvor (bestehende Overview-Tests bleiben
+   grün) + optional Query-Count-Assertion (Preload greift).
+3. Bestehende Calc-Tests (Default-None-Pfad) bleiben unverändert grün.
+
+## Bewusst NICHT dabei (YAGNI)
+
+- **milog `get_overtime_history_detailed`** (multi-year Holiday-Range, nur
+  Konto-MA) — separat, falls je nötig.
+- Keine `Absence`/`TimeEntry`-Bulk-Vorladung (inhärent per-User; wäre die „Voll"-
+  Variante mit tieferem Calc-Eingriff).
+- Keine Pagination/Cache des Endpoints.
+
+## Betroffene Dateien
+
+- `backend/app/routers/admin_users.py` (Preload + Durchreichen).
+- `backend/app/services/calculation_service.py` (`get_vacation_account`,
+  `get_ytd_summary`, `absence_days`, `child_sick_days_used` — optionale Params).
+- `backend/tests/` (neue Byte-identisch-Tests; z. B. `test_calc_preload.py`).
+
+## Risiko
+
+Gering-mittel: berührt den auditierten Calc, aber nur Query-Vermeidung hinter
+Default-None-Params; Byte-identisch-Tests + volle Suite + adversariale Review
+sichern ab. Kein Verhaltenswechsel für Bestandsaufrufer.


### PR DESCRIPTION
Behebt #204 Item 1 (Items 2+3 waren bereits gefixt).

## Problem
`GET /api/admin/users-overview` rechnete **pro User** `get_vacation_account` + `get_ytd_summary` (+ child_sick), jede mit eigenen `PublicHoliday`- und `WorkingHoursChange`-Queries → **O(N × ~9 Queries)**.

## Lösung (gezielt, auditierter Calc byte-identisch)
Referenzdaten **einmal** vorladen und via **optionale** Params (Default `None` → re-query wie bisher) durchreichen:
- Router: Feiertage (tenant+jahr via `date_in_year`, geteilt) + alle `WorkingHoursChange` (tenant, nach `user_id` gruppiert) — beide **F-026** tenant-scoped.
- `calculation_service`: `get_vacation_account`/`get_ytd_summary` + `holidays=`/`wh_changes=`; `absence_days`/`child_sick_days_used` + `wh_changes=`.
- `date_in_year` statt `PublicHoliday.year` → garantiert identisch zu den internen Filtern, unabhängig von der year-Spalte.
- **milog** `get_overtime_history_detailed` bewusst gelassen (nur Konto-MA + multi-year-Holiday-Range).

Ergebnis: Feiertags- + WHChange-Queries **konstant (je 1)** statt O(N).

## QA
- **`test_calc_preload.py`:** 4× byte-identisch (WHChange-mid-year/Urlaub/Feiertag/24.–31.12.), Router-Integration (Grouping korrekt), Query-Count-Beweis (je 1 Query bei 6 Usern).
- Volle Backend-Suite **1303 passed**. Adversariale Multi-Agent-Review: **0 High/Medium** (byte-identisch + F-026 verifiziert).
- Keine Migration, keine Schema-/Response-Änderung.

Spec: `docs/superpowers/specs/2026-07-13-users-overview-preload-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
