### PR TITLE
fix(#394): Betriebsferien beachten Halbtags-Sondertage + Einzeltag-Absencen

### DIFF
--- a/backend/app/routers/company_closures.py
+++ b/backend/app/routers/company_closures.py
@@ -4,6 +4,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 from typing import List
 from datetime import date, timedelta
+from decimal import Decimal
 from pydantic import BaseModel, ConfigDict
 from uuid import UUID
 
@@ -125,6 +126,17 @@ def _create_closure_absences(
     workdays = sorted(workdays)
     affected = 0
 
+    # #394: half-day special days (24./31.12. configured as "halber Feiertag")
+    # have a 0.5 target factor. The closure must book only HALF a day for them —
+    # otherwise a full vacation/overtime day is deducted for a 0.5-Soll day
+    # (customer report philvdb). `free` special days already reduce the target to
+    # 0 and are excluded from `workdays` upstream; only `half_day` reaches here.
+    # Config is per-year, shared across all employees → load once.
+    special_cfg_by_year = {
+        yr: special_days_service.get_special_day_config(db, current_user.tenant_id, yr)
+        for yr in {d.year for d in workdays}
+    }
+
     # #204: Statt ~3 Queries pro (MA × Arbeitstag) — bei z. B. 40 MA × 15 Tagen
     # ~1.800 SELECTs — die Referenzdaten in je EINER Query vorladen und in-memory
     # nachschlagen. Logik unveraendert.
@@ -220,9 +232,21 @@ def _create_closure_absences(
                     )
                     db.delete(entry)
 
+            # #394: a `half_day` special day (24./31.12.) contributes only 0.5×
+            # its target — book a HALF day (half the target hours, half_day flag,
+            # 0.5 budget consumption) instead of a full one.
+            sd_factor = special_days_service.special_day_target_factor(
+                workday, special_cfg_by_year[workday.year]
+            )
+            if sd_factor is not None and sd_factor == Decimal("0"):
+                continue  # `free` day — defensive; already excluded from workdays
+            is_half_special = sd_factor is not None and sd_factor == Decimal("0.5")
+            booked_target = day_target * Decimal("0.5") if is_half_special else day_target
+            day_consumption = 0.5 if is_half_special else 1.0
+
             # #314: decide VACATION vs OVERTIME per day. VACATION while the
-            # remaining budget covers a full day; afterwards OVERTIME (no minus-
-            # vacation). Only positive-target days consume the budget snapshot.
+            # remaining budget covers this day's consumption; afterwards OVERTIME
+            # (no minus-vacation). Only positive-target days consume the snapshot.
             day_type = absence_type
             if emp_split and day_target > 0:
                 yr = workday.year
@@ -237,9 +261,9 @@ def _create_closure_absences(
                     remaining_by_year[yr] = float(
                         calculation_service.get_vacation_account(db, employee, yr)["remaining_days"]
                     )
-                if remaining_by_year[yr] >= 1.0:
+                if remaining_by_year[yr] >= day_consumption:
                     day_type = AbsenceType.VACATION
-                    remaining_by_year[yr] -= 1.0
+                    remaining_by_year[yr] -= day_consumption
                 else:
                     day_type = AbsenceType.OVERTIME
 
@@ -247,13 +271,23 @@ def _create_closure_absences(
                 user_id=employee.id,
                 tenant_id=current_user.tenant_id,
                 date=workday,
-                end_date=closure.end_date,
+                # #394 Teil B: jede generierte Absence ist ein EINZELTAG. Vorher
+                # trug jeder Tag end_date=closure.end_date -> die Abwesenheitsliste
+                # zeigte je Zeile die ganze Closure-Spanne (z. B. "24.12 - 31.12"),
+                # der Schichtplaner las sie als Mehrtages-Span. Die Zugehoerigkeit
+                # zur Schließung steckt in note ("Betriebsferien: ...") + closure_id.
+                end_date=None,
                 type=day_type,
-                hours=float(day_target),
-                # #205-Konsistenz (Review 2026-06-23): Betriebsferien sind immer
-                # volle Tage -> half_day=False, damit get_vacation_account den
-                # tagebasierten (WHChange-stabilen) Pfad nimmt statt der Legacy-
-                # Stundenlogik (die bei spaeterer Stundenaenderung driften wuerde).
+                hours=float(booked_target),
+                # #205-Konsistenz (Review 2026-06-23): Betriebsferien decken den
+                # GANZEN (Arbeits-)Tag ab -> half_day=False (voller Absenz-Tag),
+                # damit get_vacation_account den tagebasierten (WHChange-stabilen)
+                # Pfad nimmt und das Tagessoll voll auf 0 setzt (kein Rest-Defizit).
+                # #394: an einem `half_day`-Sondertag (24./31.12.) ist der Tag nur
+                # ein halber Arbeitstag -> hours=0,5×Soll (oben) + Urlaubs-/Absenz-
+                # KOSTEN 0,5 kommen ueber den Sondertags-Faktor in get_vacation_
+                # account/absence_days, NICHT ueber half_day (das wuerde das Soll
+                # doppelt halbieren -> Phantom-Defizit).
                 half_day=False,
                 note=f"Betriebsferien: {closure.name}",
                 closure_id=closure.id,
@@ -481,7 +515,7 @@ def update_closure(
     ).all()
 
     # Remove absences for days that are no longer covered by the closure;
-    # keep the rest in sync (note on rename, end_date on range change,
+    # keep the rest in sync (note on rename, single-day end_date reset per #394,
     # type on Urlaub<->Freistellung switch, #145). Each covered day holds at
     # most one closure-absence (the create helper skips days with an existing
     # absence), so flipping its type can never collide with the
@@ -495,7 +529,9 @@ def update_closure(
         else:
             if name_changed:
                 absence.note = f"Betriebsferien: {data.name}"
-            absence.end_date = data.end_date
+            # #394 Teil B: Closure-Absencen sind Einzeltage (siehe _create_closure_
+            # absences) — nie die ganze Spanne an jedem Datum.
+            absence.end_date = None
             if type_changed:
                 absence.type = new_absence_type
 

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -1011,16 +1011,34 @@ def absence_days(db: Session, user: User, absences: list,
     bzw. Halbtage falsch ist)."""
     tracked = get_daily_target(user) > 0
     total = Decimal('0')
+    # #394: Halbtags-Sondertag (24./31.12.) → ein Absenz-Tag darauf zählt 0,5
+    # (halber Arbeitstag). Config lazy je Jahr (Liste kann jahresübergreifend sein).
+    _sd_cfg: dict = {}
+
+    def _half_special(d: date) -> bool:
+        cfg = _sd_cfg.get(d.year)
+        if cfg is None:
+            cfg = special_days_service.get_special_day_config(db, user.tenant_id, d.year)
+            _sd_cfg[d.year] = cfg
+        f = special_days_service.special_day_target_factor(d, cfg)
+        return f is not None and f == Decimal('0.5')
+
     for a in absences:
         if not tracked:
-            total += Decimal('0.5') if a.half_day else Decimal('1')
+            base = Decimal('0.5') if a.half_day else Decimal('1')
+            if _half_special(a.date):
+                base *= Decimal('0.5')
+            total += base
             continue
         dt_day = get_daily_target_for_date(user, a.date, get_weekly_hours_for_date(db, user, a.date, wh_changes=wh_changes))
         if dt_day > 0:
             if a.half_day is None:
                 total += Decimal(str(a.hours)) / Decimal(str(dt_day))
             else:
-                total += Decimal('0.5') if a.half_day else Decimal('1')
+                base = Decimal('0.5') if a.half_day else Decimal('1')
+                if _half_special(a.date):
+                    base *= Decimal('0.5')
+                total += base
     return total
 
 
@@ -1172,6 +1190,10 @@ def get_vacation_account(
     # Halbtag = 0,5) — unabhängig vom Wochentag. Das verhindert, dass ein
     # Montag-Urlaub (z. B. 8h) mehr kostet als ein Dienstag-Urlaub (z. B. 3h)
     # bei ungleichmäßigem Tagesplan. Die Stundensumme bleibt nur informativ.
+    # #394: config der Halbtags-Sondertage (24./31.12.) — ein Urlaubstag an einem
+    # solchen Tag ist nur ein halber Arbeitstag und kostet daher 0,5 (§3 BUrlG).
+    # Für alle anderen Tage bleibt der Faktor 1,0 → byte-identisch zur Altlogik.
+    special_cfg_vac = special_days_service.get_special_day_config(db, user.tenant_id, year)
     used_hours = Decimal('0')
     used_days = Decimal('0')
     for a in vacation_absences:
@@ -1193,7 +1215,12 @@ def get_vacation_account(
             else:
                 # #205: tagebasiert (Voll-Tag 1,0; Halbtag 0,5) — unabhaengig von
                 # spaeteren Aenderungen des Tagessolls (kein Drift mehr).
-                used_days += (Decimal('0.5') if a.half_day else Decimal('1'))
+                base = Decimal('0.5') if a.half_day else Decimal('1')
+                # #394: Halbtags-Sondertag → 0,5 × Basis (voller Urlaubstag = 0,5).
+                sd_factor = special_days_service.special_day_target_factor(a.date, special_cfg_vac)
+                if sd_factor is not None and sd_factor == Decimal('0.5'):
+                    base *= Decimal('0.5')
+                used_days += base
 
     # #146: a special day (24./31.12.) configured as `free` + counts_as_vacation
     # consumes one vacation day too. We account for it non-invasively here
@@ -1222,8 +1249,15 @@ def get_vacation_account(
     # zum 0,5-Vorab-Budgetcheck). Legacy-Rows (half_day=None, vor dem Feld) und
     # Voll-Tage zaehlen 1,0 wie bisher.
     if daily_target <= 0:
+        def _untracked_vac_weight(a):
+            base = Decimal('0.5') if a.half_day else Decimal('1')
+            # #394: halber Feiertag (24./31.12.) → 0,5 (auch für untracked/leitende).
+            f = special_days_service.special_day_target_factor(a.date, special_cfg_vac)
+            if f is not None and f == Decimal('0.5'):
+                base *= Decimal('0.5')
+            return base
         used_days = sum(
-            (Decimal('0.5') if a.half_day else Decimal('1') for a in vacation_absences),
+            (_untracked_vac_weight(a) for a in vacation_absences),
             Decimal('0'),
         )
         for d in deduction_dates:

--- a/backend/tests/test_closure_overtime_split.py
+++ b/backend/tests/test_closure_overtime_split.py
@@ -18,7 +18,7 @@ from app.middleware.auth import get_current_user, require_admin
 from app.models import User, UserRole, Absence, AbsenceType
 from app.models.tenant import Tenant
 from app.models.system_setting import SystemSetting
-from app.services import auth_service
+from app.services import auth_service, calculation_service
 from tests.conftest import DEFAULT_TENANT_ID, engine, TestingSessionLocal
 
 # Mon–Thu in a clean week (4 workdays), no holidays seeded.
@@ -531,3 +531,76 @@ class TestClosureSpecialDays:
             Absence.user_id == emp.id, Absence.closure_id == uuid.UUID(r.json()["id"])).all()}
         assert date(2025, 12, 24) not in booked, "24.12. (free) darf NICHT gebucht werden"
         assert date(2025, 12, 22) in booked and date(2025, 12, 26) in booked
+
+    def test_closure_half_special_day_books_half_vacation(self, db, default_tenant, admin_client):
+        """#394 Teil A: 24./31.12. als 'halber Feiertag' → die Betriebsferien-Buchung
+        bucht nur einen HALBEN Tag (Sondertags-Faktor 0,5), nicht den vollen Tag.
+        Sonst wird für einen 0,5-Soll-Tag ein voller Urlaubstag abgezogen."""
+        from app.models.system_setting import SystemSetting
+        emp = _make_user(db, "e_half", vacation_days=30)
+        db.add(SystemSetting(key="special_day_dec24_mode", tenant_id=DEFAULT_TENANT_ID, value="half_day"))
+        db.commit()
+        r = admin_client.post("/api/company-closures/", json={
+            "name": "Heiligabend", "start_date": "2025-12-24", "end_date": "2025-12-24",
+            "counts_as_vacation": True})
+        assert r.status_code == 201, r.text
+        a = db.query(Absence).filter(Absence.user_id == emp.id, Absence.date == date(2025, 12, 24)).one()
+        assert a.type == AbsenceType.VACATION
+        # half_day bleibt False: die Betriebsferien decken den ganzen (halben)
+        # Arbeitstag ab → das Tagessoll wird voll auf 0 gesetzt (KEIN Rest-Defizit).
+        # Die 0,5-Kosten kommen über den Sondertags-Faktor, nicht über half_day.
+        assert a.half_day is False
+        assert abs(float(a.hours) - 4.0) < 0.001, f"halber Tag = 4h, nicht {a.hours}"
+        acct = calculation_service.get_vacation_account(db, emp, 2025)
+        assert abs(float(acct["used_days"]) - 0.5) < 0.001, f"nur 0,5 Urlaubstag, nicht {acct['used_days']}"
+        # kein Phantom-Defizit: der halbe Feiertag ist durch Urlaub voll abgedeckt.
+        assert abs(float(calculation_service.get_overtime_account(db, emp, 2025, 12))) < 0.001, "kein Rest-Soll/Defizit"
+
+    def test_closure_half_special_day_books_half_overtime(self, db, default_tenant, admin_client):
+        """#394 Teil A + #314: erschöpftes Urlaubsbudget → OVERTIME-Buchung eines
+        halben Sondertags zieht nur 4h Überstunden ab (nicht 8h)."""
+        from app.models.system_setting import SystemSetting
+        emp = _make_user(db, "e_half_ot", vacation_days=0)  # kein Budget → OVERTIME
+        _set_toggle(db, True)
+        db.add(SystemSetting(key="special_day_dec24_mode", tenant_id=DEFAULT_TENANT_ID, value="half_day"))
+        db.commit()
+        r = admin_client.post("/api/company-closures/", json={
+            "name": "Heiligabend", "start_date": "2025-12-24", "end_date": "2025-12-24",
+            "counts_as_vacation": True})
+        assert r.status_code == 201, r.text
+        a = db.query(Absence).filter(Absence.user_id == emp.id, Absence.date == date(2025, 12, 24)).one()
+        assert a.type == AbsenceType.OVERTIME
+        # gebuchte Ausgleichsstunden (Report/Export lesen absence.hours) = halbes
+        # Tagessoll (4h), nicht 8h — genau der Kundenbefund "volle Tage abgezogen".
+        assert abs(float(a.hours) - 4.0) < 0.001, f"halber OT-Tag = 4h, nicht {a.hours}"
+        # das Tages-Soll (= Überstunden-Drawdown-Basis) ist am halben Feiertag 4h.
+        soll = calculation_service.get_range_target(db, emp, date(2025, 12, 24), date(2025, 12, 24))
+        assert abs(float(soll) - 4.0) < 0.001, f"halber Feiertag-Soll = 4h, nicht {soll}"
+
+    def test_closure_absences_are_single_day(self, db, default_tenant, admin_client):
+        """#394 Teil B: jede generierte Betriebsferien-Absence ist ein EINZELTAG
+        (end_date=None), nicht die ganze Closure-Spanne an jedem Datum — was die
+        Abwesenheitsliste je Zeile verwirrend als '10.03 – 13.03' anzeigte."""
+        emp = _make_user(db, "e_span", vacation_days=30)
+        r = admin_client.post("/api/company-closures/", json={
+            "name": "BF", "start_date": MON.isoformat(), "end_date": THU.isoformat(),
+            "counts_as_vacation": True})
+        assert r.status_code == 201, r.text
+        absences = db.query(Absence).filter(Absence.user_id == emp.id).all()
+        assert len(absences) == 4
+        assert all(a.end_date is None for a in absences), "Closure-Absencen müssen Einzeltage sein"
+
+    def test_update_closure_keeps_single_day(self, db, default_tenant, admin_client):
+        """#394 Teil B: auch ein Re-Save/Umbenennen hält die Absencen als Einzeltage."""
+        emp = _make_user(db, "e_span2", vacation_days=30)
+        r = admin_client.post("/api/company-closures/", json={
+            "name": "BF", "start_date": MON.isoformat(), "end_date": THU.isoformat(),
+            "counts_as_vacation": True})
+        assert r.status_code == 201, r.text
+        cid = r.json()["id"]
+        r2 = admin_client.put(f"/api/company-closures/{cid}", json={
+            "name": "BF neu", "start_date": MON.isoformat(), "end_date": THU.isoformat(),
+            "counts_as_vacation": True})
+        assert r2.status_code == 200, r2.text
+        absences = db.query(Absence).filter(Absence.user_id == emp.id).all()
+        assert absences and all(a.end_date is None for a in absences)

--- a/backend/tests/test_company_closure_edit.py
+++ b/backend/tests/test_company_closure_edit.py
@@ -205,8 +205,9 @@ class TestPutExtendsRange:
 
         absences = _closure_absences(db, employee, closure["id"])
         assert {a.date for a in absences} == {MON, TUE, WED, THU}
-        # end_date of all linked absences updated to the new range end.
-        assert all(a.end_date == THU for a in absences)
+        # #394 Teil B: jede Closure-Absence ist ein EINZELTAG (end_date=None),
+        # nicht die ganze (neue) Spanne an jedem Datum.
+        assert all(a.end_date is None for a in absences)
 
     def test_extending_into_next_week_skips_weekend(self, db, employee, admin_client):
         """Prüft dass beim Verlängern über das Wochenende nur Werktage Absences bekommen."""

--- a/backend/tests/test_special_days.py
+++ b/backend/tests/test_special_days.py
@@ -218,6 +218,37 @@ def test_free_vacation_on_holiday_no_deduction(db, test_user):
 
 
 # ---------------------------------------------------------------------------
+# half_day special day: a vacation/absence day on it costs 0.5 (#394)
+# ---------------------------------------------------------------------------
+
+def test_half_special_day_vacation_costs_half(db, test_user):
+    """#394: ein Urlaubstag an einem als 'halber Feiertag' konfigurierten Sondertag
+    (24./31.12.) kostet 0,5 Urlaubstage, nicht 1,0 — der Tag ist nur ein halber
+    Arbeitstag (§3 BUrlG Tagesprinzip)."""
+    _set_special_day(db, "special_day_dec24", "half_day")
+    a = Absence(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID, date=DEC24,
+                type=AbsenceType.VACATION, hours=8.0, half_day=False)
+    db.add(a)
+    db.commit()
+
+    acct = calculation_service.get_vacation_account(db, test_user, 2025)
+    assert acct["used_days"] == Decimal("0.5")
+    # absence_days (Report-/Export-Tagezählung) muss identisch 0,5 liefern.
+    assert calculation_service.absence_days(db, test_user, [a]) == Decimal("0.5")
+
+
+def test_normal_day_vacation_still_costs_full(db, test_user):
+    """Kontrolle: an einem NICHT-Sondertag bleibt ein Urlaubstag 1,0 (byte-identisch)."""
+    a = Absence(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID, date=date(2025, 12, 23),
+                type=AbsenceType.VACATION, hours=8.0, half_day=False)
+    db.add(a)
+    db.commit()
+    acct = calculation_service.get_vacation_account(db, test_user, 2025)
+    assert acct["used_days"] == Decimal("1.0")
+    assert calculation_service.absence_days(db, test_user, [a]) == Decimal("1.0")
+
+
+# ---------------------------------------------------------------------------
 # Settings validation surface
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Behebt [#394](https://github.com/phash/praxiszeit/issues/394) (Kundenreport philvdb).

## Teil A — Halbtags-Sondertag (24./31.12. = „halber Feiertag")
Die Betriebsferien-Buchung ignorierte den Sondertags-Faktor (0,5) und buchte einen **vollen** Tag für einen halben Arbeitstag → „volle Tage an Überstunden abgezogen".

**Fix** (`_create_closure_absences`): bucht `hours = 0,5 × Tagessoll` (4h statt 8h) und verbraucht 0,5 statt 1,0 Urlaubsbudget im #314-Split. `half_day` bleibt bewusst **False** (der ganze halbe Feiertag ist abgedeckt → Tagessoll voll auf 0, **kein** Rest-Defizit); die 0,5-**Kosten** kommen über den Sondertags-Faktor in `get_vacation_account.used_days` + `absence_days` — tracked, untracked/leitende **und** die Report-/Export-Tagezählung. `half_day=True` würde das Soll doppelt halbieren → Phantom-Defizit (im Review verworfen).

⚠️ **Frozen-Calc-Hinweis:** `get_vacation_account`/`absence_days` sind §16-relevant. Der Change ist **byte-identisch für alle Nicht-Halbtags-Sondertage** (Faktor ×1,0); nur echte `half_day`-Sondertage zählen jetzt 0,5. Kontroll-Test `test_normal_day_vacation_still_costs_full` sichert das.

## Teil B — Einzeltag-Absencen
Jede generierte Absence trug `end_date=closure.end_date` → die Liste zeigte je Zeile die ganze Spanne („24.12 – 31.12"), der Schichtplaner las sie als Mehrtages-Span. Jetzt `end_date=None` (Einzeltag) in `_create_closure_absences` **und** `update_closure`. Die Kennzeichnung „im Rahmen der Betriebsferien" liefert weiter die note („Betriebsferien: …", in der Liste bereits sichtbar) + `closure_id`.

## Tests
- `test_closure_overtime_split::TestClosureSpecialDays`: Halbtags-Vacation (4h, half_day False, 0,5 Urlaubstag, kein Defizit), Halbtags-Overtime (4h, Soll 4h), Einzeltag-Absencen, Re-Save-Einzeltag.
- `test_special_days`: Halbtags-Urlaub kostet 0,5 (get_vacation_account + absence_days) + Kontroll-Normaltag 1,0 (byte-identisch).
- `test_company_closure_edit`: Assertion auf Einzeltag angepasst.
- **Backend-Suite 1303 passed / 49 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
