### PR TITLE
Release 1.14.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.14.1 (Stand 2026-07-13)
+**Aktuelle Version:** 1.14.2 (Stand 2026-07-13)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -36,7 +36,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.14.1"
+APP_VERSION = "1.14.2"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.14.1",
+      "version": "1.14.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.14.1",
+  "version": "1.14.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.14.1"
+APP_VERSION="1.14.2"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
PATCH-Release. Bündelt die bereits gemergten #204 (PR #395) + #383-2-Nachkommastellen (PR #396) und bumpt die Version 1.14.1 → 1.14.2.

## Inhalt
- **#204** (PR #395): `users_overview` preloaded Feiertage (via `date_in_year`) + alle `WorkingHoursChange` je User → N+1 eliminiert. Neue **optionale** Calc-Params (Default `None` → Re-Query, byte-identisch); dedizierte Tests + Query-Count-Beweis.
- **#383-Nachkommastellen** (PR #396, **Migration 064**): `YearCarryover.vacation_days` `Numeric(4,1)` → `Numeric(5,2)` + Frontend-Step `0.5` → `0.01` (Kundenreport philvdb: 0,5-Schritte zu grob).

## QA
- Backend-Suite **1304 passed** / 49 skipped.
- Release-Review (Diff `v1.14.1..HEAD`): **0 Findings**.
- Migration 064 up→down→up auf PG18 (head=064, `Numeric(5,2)` bestätigt).
- Build: 6 Artefakte, Windows-ZIP-Integrität (kein setup.exe, PG-SHA == 18.4-Pin), Bundle-Version 1.14.2. validate-release **5/5** (PG 18.4).
- **Lokaler Docker 1.14.2:** Login 200 + `users-overview` 200 (#204) + #383 `3.33`-Round-Trip auf Live-PG.
- **.131 nativ Update 1.14.1 → 1.14.2** (echtes PG, Live-Daten): alembic **063→064**, `time_entries`/`public_holidays`/`users` md5-byte-identisch, `vacation_days` → `numeric(5,2)`, **Login 200**, #204 200, #383 `3.33`-Round-Trip auf live-migrierter Spalte (vor 064 hätte 3,3 gerundet).
- Win-Emulator + Native-Fresh übersprungen: **0 `installer/`-Änderungen seit v1.13.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
