### PR TITLE
fix(#383): Übertrag Urlaubstage mit 2 Nachkommastellen

### DIFF
--- a/backend/alembic/versions/2026_07_13_1600-064_carryover_vacation_precision.py
+++ b/backend/alembic/versions/2026_07_13_1600-064_carryover_vacation_precision.py
@@ -1,0 +1,30 @@
+"""#383: year_carryovers.vacation_days Numeric(4,1) → Numeric(5,2)
+
+Kundenreport (philvdb): der Urlaubs-Übertrag braucht 2 Nachkommastellen (krumme
+Werte, z. B. 3,33 Tage). Die alte Numeric(4,1) rundete auf 1 Stelle. Additiv/
+verlustfrei im Up (mehr Präzision); Down rundet zurück auf 1 Stelle (lossy —
+Natur einer Präzisionsreduktion, akzeptiert).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "064_carryover_vac_prec"
+down_revision = "063_agreed_monthly_hours"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "year_carryovers", "vacation_days",
+        type_=sa.Numeric(5, 2),
+        existing_nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "year_carryovers", "vacation_days",
+        type_=sa.Numeric(4, 1),
+        existing_nullable=False,
+    )

--- a/backend/app/models/year_carryover.py
+++ b/backend/app/models/year_carryover.py
@@ -18,7 +18,7 @@ class YearCarryover(Base):
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     year = Column(Integer, nullable=False)  # The year these carryovers apply TO
     overtime_hours = Column(Numeric(8, 2), nullable=False, default=0)  # Overtime hours from previous year
-    vacation_days = Column(Numeric(4, 1), nullable=False, default=0)  # Vacation days from previous year
+    vacation_days = Column(Numeric(5, 2), nullable=False, default=0)  # #383: 2 Nachkommastellen (krumme Übertragswerte)
     # Fix #7: provenance — 'year_closing' (created/updated by create_year_closing,
     # removable via delete_year_closing) vs 'manual' (admin-entered via
     # upsert_carryover, must survive delete_year_closing).

--- a/backend/tests/test_year_closing_guards.py
+++ b/backend/tests/test_year_closing_guards.py
@@ -233,3 +233,19 @@ def test_delete_closure_after_closing_returns_stale_warning(db, default_tenant, 
     _app.dependency_overrides.clear()
     assert r.status_code == 200, r.text
     assert "Jahresabschluss 2027" in r.json()["warning"]
+
+
+def test_carryover_vacation_days_two_decimals(db, admin, emp):
+    """#383-Reopen (philvdb): der Urlaubs-Übertrag muss 2 Nachkommastellen halten
+    (krumme Werte, z. B. 3,33). Round-Trip über die Admin-Endpoint + Modell.
+    (Präzision selbst = Numeric(5,2), auf Postgres verifiziert; SQLite ignoriert
+    die Skala, daher hier v. a. Schema-/Flow-Guard.)"""
+    client = _client_as(db, admin)
+    r = client.put(f"/api/admin/users/{emp.id}/carryovers/2026",
+                   json={"overtime_hours": 0.0, "vacation_days": 3.33})
+    assert r.status_code == 200, r.text
+    assert float(r.json()["vacation_days"]) == 3.33
+    lst = client.get(f"/api/admin/users/{emp.id}/carryovers").json()
+    row = next(c for c in lst if c["year"] == 2026)
+    assert float(row["vacation_days"]) == 3.33
+    _app.dependency_overrides.clear()

--- a/frontend/src/pages/admin/users/UserForm.tsx
+++ b/frontend/src/pages/admin/users/UserForm.tsx
@@ -458,7 +458,7 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
             <input
               id="f-vacation-carryover"
               type="number"
-              step="0.5"
+              step="0.01"
               min="-50"
               max="50"
               value={formData.vacation_carryover}


### PR DESCRIPTION
Follow-up auf #383 (Kundenreport philvdb): das Feld „Übertrag Urlaubstage" ließ nur 0,5-Schritte zu; 6/8 MA haben krumme Werte.

## Wurzel (doppelt)
1. Frontend-Input `step="0.5"` → Browser beschränkt auf 0,5-Schritte.
2. **`YearCarryover.vacation_days = Numeric(4,1)`** → Backend rundete auf **1** Nachkommastelle (`3,33 → 3,3`).

## Fix
- Modell + **Migration 064**: `vacation_days` `Numeric(4,1)` → `Numeric(5,2)`.
- Frontend-Input `step="0.5"` → `step="0.01"` (min/max ±50 bleiben).

Auf PG18 verifiziert: `numeric(5,2)` hält `3,33`/`12,75`; das alte `numeric(4,1)` rundete auf `3,3`/`12,8`. Migration up→down→up grün.

## QA
`test_year_closing_guards`: Admin-Carryover-Round-Trip `3,33`. **1304** Backend / 13 UserForm-Frontend grün, `tsc` sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
