### PR TITLE
Projekt-Review: Schwachstellen/Logiklücken/toter Code/falsche Tests (23 Findings gefixt)

### DIFF
--- a/backend/app/core/license.py
+++ b/backend/app/core/license.py
@@ -256,12 +256,14 @@ def set_license_state(license_info: Optional[LicenseInfo], read_only: bool = Fal
 
 def require_writable():
     """
-    FastAPI dependency that blocks write operations when license is expired.
-    Use in POST/PUT/DELETE endpoints that create or modify data.
+    FastAPI dependency that raises 403 while the license is in read-only mode.
 
-    Usage:
-        @router.post("/api/time-entries", dependencies=[Depends(require_writable)])
-        def create_entry(...): ...
+    NOT attached to any route as a ``Depends`` — write enforcement is done
+    globally by ``LicenseReadOnlyMiddleware`` (see ``app/middleware/license.py``),
+    which covers every write endpoint by default instead of relying on each
+    new one remembering to add this dependency. Kept as a small, directly
+    testable unit (see ``test_read_only_guard`` in ``test_native_mode.py``)
+    for the read-only-state check itself.
     """
     from fastapi import HTTPException
     if _license_read_only:

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -12,18 +12,14 @@ The update flow:
 """
 
 import base64
-import hashlib
 import json
 import logging
 import platform
-import shutil
-import tempfile
 import urllib.request
 import urllib.error
 import ssl
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -220,7 +216,7 @@ def check_for_updates(server_url: str, license_id: str = "") -> Optional[UpdateI
         return None
 
     download_url = data.get("download_url", "")
-    # Verify host allowlist before we ever hand this URL to download_update().
+    # Verify host allowlist before caching the download URL for later use.
     try:
         _verify_download_host(download_url)
     except ValueError as e:
@@ -243,64 +239,6 @@ def check_for_updates(server_url: str, license_id: str = "") -> Optional[UpdateI
         logger.info(f"Update available: {latest}")
 
     return _cached_update
-
-
-def download_update(update: UpdateInfo, target_dir: Path) -> Path:
-    """
-    Download an update package and verify its checksum.
-
-    Args:
-        update: UpdateInfo with download URL and checksum
-        target_dir: Directory to save the downloaded package
-
-    Returns:
-        Path to the downloaded file
-
-    Raises:
-        ValueError: If checksum verification fails
-        urllib.error.URLError: If download fails
-    """
-    target_dir.mkdir(parents=True, exist_ok=True)
-
-    # F-036: defense-in-depth — re-verify the download URL before opening it.
-    # (check_for_updates already did this when populating UpdateInfo, but the
-    # object could have been constructed by other code paths in the future.)
-    _verify_download_host(update.download_url)
-
-    filename = f"praxiszeit-{update.latest_version}-{platform.system().lower()}.tar.gz"
-    target_path = target_dir / filename
-
-    logger.info(f"Downloading update {update.latest_version} ({update.size_mb} MB)...")
-
-    ctx = ssl.create_default_context()
-    req = urllib.request.Request(
-        update.download_url,
-        headers={"User-Agent": f"PraxisZeit/{APP_VERSION}"},
-    )
-
-    hasher = hashlib.sha256()
-    with urllib.request.urlopen(req, context=ctx, timeout=300) as resp:
-        with open(target_path, "wb") as f:
-            while True:
-                chunk = resp.read(8192)
-                if not chunk:
-                    break
-                f.write(chunk)
-                hasher.update(chunk)
-
-    # Verify checksum
-    if update.checksum_sha256:
-        actual = hasher.hexdigest()
-        if actual != update.checksum_sha256:
-            target_path.unlink()
-            raise ValueError(
-                f"Checksum mismatch! Expected {update.checksum_sha256[:16]}..., "
-                f"got {actual[:16]}..."
-            )
-        logger.info("Checksum verified")
-
-    logger.info(f"Update downloaded: {target_path}")
-    return target_path
 
 
 def get_update_status() -> dict:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -323,29 +323,39 @@ async def lifespan(app: FastAPI):
         # keine Kundenangaben), aber die License-Middleware respektiert
         # den read_only-Flag.
         from app.core.license import set_license_state
-        try:
-            from datetime import date as _date
-            demo_until = _date.fromisoformat(settings.LICENSE_DEMO_EXPIRES_AT.strip())
-        except ValueError:
-            print(f"LICENSE ERROR: ungueltiges LICENSE_DEMO_EXPIRES_AT "
-                  f"'{settings.LICENSE_DEMO_EXPIRES_AT}' (erwartet YYYY-MM-DD)")
-            sys.exit(1)
         from datetime import date
-        today = date.today()
-        if today > demo_until:
-            print(f"WARNING: Demo-Lizenz abgelaufen am {demo_until.isoformat()}.")
+        try:
+            demo_until = date.fromisoformat(settings.LICENSE_DEMO_EXPIRES_AT.strip())
+        except ValueError:
+            # Ein kaputtes/unparsebares Datum darf den Dienst NICHT abschiessen
+            # (dasselbe Prinzip wie bei LicenseError oben: read-only statt
+            # sys.exit(1) -> Crash-Loop/Totalausfall, niemand kommt rein).
+            # Konservativ wie eine abgelaufene Demo behandeln.
+            print(f"LICENSE ERROR: ungueltiges LICENSE_DEMO_EXPIRES_AT "
+                  f"'{settings.LICENSE_DEMO_EXPIRES_AT}' (erwartet YYYY-MM-DD).")
             print("App running in READ-ONLY mode.")
             set_license_state(None, read_only=True)
             # M6: structured audit-log fuer DSGVO Art. 32 / ArbZG §16
             audit_license_readonly_event(
-                reason="Demo-Frist überschritten",
+                reason="Ungültiges LICENSE_DEMO_EXPIRES_AT",
                 default_tenant_id=default_tenant_id,
             )
         else:
-            days_left = (demo_until - today).days
-            print(f"License: 30-Tage-Demo (laeuft am {demo_until.isoformat()} "
-                  f"ab, noch {days_left} Tage)")
-            set_license_state(None, read_only=False)
+            today = date.today()
+            if today > demo_until:
+                print(f"WARNING: Demo-Lizenz abgelaufen am {demo_until.isoformat()}.")
+                print("App running in READ-ONLY mode.")
+                set_license_state(None, read_only=True)
+                # M6: structured audit-log fuer DSGVO Art. 32 / ArbZG §16
+                audit_license_readonly_event(
+                    reason="Demo-Frist überschritten",
+                    default_tenant_id=default_tenant_id,
+                )
+            else:
+                days_left = (demo_until - today).days
+                print(f"License: 30-Tage-Demo (laeuft am {demo_until.isoformat()} "
+                      f"ab, noch {days_left} Tage)")
+                set_license_state(None, read_only=False)
 
     # Configuration sanity checks
     if settings.COOKIE_SECURE and settings.ENVIRONMENT != "production":
@@ -395,25 +405,10 @@ _instrumentator.instrument(app)
 if not settings.SERVE_FRONTEND:
     _instrumentator.expose(app)
 
-# Configure CORS
-cors_origins = [origin.strip() for origin in settings.CORS_ORIGINS.split(",")]
-_cors_is_wildcard = cors_origins == ["*"]
-# F-024 audit: ``Cookie`` is a forbidden header name in browsers (JS cannot
-# set it), so listing it in allow_headers is both pointless and misleading.
-# ``X-CSRF-Token`` is the double-submit header the frontend mirrors the
-# csrf_token cookie into — it must be allowlisted for cross-origin use.
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=cors_origins,
-    allow_credentials=not _cors_is_wildcard,  # Disable credentials with wildcard origins
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type", "X-CSRF-Token"],
-    expose_headers=["X-Requires-TOTP"],
-)
-
 # F-024: CSRF double-submit cookie enforcement on unsafe methods.
-# Must be added AFTER CORSMiddleware so that preflight requests handled by
-# CORS are still processed (OPTIONS is not an unsafe method anyway).
+# NOTE: CORSMiddleware is registered further down (after TrustedHostMiddleware),
+# not here — see the comment at its registration site for why (Finding 11,
+# CORS must be the OUTERMOST middleware).
 app.add_middleware(CSRFMiddleware)
 
 # License read-only enforcement for native installs (no-op when no license
@@ -471,11 +466,39 @@ def _allowed_hosts() -> list[str]:
 
 
 # Vuln-3 / CVE-2026-48710 "BadHost": validate the Host header against an
-# operator-configured allowlist. Added last → outermost → runs before the
-# path-based middlewares (CSRF exemption, license, SPA routing) that a Host
-# desync on an unpatched Starlette could otherwise confuse. No-op while
-# ALLOWED_HOSTS="*" (the default).
+# operator-configured allowlist. Runs before the path-based middlewares
+# (CSRF exemption, license, SPA routing) that a Host desync on an unpatched
+# Starlette could otherwise confuse. No-op while ALLOWED_HOSTS="*" (the
+# default). CORSMiddleware (below) wraps it too, but CORS never routes on
+# the Host header, so TrustedHost still gets to reject a bad Host before any
+# app logic runs.
 app.add_middleware(TrustedHostMiddleware, allowed_hosts=_allowed_hosts())
+
+# Configure CORS. Registered LAST (Finding 11) so Starlette makes it the
+# OUTERMOST middleware — in Starlette, ``add_middleware`` builds the stack
+# such that the most-recently-added middleware wraps everything added
+# before it. CORS was previously added FIRST (innermost), so any
+# short-circuited response from a middleware added after it — the CSRF/
+# License/Impersonation 403s, the RequestSizeLimit 413, the TrustedHost 400
+# — never passed back through CORSMiddleware and reached the browser with
+# NO Access-Control-Allow-Origin header. The browser then reports a generic
+# CORS/network error, hiding the real 403/413 from the frontend. Outermost
+# CORS guarantees every response, including short-circuits, gets the
+# correct CORS headers.
+cors_origins = [origin.strip() for origin in settings.CORS_ORIGINS.split(",")]
+_cors_is_wildcard = cors_origins == ["*"]
+# F-024 audit: ``Cookie`` is a forbidden header name in browsers (JS cannot
+# set it), so listing it in allow_headers is both pointless and misleading.
+# ``X-CSRF-Token`` is the double-submit header the frontend mirrors the
+# csrf_token cookie into — it must be allowlisted for cross-origin use.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_origins,
+    allow_credentials=not _cors_is_wildcard,  # Disable credentials with wildcard origins
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "X-CSRF-Token"],
+    expose_headers=["X-Requires-TOTP"],
+)
 
 # Attach DB error logging handler (captures WARNING+ logs to error_logs table)
 # DSGVO F-007: sqlalchemy.engine intentionally NOT attached (SQL queries can contain PII)

--- a/backend/app/routers/absences.py
+++ b/backend/app/routers/absences.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
 from app.services.date_filters import date_in_year, date_in_month, parse_year_month
-from sqlalchemy import extract
 from typing import List, Optional
 from datetime import timedelta, date
 from app.services.timezone_service import today_local

--- a/backend/app/routers/admin_change_requests.py
+++ b/backend/app/routers/admin_change_requests.py
@@ -530,6 +530,21 @@ def review_change_request(
                 and cr.proposed_absence_type == AbsenceType.VACATION.value
                 and cr.proposed_date
             ):
+                # AC-11 / F-5: 'free'-Sondertage (24./31.12.) sind soll-frei —
+                # sie dürfen keine VACATION-Absence bekommen (mirrors
+                # create_absence/review_vacation_request, wo der Tag komplett
+                # aus dates_to_create ausgeschlossen wird). half_special_day_weight
+                # kennt nur half_day=0,5, NICHT free=0 (free läuft separat über
+                # vacation_deduction_dates in get_vacation_account) — ohne diesen
+                # Ausschluss lud der Check hier fälschlich 1,0 Tage für einen
+                # counts_as_vacation=False-Freitag.
+                if cr.proposed_date in special_days_service.free_special_days_in_range(
+                    db, cr_user.tenant_id, cr.proposed_date, cr.proposed_date
+                ):
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Kein gültiger Arbeitstag (soll-freier Sondertag) — es kann kein Urlaubstag gebucht werden.",
+                    )
                 _bill_day = True
                 if getattr(cr_user, "use_daily_schedule", False) and cr_user.track_hours:
                     _bw = get_weekly_hours_for_date(db, cr_user, cr.proposed_date)
@@ -643,6 +658,16 @@ def review_change_request(
             )
             _target_date = cr.proposed_date or absence.date
             if _bud_user and _target_type == AbsenceType.VACATION and _target_date:
+                # AC-11 / F-5: dasselbe Free-Sondertag-Verbot wie im CREATE-Branch —
+                # ein UPDATE darf einen Urlaubstag nicht auf einen soll-freien
+                # 24./31.12. verschieben (oder ihn als VACATION dort belassen).
+                if _target_date in special_days_service.free_special_days_in_range(
+                    db, _bud_user.tenant_id, _target_date, _target_date
+                ):
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Kein gültiger Arbeitstag (soll-freier Sondertag) — es kann kein Urlaubstag gebucht werden.",
+                    )
                 _target_year = _target_date.year
                 _post_days = _vacation_day_contribution(
                     db, _bud_user, _target_date, absence.half_day

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -325,9 +325,8 @@ def anonymize_user(
     current_user: User = Depends(require_admin),
 ):
     """DSGVO Art. 17: Anonymize an inactive user in-place. Keeps time entries (ArbZG SS16 -- 2-year retention), deletes absences."""
+    # _get_user_in_tenant raises 404 itself (never returns None) — see get_user.
     user = _get_user_in_tenant(db, user_id, current_user)
-    if not user:
-        raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
     if user.is_active:
         raise HTTPException(status_code=400, detail="Benutzer muss zuerst deaktiviert werden (Art. 17 DSGVO)")
     if user.username.startswith("deleted_"):
@@ -385,9 +384,8 @@ def purge_user(
     current_user: User = Depends(require_admin),
 ):
     """DSGVO Art. 17: Permanently delete a user and all data. Only allowed after ArbZG SS16 retention period (730 days)."""
+    # _get_user_in_tenant raises 404 itself (never returns None) — see get_user.
     user = _get_user_in_tenant(db, user_id, current_user)
-    if not user:
-        raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
     if user.is_active:
         raise HTTPException(status_code=400, detail="Benutzer muss zuerst deaktiviert werden")
 
@@ -631,9 +629,8 @@ def update_user(
     current_user: User = Depends(require_admin)
 ):
     """Update user data (admin only)."""
+    # _get_user_in_tenant raises 404 itself (never returns None) — see get_user.
     user = _get_user_in_tenant(db, user_id, current_user)
-    if not user:
-        raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 
     if user_data.username and user_data.username.lower() != user.username.lower():
         # F-026: scope the uniqueness probe to the tenant (parity with
@@ -682,9 +679,8 @@ def set_password(
     current_user: User = Depends(require_admin),
 ):
     """Set a new password for a user (admin only)."""
+    # _get_user_in_tenant raises 404 itself (never returns None) — see get_user.
     user = _get_user_in_tenant(db, user_id, current_user)
-    if not user:
-        raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 
     user.password_hash = auth_service.hash_password(body.password)
     user.token_version += 1  # Invalidate all existing tokens
@@ -699,9 +695,8 @@ def deactivate_user(user_id: str, db: Session = Depends(get_db), current_user: U
     if str(current_user.id) == user_id:
         raise HTTPException(status_code=400, detail="Sie können sich nicht selbst deaktivieren")
 
+    # _get_user_in_tenant raises 404 itself (never returns None) — see get_user.
     user = _get_user_in_tenant(db, user_id, current_user)
-    if not user:
-        raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 
     user.is_active = False
     user.deactivated_at = datetime.now(timezone.utc)
@@ -713,9 +708,8 @@ def deactivate_user(user_id: str, db: Session = Depends(get_db), current_user: U
 @router.post("/users/{user_id}/reactivate", response_model=UserResponse)
 def reactivate_user(user_id: str, db: Session = Depends(get_db), current_user: User = Depends(require_admin)):
     """Reactivate a previously deactivated user (admin only)."""
+    # _get_user_in_tenant raises 404 itself (never returns None) — see get_user.
     user = _get_user_in_tenant(db, user_id, current_user)
-    if not user:
-        raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 
     # Seat-limit enforcement: a reactivation is logically a seat add.
     from app.models.tenant import Tenant
@@ -734,9 +728,8 @@ def reactivate_user(user_id: str, db: Session = Depends(get_db), current_user: U
 @router.post("/users/{user_id}/toggle-hidden", response_model=UserResponse)
 def toggle_hidden_user(user_id: str, db: Session = Depends(get_db), current_user: User = Depends(require_admin)):
     """Toggle the is_hidden flag for a user (admin only)."""
+    # _get_user_in_tenant raises 404 itself (never returns None) — see get_user.
     user = _get_user_in_tenant(db, user_id, current_user)
-    if not user:
-        raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 
     user.is_hidden = not user.is_hidden
     db.commit()
@@ -753,9 +746,8 @@ def list_working_hours_changes(
     current_user: User = Depends(require_admin)
 ):
     """Get working hours change history for a user (admin only)."""
+    # _get_user_in_tenant raises 404 itself (never returns None) — see get_user.
     user = _get_user_in_tenant(db, user_id, current_user)
-    if not user:
-        raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 
     changes = db.query(WorkingHoursChange).filter(
         WorkingHoursChange.user_id == user_id,
@@ -772,9 +764,8 @@ def create_working_hours_change(
     current_user: User = Depends(require_admin)
 ):
     """Create a new working hours change for a user (admin only)."""
+    # _get_user_in_tenant raises 404 itself (never returns None) — see get_user.
     user = _get_user_in_tenant(db, user_id, current_user)
-    if not user:
-        raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
 
     # Fix #2: a WorkingHoursChange only feeds get_weekly_hours_for_date, which
     # get_daily_target_for_date IGNORES when use_daily_schedule=True (it reads
@@ -812,6 +803,15 @@ def create_working_hours_change(
         note=change_data.note
     )
     db.add(change)
+    # Finding 4 (Review 2026-07-14): the session is autoflush=False. Without an
+    # explicit flush here, the most-recent self-query below (which also filters
+    # on WorkingHoursChange) would not see the row just added — the first
+    # past-dated change would leave user.weekly_hours unchanged, and a second,
+    # superseding past-dated change would pick up the PREVIOUS committed row
+    # instead of itself. delete_working_hours_change already commits before its
+    # analogous re-query; flush gives create the same guarantee without an
+    # early partial commit.
+    db.flush()
 
     if change_data.effective_from <= today_local():
         most_recent = db.query(WorkingHoursChange).filter(

--- a/backend/app/routers/company_closures.py
+++ b/backend/app/routers/company_closures.py
@@ -6,12 +6,10 @@ from typing import List
 from datetime import date, timedelta
 from decimal import Decimal
 from pydantic import BaseModel, ConfigDict
-from uuid import UUID
 
 from app.database import get_db
 from app.middleware.auth import get_current_user, require_admin
 from app.models import User, Absence, AbsenceType, PublicHoliday, CompanyClosure, TimeEntry, WorkingHoursChange
-from app.schemas.absence import AbsenceResponse
 from app.services import calculation_service, settings_service, special_days_service
 # Fix #3: the year re-split lives in a service module so the private-vacation
 # write paths can call it without importing this router (circular-import safe).

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -2,7 +2,6 @@ import logging
 from fastapi import APIRouter, Depends, Query, HTTPException
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
-from sqlalchemy import extract
 from starlette.requests import Request
 from typing import List
 from decimal import Decimal
@@ -141,6 +140,7 @@ def get_monthly_report(
             sick_hours=sick_hours if include_health_data else 0.0,
             sick_days=sick_days if include_health_data else 0.0,
             exempt_from_arbzg=bool(user.exempt_from_arbzg),
+            track_hours=bool(user.track_hours),
         ))
 
     # L-2: Report erfolgreich gebaut -> jetzt erst den (ggf. oben geflushten)
@@ -262,6 +262,7 @@ def get_weekly_report(
             sick_hours=sick_hours if include_health_data else 0.0,
             sick_days=sick_days if include_health_data else 0.0,
             exempt_from_arbzg=bool(user.exempt_from_arbzg),
+            track_hours=bool(user.track_hours),
         ))
 
     if include_health_data:
@@ -306,49 +307,39 @@ def get_yearly_absences(
     results = []
 
     for user in users:
-        # Uses current daily target for hours-to-days conversion — approximate for display.
-        # The hour totals are always exact; only the "days" column is an approximation
-        # when weekly_hours changed during the year.
-        daily_target = calculation_service.get_daily_target(user)
-
-        # If daily_target is 0, we can't calculate days
-        if daily_target == 0:
-            daily_target = Decimal('8.0')  # Use default 8h for calculation
-
         # F-033 + Sprint 3.4: fetch all absences for this user+year in ONE
         # query, group by type in Python. Previous code issued 5 separate
         # queries per user (one per type).
         all_absences = db.query(Absence).filter(
             Absence.user_id == user.id,
+            Absence.tenant_id == current_user.tenant_id,  # F-026 belt-and-suspenders
             date_in_year(Absence.date, year),
         ).all()
-        hours_by_type: dict = {}
+        absences_by_type: dict = {}
         for a in all_absences:
-            hours_by_type[a.type] = hours_by_type.get(a.type, 0.0) + float(a.hours)
+            absences_by_type.setdefault(a.type, []).append(a)
 
-        # Vacation is reported DAY-BASED (Tagesprinzip §3 BUrlG) from the same
-        # source as remaining below — so "budget − genommen == Rest" holds in the
-        # same response. The hours/Ø-target approximation (used by the other
-        # columns, documented above) diverges from the day principle for
-        # use_daily_schedule employees; vacation is the maßgebliche value and
-        # must not contradict the vacation account.
+        # Finding 2 (Review 2026-07-14): ALL day columns — including vacation —
+        # are TAGEBASIERT (Tagesprinzip §3 BUrlG) via calculation_service.
+        # absence_days(), exactly the helper /monthly + /weekly already use.
+        # The former naive Σh ÷ Ø-Tagessoll approximation always returned 0.0
+        # for track_hours=False employees (Absence.hours is always 0 for them)
+        # and drifted for uneven per-weekday schedules (use_daily_schedule).
         vacation_account = calculation_service.get_vacation_account(db, user, year)
         vacation_days = float(vacation_account['used_days'])
 
-        sick_hours = hours_by_type.get(AbsenceType.SICK, 0.0)
-        sick_days = sick_hours / float(daily_target)
+        def _days(absence_type) -> float:
+            return float(
+                calculation_service.absence_days(
+                    db, user, absences_by_type.get(absence_type, [])
+                ).quantize(Decimal('0.1'))
+            )
 
-        training_hours = hours_by_type.get(AbsenceType.TRAINING, 0.0)
-        training_days = training_hours / float(daily_target)
-
-        overtime_comp_hours = hours_by_type.get(AbsenceType.OVERTIME, 0.0)
-        overtime_comp_days = overtime_comp_hours / float(daily_target)
-
-        other_hours = hours_by_type.get(AbsenceType.OTHER, 0.0)
-        other_days = other_hours / float(daily_target)
-
-        paid_leave_hours = hours_by_type.get(AbsenceType.PAID_LEAVE, 0.0)
-        paid_leave_days = paid_leave_hours / float(daily_target)
+        sick_days = _days(AbsenceType.SICK)
+        training_days = _days(AbsenceType.TRAINING)
+        overtime_comp_days = _days(AbsenceType.OVERTIME)
+        other_days = _days(AbsenceType.OTHER)
+        paid_leave_days = _days(AbsenceType.PAID_LEAVE)
 
         effective_sick_days = sick_days if include_health_data else 0.0
         total_days = vacation_days + effective_sick_days + training_days + overtime_comp_days + other_days + paid_leave_days
@@ -978,6 +969,7 @@ def get_24_week_averaging_period(
             a.date
             for a in db.query(Absence).filter(
                 Absence.user_id == user.id,
+                Absence.tenant_id == current_user.tenant_id,  # F-026 belt-and-suspenders
                 Absence.date >= start_date,
                 Absence.date <= end_date,
                 Absence.type.notin_([

--- a/backend/app/routers/time_entries.py
+++ b/backend/app/routers/time_entries.py
@@ -246,7 +246,27 @@ def clock_in(
     current_user: User = Depends(get_current_user),
 ):
     """Clock in: create a time entry with start_time=now, end_time=NULL."""
-    # VULN-009: use SELECT FOR UPDATE to prevent race condition on concurrent clock-in
+    # VULN-009 / Review 2026-07-14: unter READ COMMITTED sperrt ein
+    # `SELECT ... FOR UPDATE` auf NULL Treffer (die typische Lage vor dem
+    # ERSTEN Einstempeln des Tages) gar nichts — man kann keine Phantomzeile
+    # sperren. Zwei echt-gleichzeitige clock-in-Requests sehen dann BEIDE
+    # "kein offener Eintrag" und legen beide eine neue Zeile an; bisher wurde
+    # das nur zufällig durch `uq_tenant_user_date_start` aufgefangen (weil
+    # start_time auf die Minute gerundet wird), nicht durch den Lock unten.
+    # Serialize concurrent clock-ins for THIS user: FOR UPDATE on the (existing) User
+    # row actually locks (unlike FOR UPDATE on the not-yet-existing open TimeEntry),
+    # so a truly-concurrent second clock-in blocks here, then sees the first's committed
+    # open entry via _get_open_entry and returns the "already clocked in" path instead
+    # of inserting a duplicate. (Same pattern as absences.py's User-row anchor lock.)
+    db.query(User).filter(
+        User.id == current_user.id, User.tenant_id == current_user.tenant_id
+    ).with_for_update().first()
+
+    # `_get_open_entry(with_lock=True)` bleibt als defense-in-depth: sobald die
+    # Zeile existiert (Stale-Entry von gestern, s.u.), sperrt FOR UPDATE hier
+    # echt und verhindert eine parallele Änderung/Auto-Close-Race auf genau
+    # dieser Zeile. Für clock_out (existierende offene Zeile) ist genau dieser
+    # Lock bereits ausreichend — dort gibt es keine Cold-Start-Lücke.
     open_entry = _get_open_entry(db, current_user.id, with_lock=True, tenant_id=current_user.tenant_id)
     if open_entry:
         if open_entry.date != _today_local():

--- a/backend/app/routers/time_entries.py
+++ b/backend/app/routers/time_entries.py
@@ -2,7 +2,6 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from app.services.date_filters import date_in_year, date_in_month
-from sqlalchemy import extract
 from typing import List, Optional
 from datetime import datetime, date, time, timezone
 from app.services.timezone_service import LOCAL_TZ, now_local as _now_local, today_local as _today_local
@@ -19,7 +18,7 @@ from app.schemas.time_entry import (
 )
 from app.services.holiday_service import is_holiday
 from app.services.break_validation_service import validate_daily_break
-from app.services.arbzg_utils import is_night_work, NIGHT_THRESHOLD_MINUTES
+from app.services.arbzg_utils import is_night_work
 from app.routers.admin_helpers import _create_audit_log
 from uuid import UUID as UUIDType
 

--- a/backend/app/routers/vacation_requests.py
+++ b/backend/app/routers/vacation_requests.py
@@ -137,6 +137,12 @@ def apply_vacation_request_patch(
                 PublicHoliday.tenant_id == vr.tenant_id,
             ).all():
                 holiday_dates.add(h.date)
+        # F-10 / AC-11: 'free'-Sondertage (24./31.12.) sind ebenfalls soll-frei
+        # und dürfen genau wie Feiertage nicht als verbrauchter Urlaubstag
+        # zählen — Parität mit admin_vacations.review_vacation_request.
+        holiday_dates |= special_days_service.free_special_days_in_range(
+            db, vr.tenant_id, new_date, effective_end
+        )
 
         dates_by_year: dict[int, list] = {}
         d = new_date
@@ -293,6 +299,13 @@ def create_vacation_request(
                 PublicHoliday.tenant_id == current_user.tenant_id,
             ).all():
                 holiday_dates.add(h.date)
+        # F-10 / AC-11: 'free'-Sondertage (24./31.12.) sind ebenfalls soll-frei
+        # und dürfen genau wie Feiertage nicht als verbrauchter Urlaubstag
+        # zählen — Parität mit dem PATCH-Pfad und
+        # admin_vacations.review_vacation_request.
+        holiday_dates |= special_days_service.free_special_days_in_range(
+            db, current_user.tenant_id, start_date, end_date
+        )
 
         dates_by_year: dict[int, list] = {}
         d = start_date

--- a/backend/app/schemas/reports.py
+++ b/backend/app/schemas/reports.py
@@ -85,6 +85,7 @@ class EmployeeMonthlyReport(BaseModel):
     sick_hours: float
     sick_days: float            # 0 ohne include_health_data (DSGVO Art. 9)
     exempt_from_arbzg: bool = False  # #159: leitende Angestellte (§18) — Filter im Dashboard-Schnitt
+    track_hours: bool = True    # Finding 14: #191-untracked MA aus "Ø Saldo" ausschließbar
 
 
 class PublicHolidayResponse(BaseModel):

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -42,6 +42,7 @@ def get_weekly_hours_for_date(
         # Classic path: one DB query, always correct.
         change = db.query(WorkingHoursChange).filter(
             WorkingHoursChange.user_id == user.id,
+            WorkingHoursChange.tenant_id == user.tenant_id,  # F-026 belt-and-suspenders
             WorkingHoursChange.effective_from <= target_date
         ).order_by(WorkingHoursChange.effective_from.desc()).first()
     else:
@@ -610,6 +611,7 @@ def get_overtime_account(
     # directly" without paying the per-day DB-query cost.
     wh_changes = db.query(WorkingHoursChange).filter(
         WorkingHoursChange.user_id == user.id,
+        WorkingHoursChange.tenant_id == user.tenant_id,  # F-026 belt-and-suspenders
     ).order_by(WorkingHoursChange.effective_from).all()
 
     # #146: special-day configs are per-year; cache them across the month loop
@@ -778,6 +780,7 @@ def get_overtime_history_detailed(
 
     wh_changes = db.query(WorkingHoursChange).filter(
         WorkingHoursChange.user_id == user.id,
+        WorkingHoursChange.tenant_id == user.tenant_id,  # F-026 belt-and-suspenders
     ).order_by(WorkingHoursChange.effective_from).all()
 
     special_day_configs: Dict[int, dict] = {}
@@ -937,6 +940,7 @@ def get_ytd_summary(
     if wh_changes is None:
         wh_changes = db.query(WorkingHoursChange).filter(
             WorkingHoursChange.user_id == user.id,
+            WorkingHoursChange.tenant_id == user.tenant_id,  # F-026 belt-and-suspenders
         ).order_by(WorkingHoursChange.effective_from).all()
 
     # #146: special-day config for the YTD year (24./31.12. always fall in

--- a/backend/app/services/closure_split_service.py
+++ b/backend/app/services/closure_split_service.py
@@ -7,6 +7,7 @@ re-split WITHOUT importing the router — which would risk a circular import.
 ``_resplit_year_closures`` so its existing call sites keep working.
 """
 from datetime import date
+from decimal import Decimal
 
 from sqlalchemy.orm import Session
 
@@ -101,8 +102,8 @@ def resplit_year_closures(db: Session, tenant_id, year: int, current_user: User 
     # (Release-Review 1.14.3). Config einmal je Jahr laden; `_wt(d)` = 0,5/1,0.
     special_cfg = special_days_service.get_special_day_config(db, tenant_id, year)
 
-    def _wt(d: date) -> float:
-        return float(calculation_service.half_special_day_weight(d, special_cfg))
+    def _wt(d: date) -> Decimal:
+        return calculation_service.half_special_day_weight(d, special_cfg)
 
     for user_id, absences in by_user.items():
         employee = users.get(user_id)
@@ -112,9 +113,11 @@ def resplit_year_closures(db: Session, tenant_id, year: int, current_user: User 
             continue
 
         # Gross annual budget (pro-rata + carryover), independent of bookings.
-        budget = float(
+        # Decimal (L2, review 2026-07-14): the walk gate below then compares
+        # exactly, no epsilon needed.
+        budget = Decimal(str(
             calculation_service.get_vacation_account(db, employee, year)["budget_days"]
-        )
+        ))
 
         # Non-closure vacation consumption (private vacation + free special days)
         # is ALL deducted up front, so the closure days only ever take the
@@ -129,7 +132,7 @@ def resplit_year_closures(db: Session, tenant_id, year: int, current_user: User 
             Absence.date <= year_end,
         ).all()
         private_dates = {a.date for a in private}
-        consumed = 0.0
+        consumed = Decimal('0')
         for a in private:
             # Fix #3: skip days with Tagessoll 0 (e.g. a use_daily_schedule MA's
             # free weekday) exactly like get_vacation_account's used_days loop —
@@ -142,8 +145,18 @@ def resplit_year_closures(db: Session, tenant_id, year: int, current_user: User 
             )
             if dt_day <= 0:
                 continue
-            # #394: an einem Halbtags-Sondertag kostet der Urlaubstag 0,5.
-            consumed += (0.5 if a.half_day else 1.0) * _wt(a.date)
+            # Finding 1 (review 2026-07-14): mirror calculation_service's
+            # three-way branch (get_vacation_account / absence_days) exactly.
+            # ``None`` is falsy, so the old ``(0.5 if a.half_day else 1.0)``
+            # fell into the ``else`` branch and charged a FULL day for a
+            # legacy (pre-migration-052, half_day IS NULL) hours-based row —
+            # only an explicit True/False half_day uses the 0.5/1.0 × special-
+            # day-weight shortcut.
+            if a.half_day is None:
+                consumed += Decimal(str(a.hours)) / Decimal(str(dt_day))
+            else:
+                # #394: an einem Halbtags-Sondertag kostet der Urlaubstag 0,5.
+                consumed += (Decimal('0.5') if a.half_day else Decimal('1')) * _wt(a.date)
         for d in deduction_dates:
             if d in private_dates:
                 continue  # already counted via a real VACATION absence
@@ -160,19 +173,20 @@ def resplit_year_closures(db: Session, tenant_id, year: int, current_user: User 
             )
             if dt_day <= 0:
                 continue
-            consumed += 1.0
+            consumed += Decimal('1')
 
         closure_budget = budget - consumed
 
         # Walk the closure days in CALENDAR order: VACATION while the remaining
         # closure budget covers a full day, OVERTIME afterwards. The surplus
         # therefore lands on the latest closure of the year.
-        used = 0.0
+        used = Decimal('0')
         for a in sorted(absences, key=lambda x: x.date):
             # #394: ein Halbtags-Sondertag kostet nur 0,5 Closure-Budget (deckt sich
             # mit day_consumption in _create_closure_absences + used_days).
             day_cost = _wt(a.date)
-            if closure_budget - used >= day_cost - 1e-9:
+            # L2 (review 2026-07-14): exact Decimal compare, no epsilon needed.
+            if closure_budget - used >= day_cost:
                 a.type = AbsenceType.VACATION
                 used += day_cost
             else:

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -12,7 +12,6 @@ from app.services import calculation_service, special_days_service
 from app.services.arbzg_utils import is_night_work
 from app.services.date_filters import date_in_year, date_in_month, date_in_year_up_to_month
 from app.config import settings
-from sqlalchemy import extract
 
 
 # M-SEC1: spreadsheet formula / CSV injection guard. A cell whose text starts
@@ -173,8 +172,10 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
     _, last_day = monthrange(year, month)
 
     # Get all time entries for the month (list-based: multiple entries per day)
+    # F-026: explicit tenant filter (belt-and-suspenders on top of RLS)
     time_entries = db.query(TimeEntry).filter(
         TimeEntry.user_id == user.id,
+        TimeEntry.tenant_id == user.tenant_id,
         date_in_month(TimeEntry.date, year, month)
     ).order_by(TimeEntry.start_time).all()
     entries_by_date = _group_by_date(time_entries)  # #219: shared
@@ -184,8 +185,10 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
     # (date, type) — z. B. ein halber Tag Urlaub + ein halber Tag Sonstiges).
     # Daher pro Tag eine LISTE statt einer einzelnen Absence, sonst verschluckt
     # die Anzeige die zweite stillschweigend.
+    # F-026: explicit tenant filter (belt-and-suspenders on top of RLS)
     absences = db.query(Absence).filter(
         Absence.user_id == user.id,
+        Absence.tenant_id == user.tenant_id,
         date_in_month(Absence.date, year, month)
     ).all()
     absences_by_date = _group_by_date(absences)  # #219: shared
@@ -673,16 +676,20 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
         cell.alignment = Alignment(horizontal="center")
 
     # Get all time entries for the year (list-based: multiple entries per day)
+    # F-026: explicit tenant filter (belt-and-suspenders on top of RLS)
     time_entries = db.query(TimeEntry).filter(
         TimeEntry.user_id == user.id,
+        TimeEntry.tenant_id == user.tenant_id,
         date_in_year(TimeEntry.date, year)
     ).order_by(TimeEntry.start_time).all()
     entries_by_date = _group_by_date(time_entries)  # #219: shared
 
     # Get all absences for the year.
     # I-1: pro Tag eine LISTE (mehrere Absences je Tag möglich, s. _create_employee_sheet).
+    # F-026: explicit tenant filter (belt-and-suspenders on top of RLS)
     absences = db.query(Absence).filter(
         Absence.user_id == user.id,
+        Absence.tenant_id == user.tenant_id,
         date_in_year(Absence.date, year)
     ).all()
     absences_by_date = _group_by_date(absences)  # #219: shared
@@ -1064,8 +1071,10 @@ def _create_employee_classic_sheet(wb: Workbook, db: Session, user: User, year: 
         sheet.cell(row=7, column=col).alignment = right_align
 
         # Row 8: Sick hours
+        # F-026: explicit tenant filter (belt-and-suspenders on top of RLS)
         sick_absences = db.query(Absence).filter(
             Absence.user_id == user.id,
+            Absence.tenant_id == user.tenant_id,
             Absence.type == AbsenceType.SICK,
             date_in_month(Absence.date, year, month)
         ).all()
@@ -1084,8 +1093,10 @@ def _create_employee_classic_sheet(wb: Workbook, db: Session, user: User, year: 
         sheet.cell(row=8, column=col).alignment = right_align
 
         # Row 9: Vacation hours
+        # F-026: explicit tenant filter (belt-and-suspenders on top of RLS)
         vacation_absences = db.query(Absence).filter(
             Absence.user_id == user.id,
+            Absence.tenant_id == user.tenant_id,
             Absence.type == AbsenceType.VACATION,
             date_in_month(Absence.date, year, month)
         ).all()
@@ -1167,8 +1178,10 @@ def _create_employee_classic_sheet(wb: Workbook, db: Session, user: User, year: 
         sheet.cell(row=15, column=col).alignment = right_align
 
         # Row 16: Night work days per month (§6 ArbZG)
+        # F-026: explicit tenant filter (belt-and-suspenders on top of RLS)
         month_entries = db.query(TimeEntry).filter(
             TimeEntry.user_id == user.id,
+            TimeEntry.tenant_id == user.tenant_id,
             date_in_month(TimeEntry.date, year, month),
             TimeEntry.end_time.isnot(None),
         ).all()
@@ -1283,8 +1296,10 @@ def generate_monthly_report_pdf(db: Session, year: int, month: int, include_heal
         # ── Fetch data ──
         _, last_day = monthrange(year, month)
 
+        # F-026: explicit tenant filter (belt-and-suspenders on top of RLS)
         time_entries = db.query(TimeEntry).filter(
             TimeEntry.user_id == user.id,
+            TimeEntry.tenant_id == user.tenant_id,
             date_in_month(TimeEntry.date, year, month),
         ).order_by(TimeEntry.start_time).all()
         entries_by_date: dict = {}
@@ -1293,6 +1308,7 @@ def generate_monthly_report_pdf(db: Session, year: int, month: int, include_heal
 
         absences = db.query(Absence).filter(
             Absence.user_id == user.id,
+            Absence.tenant_id == user.tenant_id,
             date_in_month(Absence.date, year, month),
         ).all()
         # I-1: pro Tag eine LISTE (mehrere Absences je Tag möglich, s. _create_employee_sheet).

--- a/backend/app/services/milog_service.py
+++ b/backend/app/services/milog_service.py
@@ -99,7 +99,17 @@ def settlement_aging(db, user, as_of: date, detailed=None):
     if not user.milog_working_time_account or not user.track_hours:
         return None
     if detailed is None:
-        detailed = calculation_service.get_overtime_history_detailed(db, user, as_of.year, as_of.month)
+        # Finding 8 (review 2026-07-14): a direct call (no pre-computed
+        # ``detailed``) MUST apply the #313 Saldo-Stichtag itself — mirrors the
+        # push-callers (dashboard.py / admin_users.py), which always compute
+        # this cutoff before calling get_overtime_history_detailed. Without it
+        # the running, unfinished month is compared against a FULL month-Soll
+        # while only month-to-date Ist exists, fabricating a phantom deficit
+        # that eats the FIFO seed and silently drops MILOG_SETTLEMENT_DUE.
+        cutoff = calculation_service.get_soll_cutoff_date(db, user, today=as_of)
+        detailed = calculation_service.get_overtime_history_detailed(
+            db, user, as_of.year, as_of.month, cutoff_date=cutoff
+        )
     if not detailed:
         return None
 

--- a/backend/app/services/ods_export_service.py
+++ b/backend/app/services/ods_export_service.py
@@ -10,7 +10,6 @@ from decimal import Decimal
 from typing import List
 
 from sqlalchemy.orm import Session
-from sqlalchemy import extract
 from odf.opendocument import OpenDocumentSpreadsheet
 from odf.style import Style, TextProperties, TableColumnProperties, TableCellProperties
 from odf.text import P
@@ -176,6 +175,7 @@ def _monthly_sheet(doc, db, user, year, month, bold, normal, include_health_data
     entries_by_date: dict = {}
     for e in db.query(TimeEntry).filter(
         TimeEntry.user_id == user.id,
+        TimeEntry.tenant_id == user.tenant_id,  # F-026
         date_in_month(TimeEntry.date, year, month),
     ).order_by(TimeEntry.start_time).all():
         entries_by_date.setdefault(e.date, []).append(e)
@@ -366,7 +366,7 @@ def _yearly_overview_sheet(doc, db, users, year, bold, include_health_data: bool
     headers = [
         "Mitarbeiter", "Wochenstunden",
         "Soll (Std)", "Ist (Std)", "Saldo (Std)",
-        "Überstunden kum.", "Urlaub (Std)", "Krank (Std)",
+        "Überstunden kum.", "Urlaub (Tage)", "Krank (Tage)",
     ]
     table.addElement(_header_row(headers, bold))
 
@@ -381,22 +381,21 @@ def _yearly_overview_sheet(doc, db, users, year, bold, include_health_data: bool
         )
         overtime = float(calculation_service.get_overtime_account(db, user, year, 12))
 
-        vac_h = sum(
-            float(a.hours)
-            for a in db.query(Absence).filter(
-                Absence.user_id == user.id,
-                Absence.type == AbsenceType.VACATION,
-                date_in_year(Absence.date, year),
-            ).all()
-        )
-        sick_h = sum(
-            float(a.hours)
-            for a in db.query(Absence).filter(
-                Absence.user_id == user.id,
-                Absence.type == AbsenceType.SICK,
-                date_in_year(Absence.date, year),
-            ).all()
-        )
+        # Finding 9 (Review 2026-07-14): Tagesprinzip (§3 BUrlG, #156/#205) — die
+        # TAGE tagebasiert zählen, identisch zum 'Abwesenheiten'-Sheet weiter
+        # unten (absence_days / get_vacation_account), NICHT als Σ(Absence.hours).
+        # Die naive Stundensumme liefert für track_hours=False-MA (Stunden bleiben
+        # 0, s. GLOSSAR) 0 Urlaubs-/Krankheitstage trotz genommener Tage.
+        vac_acc = calculation_service.get_vacation_account(db, user, year)
+        vac_days = round(float(vac_acc["used_days"]), 1)
+
+        sick_absences = db.query(Absence).filter(
+            Absence.user_id == user.id,
+            Absence.tenant_id == user.tenant_id,  # F-026
+            Absence.type == AbsenceType.SICK,
+            date_in_year(Absence.date, year),
+        ).all()
+        sick_days = float(calculation_service.absence_days(db, user, sick_absences).quantize(Decimal('0.1')))
 
         tr = TableRow()
         tr.addElement(_str_cell(f"{user.last_name}, {user.first_name}"))
@@ -405,9 +404,9 @@ def _yearly_overview_sheet(doc, db, users, year, bold, include_health_data: bool
         tr.addElement(_float_cell(actual))
         tr.addElement(_float_cell(actual - target))
         tr.addElement(_float_cell(overtime))
-        tr.addElement(_float_cell(vac_h))
-        # DSGVO F-003: mask sick hours unless health data explicitly requested (Art. 9)
-        tr.addElement(_float_cell(sick_h) if include_health_data else _str_cell("–"))
+        tr.addElement(_float_cell(vac_days))
+        # DSGVO F-003: mask sick days unless health data explicitly requested (Art. 9)
+        tr.addElement(_float_cell(sick_days) if include_health_data else _str_cell("–"))
         table.addElement(tr)
 
 
@@ -490,6 +489,7 @@ def _yearly_employee_sheet(doc, db, user, year, bold, include_health_data: bool 
     entries_by_date: dict = {}
     for e in db.query(TimeEntry).filter(
         TimeEntry.user_id == user.id,
+        TimeEntry.tenant_id == user.tenant_id,  # F-026
         date_in_year(TimeEntry.date, year),
     ).order_by(TimeEntry.start_time).all():
         entries_by_date.setdefault(e.date, []).append(e)
@@ -673,8 +673,10 @@ def _classic_sheet(doc, db, user, year, bold, include_health_data: bool = False)
     # 5 Typ-Queries × 12 Monate plus 12 Monats-Nacht-Queries. In dicts gruppieren;
     # die Monatsschleife schlägt nur noch nach. Identische Werte: pro (Monat, Typ)
     # werden dieselben float(a.hours) summiert; Nacht-Tage bleiben ein Date-Set.
+    # F-026: explicit tenant filter (belt-and-suspenders on top of RLS)
     year_absences = db.query(Absence).filter(
         Absence.user_id == user.id,
+        Absence.tenant_id == user.tenant_id,
         date_in_year(Absence.date, year),
     ).all()
     absence_hours_by_month_type: dict = {}
@@ -684,6 +686,7 @@ def _classic_sheet(doc, db, user, year, bold, include_health_data: bool = False)
 
     year_entries = db.query(TimeEntry).filter(
         TimeEntry.user_id == user.id,
+        TimeEntry.tenant_id == user.tenant_id,
         date_in_year(TimeEntry.date, year),
         TimeEntry.end_time.isnot(None),
     ).all()

--- a/backend/tests/test_absence_cr.py
+++ b/backend/tests/test_absence_cr.py
@@ -349,3 +349,84 @@ class TestAbsenceCRValidationNoReason:
         with pytest.raises(HTTPException) as exc:
             create_change_request(data=data, db=db, current_user=test_user)
         assert exc.value.status_code == 400
+
+
+class TestAbsenceCRFreeSpecialDay:
+    """AC-11 / F-5: die CR-Genehmigung ist ein PARALLELER Buchungspfad zu
+    create_absence/review_vacation_request und muss denselben 'free'-Sondertag-
+    Ausschluss spiegeln — ein 24./31.12. im Modus 'free' ist soll-frei und darf
+    KEINEN vollen Urlaubstag kosten (half_special_day_weight kennt nur half_day=0,5,
+    nicht free=0 → ohne den Fix wurde ein counts_as_vacation=False-Freitag
+    fälschlich als 1,0 Urlaubstage abgerechnet)."""
+
+    def _admin(self, db):
+        return _make_user(db, username="cr_admin_free", email="adminfree@test.de", role=UserRole.ADMIN)
+
+    def _set_free(self, db):
+        from app.models.system_setting import SystemSetting
+        db.add(SystemSetting(
+            key="special_day_dec24_mode", tenant_id=DEFAULT_TENANT_ID, value="free",
+        ))
+        db.add(SystemSetting(
+            key="special_day_dec24_counts_as_vacation", tenant_id=DEFAULT_TENANT_ID, value="false",
+        ))
+        db.commit()
+
+    def test_create_cr_vacation_on_free_day_rejected(self, db):
+        from fastapi import HTTPException
+        from app.routers.admin_change_requests import review_change_request
+        from app.schemas.change_request import ChangeRequestReview
+
+        emp = _make_user(db, username="free_emp_create", email="freeemp1@test.de")
+        admin = self._admin(db)
+        self._set_free(db)
+        d = date(2026, 12, 24)  # Donnerstag, als 'free' konfiguriert
+        cr = _make_absence_cr(
+            db, emp, request_type=ChangeRequestType.CREATE,
+            proposed_date=d, proposed_absence_type="vacation",
+            proposed_absence_hours=8.0,
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            review_change_request(
+                request_id=str(cr.id),
+                review=ChangeRequestReview(action="approve"),
+                db=db, current_user=admin,
+            )
+        assert exc.value.status_code == 400
+
+        # Kein Urlaubstag verbraucht, keine Absence angelegt.
+        acc = calculation_service.get_vacation_account(db, emp, 2026)
+        assert float(acc['used_days']) == 0.0, acc['used_days']
+        assert db.query(Absence).filter(Absence.user_id == emp.id, Absence.date == d).count() == 0
+
+    def test_update_cr_moves_vacation_onto_free_day_rejected(self, db):
+        from fastapi import HTTPException
+        from app.routers.admin_change_requests import review_change_request
+        from app.schemas.change_request import ChangeRequestReview
+
+        emp = _make_user(db, username="free_emp_update", email="freeemp2@test.de")
+        admin = self._admin(db)
+        self._set_free(db)
+        orig_date = date(2026, 12, 23)  # Mittwoch, normaler Arbeitstag
+        free_date = date(2026, 12, 24)  # Donnerstag, 'free'
+        absence = _make_absence(db, emp, orig_date, AbsenceType.VACATION, 8.0)
+
+        cr = _make_absence_cr(
+            db, emp, request_type=ChangeRequestType.UPDATE,
+            absence_id=absence.id,
+            proposed_date=free_date, proposed_absence_type="vacation",
+            proposed_absence_hours=8.0,
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            review_change_request(
+                request_id=str(cr.id),
+                review=ChangeRequestReview(action="approve"),
+                db=db, current_user=admin,
+            )
+        assert exc.value.status_code == 400
+
+        # Absence unverändert am Ursprungsdatum, keine Urlaubs-Umbuchung.
+        db.refresh(absence)
+        assert absence.date == orig_date

--- a/backend/tests/test_closure_resplit_on_private_vacation.py
+++ b/backend/tests/test_closure_resplit_on_private_vacation.py
@@ -187,3 +187,29 @@ def test_booking_private_vacation_runs_resplit_no_spurious_flip(db, default_tena
     db.expire_all()
     # Budget 6, closure 4 + private 1 = 5 ≤ 6 → closure stays all VACATION.
     assert set(_closure_types(db, emp, c["id"]).values()) == {AbsenceType.VACATION}
+
+
+def test_legacy_half_day_none_private_vacation_consumes_hours_over_daily_target(db, default_tenant, admin):
+    """FINDING 1 (review 2026-07-14): a legacy pre-migration-052 private VACATION
+    row (``half_day IS NULL``) must consume ``hours / dt_day`` of the annual
+    budget — exactly like ``calculation_service.get_vacation_account``'s
+    three-way branch — NOT a full day. ``None`` is falsy, so the buggy
+    ``(0.5 if a.half_day else 1.0)`` fell into the ``else`` branch and charged
+    a full day for a half-day-worth legacy booking.
+
+    Budget 3.5, legacy row books 4h of an 8h-Soll day → correct consumption is
+    0.5, leaving 3.0 for the 4-workday closure (3 VACATION + 1 OVERTIME). The
+    pre-fix bug consumes a full day (1.0), leaving only 2.5 (2 VACATION + 2
+    OVERTIME) — wrongly flipping the 3rd, boundary closure day to OVERTIME.
+    """
+    emp2 = _make_user(db, "emp_legacy", vacation_days=3.5)
+    db.add(Absence(user_id=emp2.id, tenant_id=DEFAULT_TENANT_ID, date=date(2027, 1, 5),
+                   type=AbsenceType.VACATION, hours=4.0, half_day=None))
+    db.commit()
+    _set_toggle(db, True)
+    c = _create_closure(_client_as(db, admin))
+    _app.dependency_overrides.clear()
+
+    types = list(_closure_types(db, emp2, c["id"]).values())
+    assert types.count(AbsenceType.VACATION) == 3
+    assert types.count(AbsenceType.OVERTIME) == 1

--- a/backend/tests/test_concurrency.py
+++ b/backend/tests/test_concurrency.py
@@ -12,11 +12,10 @@ from __future__ import annotations
 import os
 import threading
 import uuid
-from datetime import date, time, timezone, datetime
+from datetime import date, time, datetime
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
 
 APP_DB_URL = os.environ.get("APP_DB_URL") or os.environ.get("DATABASE_URL")
 ADMIN_DB_URL = os.environ.get("ADMIN_DB_URL") or os.environ.get("DATABASE_URL_MIGRATIONS")
@@ -30,8 +29,21 @@ if not APP_DB_URL or not ADMIN_DB_URL:
 # F-Review (wrong-test finding): exercise the REAL locking/read code from
 # app/routers/time_entries.py instead of a hand-rolled raw-SQL reimplementation
 # that diverged from it (and silently omitted the F-026 tenant filter).
-from app.models import TimeEntry
-from app.routers.time_entries import _get_open_entry
+#
+# Review 2026-07-14 (fix-A6c): go one step further and call the REAL
+# `clock_in()` endpoint function itself (not just `_get_open_entry`), so the
+# test exercises the User-row anchor lock added in front of it. A bare
+# `SELECT ... FOR UPDATE` on zero matching rows locks nothing under READ
+# COMMITTED — see the long comment in `clock_in` — so calling only
+# `_get_open_entry` would never prove the anchor lock does anything.
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+
+from app.database import SessionLocal, set_tenant_context
+from app.models import User
+from app.routers import time_entries
+from app.schemas.time_entry import ClockInRequest
+from app.services.timezone_service import LOCAL_TZ
 
 
 TENANT_ID = uuid.UUID("ccccccc1-0000-4000-8000-000000000001")
@@ -87,102 +99,121 @@ def concurrency_seed(admin_engine):
     conn.close()
 
 
+# fix-A6c: fixed "today" for both threads, but a DIFFERENT clock-in minute
+# per thread. This deliberately keeps `uq_tenant_user_date_start` (tenant,
+# user, date, start_time) from being able to catch a duplicate — the two
+# inserts have different `start_time` values — so the ONLY thing that can
+# still prevent a double-clock-in here is the User-row anchor lock in
+# `clock_in`. A same-minute race would let the unique constraint mask a
+# missing/removed anchor lock (see fix-A6b-report.md); this test must not
+# depend on that safety net if it is to have teeth against a regression.
+_FAKE_TODAY = date(2099, 6, 1)
+_fake_time_by_thread: dict = {}
+
+
+def _fake_now_local():
+    t = _fake_time_by_thread[threading.get_ident()]
+    return datetime.combine(_FAKE_TODAY, t, tzinfo=LOCAL_TZ)
+
+
+def _fake_today_local():
+    return _FAKE_TODAY
+
+
 def _run_clock_in_attempt(
-    app_engine,
     results: list,
     idx: int,
     barrier: threading.Barrier,
-    with_lock: bool = True,
+    fake_time,
 ):
-    """Run the REAL clock-in read from app/routers/time_entries.py.
+    """Call the REAL `app.routers.time_entries.clock_in()` endpoint function
+    directly (not a reimplementation) so the test exercises everything the
+    endpoint does, including the User-row anchor lock added in front of
+    `_get_open_entry`. `time_entries._now_local`/`_today_local` are
+    monkeypatched module-wide by the test (before threads start) to
+    `_fake_now_local`/`_fake_today_local`; this thread registers its own
+    fixed `fake_time` under its thread-id so both threads land on the same
+    fake "today" but a different minute (see module comment above).
 
-    Calls the actual `_get_open_entry(db, user_id, with_lock=…, tenant_id=…)`
-    used by the `clock_in` endpoint (not a raw-SQL reimplementation), then —
-    mirroring what `clock_in` does on a miss — inserts a new open TimeEntry
-    via the ORM. Both threads use the SAME `start_time`, mirroring the real
-    endpoint's `now().time().replace(second=0, microsecond=0)` truncation:
-    two clock-in attempts racing within the same wall-clock minute (the
-    realistic double-click/retry scenario `VULN-009` targets) compute an
-    identical `start_time`.
-
-    `with_lock` is a test-only knob (default True = the real production call
-    shape). NOTE (verified empirically against real Postgres 18, see
-    fix-A6b-report.md): for this "insert into a possibly-empty table" shape,
-    PostgreSQL's row lock cannot serialize a phantom insert — `FOR UPDATE`
-    only locks rows a query *returns*, and neither racing thread's SELECT
-    ever returns a row here regardless of `with_lock`. The guarantee this
-    test observes (never more than one surviving open entry for a same-
-    minute race) is actually provided by the `uq_tenant_user_date_start`
-    unique constraint, not by `_get_open_entry`'s lock. Flipping `with_lock`
-    does not change this test's outcome — that is expected, not a bug in the
-    test; see the report for the full analysis and the resulting concern.
+    Uses `app.database.SessionLocal` + `set_tenant_context` (the REAL
+    production wiring, not a raw `SET LOCAL` on an ad-hoc sessionmaker):
+    `clock_in` does `db.refresh(entry)` AFTER `db.commit()`, which starts a
+    new transaction, and plain `SET LOCAL` is transaction-scoped — only
+    `SessionLocal`'s `after_begin` event listener (registered in
+    app/database.py) re-applies `app.tenant_id` on that new transaction, so
+    the post-commit refresh still passes RLS.
     """
-    Session = sessionmaker(bind=app_engine)
-    session = Session()
+    session = SessionLocal()
     try:
-        session.execute(text("SET LOCAL app.tenant_id = :tid"), {"tid": str(TENANT_ID)})
-        # Align the two threads so they enter the critical section at nearly
-        # the same instant.
+        set_tenant_context(session, TENANT_ID)
+        current_user = session.query(User).filter(User.id == USER_ID).first()
+        _fake_time_by_thread[threading.get_ident()] = fake_time
+
+        # Align the two threads so they enter clock_in() at nearly the same
+        # instant — this is the actual concurrency being tested.
         barrier.wait(timeout=5)
 
-        # The REAL locking read used by app.routers.time_entries.clock_in.
-        open_entry = _get_open_entry(
-            session, USER_ID, with_lock=with_lock, tenant_id=TENANT_ID,
+        time_entries.clock_in(
+            body=ClockInRequest(note=None), db=session, current_user=current_user,
         )
-
-        if open_entry is not None:
-            # Another thread already opened a row and committed — reject
-            results.append(("rejected", idx))
-            session.rollback()
-            return
-
-        # No open entry, insert one — same as clock_in's TimeEntry(...) + add.
-        entry = TimeEntry(
-            id=uuid.uuid4(),
-            tenant_id=TENANT_ID,
-            user_id=USER_ID,
-            date=date(2099, 6, 1),
-            start_time=time(9, 0),  # same for both threads, see docstring
-            end_time=None,
-            break_minutes=0,
-        )
-        session.add(entry)
-        session.commit()
         results.append(("inserted", idx))
+    except HTTPException as e:
+        # "Bereits eingestempelt" — the expected loser outcome when the
+        # anchor lock correctly serializes the two attempts.
+        session.rollback()
+        results.append(("rejected", idx, e.status_code))
+    except IntegrityError as e:
+        session.rollback()
+        results.append(("error", idx, "IntegrityError"))
     except Exception as e:  # pragma: no cover — surface the failure
         session.rollback()
         results.append(("error", idx, type(e).__name__))
     finally:
+        del _fake_time_by_thread[threading.get_ident()]
         session.close()
 
 
-def test_parallel_clock_in_serializes(app_engine, concurrency_seed, admin_engine):
+def test_parallel_clock_in_serializes(app_engine, concurrency_seed, admin_engine, monkeypatch):
     """
-    Two threads race the REAL `_get_open_entry(..., with_lock=True)` read from
-    app/routers/time_entries.py (not a raw-SQL reimplementation), then insert
-    a new open TimeEntry on a miss — mirroring `clock_in` exactly, including
-    its F-026 tenant filter and its minute-truncated `start_time`. Only ONE
-    of the two racing attempts may survive as an open entry — otherwise the
-    user ends up with two overlapping open entries.
+    Two threads race the REAL `clock_in()` endpoint function from
+    app/routers/time_entries.py (not a raw-SQL reimplementation) for the SAME
+    user, at nearly the same instant, on the same fake "today" but different
+    minutes (so the `uq_tenant_user_date_start` unique constraint cannot mask
+    a broken/missing anchor lock — see module comment above). Only ONE of the
+    two racing attempts may survive as an open entry — otherwise the user
+    ends up with two overlapping open entries, which is exactly the §16
+    double-clock-in gap this test guards against.
+
+    Regression coverage: commenting out the `db.query(User)...with_for_update()`
+    anchor lock in `clock_in` (VULN-009 / review 2026-07-14 fix) makes this
+    test fail with 2 inserted/open entries instead of 1 — verified manually
+    against Postgres 18 as part of the fix, see fix-A6c-report.md.
     """
     # Ensure the user has no open entry before the race starts
     admin = admin_engine.connect()
     admin.execute(text("DELETE FROM time_entries WHERE user_id = :u"), {"u": str(USER_ID)})
     admin.close()
 
+    monkeypatch.setattr(time_entries, "_now_local", _fake_now_local)
+    monkeypatch.setattr(time_entries, "_today_local", _fake_today_local)
+
     results: list = []
     barrier = threading.Barrier(2)
-    t1 = threading.Thread(target=_run_clock_in_attempt, args=(app_engine, results, 1, barrier))
-    t2 = threading.Thread(target=_run_clock_in_attempt, args=(app_engine, results, 2, barrier))
+    t1 = threading.Thread(
+        target=_run_clock_in_attempt, args=(results, 1, barrier, time(9, 0)),
+    )
+    t2 = threading.Thread(
+        target=_run_clock_in_attempt, args=(results, 2, barrier, time(9, 1)),
+    )
     t1.start(); t2.start(); t1.join(); t2.join()
 
     outcomes = [r[0] for r in results]
     inserted = outcomes.count("inserted")
     errored = [r for r in results if r[0] == "error"]
-    # The loser must be rejected either by the application-level open-entry
-    # check (outcome "rejected") or by the DB's uq_tenant_user_date_start
-    # unique constraint (outcome "error" / IntegrityError) — never a silent
-    # duplicate and never an unrelated crash.
+    # The loser must be rejected either by the application-level "Bereits
+    # eingestempelt" check (outcome "rejected") or, as a defense-in-depth
+    # backstop, by a DB-level unique/exclusion violation (outcome "error" /
+    # IntegrityError) — never a silent duplicate and never an unrelated crash.
     for r in errored:
         assert r[2] == "IntegrityError", f"Unexpected error type on loser thread: {r}"
     assert inserted == 1, f"Expected exactly 1 insert, got outcomes={outcomes}"

--- a/backend/tests/test_concurrency.py
+++ b/backend/tests/test_concurrency.py
@@ -27,6 +27,12 @@ if not APP_DB_URL or not ADMIN_DB_URL:
         allow_module_level=True,
     )
 
+# F-Review (wrong-test finding): exercise the REAL locking/read code from
+# app/routers/time_entries.py instead of a hand-rolled raw-SQL reimplementation
+# that diverged from it (and silently omitted the F-026 tenant filter).
+from app.models import TimeEntry
+from app.routers.time_entries import _get_open_entry
+
 
 TENANT_ID = uuid.UUID("ccccccc1-0000-4000-8000-000000000001")
 USER_ID = uuid.UUID("ccccccc1-0000-4000-8000-000000000100")
@@ -81,12 +87,35 @@ def concurrency_seed(admin_engine):
     conn.close()
 
 
-def _run_clock_in_attempt(app_engine, results: list, idx: int, barrier: threading.Barrier):
-    """Simulate the clock-in sequence from app/routers/time_entries.py with row lock.
+def _run_clock_in_attempt(
+    app_engine,
+    results: list,
+    idx: int,
+    barrier: threading.Barrier,
+    with_lock: bool = True,
+):
+    """Run the REAL clock-in read from app/routers/time_entries.py.
 
-    Mirrors `_get_open_entry(..., with_lock=True)` followed by an INSERT for a
-    new open entry. Both threads race — the row-lock acquired by whichever
-    thread enters the CRITICAL section first should serialize the second.
+    Calls the actual `_get_open_entry(db, user_id, with_lock=…, tenant_id=…)`
+    used by the `clock_in` endpoint (not a raw-SQL reimplementation), then —
+    mirroring what `clock_in` does on a miss — inserts a new open TimeEntry
+    via the ORM. Both threads use the SAME `start_time`, mirroring the real
+    endpoint's `now().time().replace(second=0, microsecond=0)` truncation:
+    two clock-in attempts racing within the same wall-clock minute (the
+    realistic double-click/retry scenario `VULN-009` targets) compute an
+    identical `start_time`.
+
+    `with_lock` is a test-only knob (default True = the real production call
+    shape). NOTE (verified empirically against real Postgres 18, see
+    fix-A6b-report.md): for this "insert into a possibly-empty table" shape,
+    PostgreSQL's row lock cannot serialize a phantom insert — `FOR UPDATE`
+    only locks rows a query *returns*, and neither racing thread's SELECT
+    ever returns a row here regardless of `with_lock`. The guarantee this
+    test observes (never more than one surviving open entry for a same-
+    minute race) is actually provided by the `uq_tenant_user_date_start`
+    unique constraint, not by `_get_open_entry`'s lock. Flipping `with_lock`
+    does not change this test's outcome — that is expected, not a bug in the
+    test; see the report for the full analysis and the resulting concern.
     """
     Session = sessionmaker(bind=app_engine)
     session = Session()
@@ -96,52 +125,45 @@ def _run_clock_in_attempt(app_engine, results: list, idx: int, barrier: threadin
         # the same instant.
         barrier.wait(timeout=5)
 
-        # SELECT … FOR UPDATE on the user's open entries
-        row = session.execute(
-            text(
-                "SELECT id FROM time_entries "
-                "WHERE user_id = :uid AND end_time IS NULL "
-                "FOR UPDATE"
-            ),
-            {"uid": str(USER_ID)},
-        ).fetchone()
+        # The REAL locking read used by app.routers.time_entries.clock_in.
+        open_entry = _get_open_entry(
+            session, USER_ID, with_lock=with_lock, tenant_id=TENANT_ID,
+        )
 
-        if row is not None:
+        if open_entry is not None:
             # Another thread already opened a row and committed — reject
             results.append(("rejected", idx))
             session.rollback()
             return
 
-        # No open entry, insert one
-        new_id = uuid.uuid4()
-        session.execute(
-            text(
-                "INSERT INTO time_entries (id, tenant_id, user_id, date, "
-                "  start_time, break_minutes) "
-                "VALUES (:id, :tid, :uid, :dt, :st, 0)"
-            ),
-            {
-                "id": str(new_id),
-                "tid": str(TENANT_ID),
-                "uid": str(USER_ID),
-                "dt": date(2099, 6, 1),
-                "st": time(9, 0),
-            },
+        # No open entry, insert one — same as clock_in's TimeEntry(...) + add.
+        entry = TimeEntry(
+            id=uuid.uuid4(),
+            tenant_id=TENANT_ID,
+            user_id=USER_ID,
+            date=date(2099, 6, 1),
+            start_time=time(9, 0),  # same for both threads, see docstring
+            end_time=None,
+            break_minutes=0,
         )
+        session.add(entry)
         session.commit()
         results.append(("inserted", idx))
     except Exception as e:  # pragma: no cover — surface the failure
         session.rollback()
-        results.append(("error", idx, str(e)))
+        results.append(("error", idx, type(e).__name__))
     finally:
         session.close()
 
 
 def test_parallel_clock_in_serializes(app_engine, concurrency_seed, admin_engine):
     """
-    Two threads try to create an open time entry simultaneously. The row-lock
-    must serialise them so that only ONE insert succeeds — otherwise the user
-    ends up with two overlapping open entries.
+    Two threads race the REAL `_get_open_entry(..., with_lock=True)` read from
+    app/routers/time_entries.py (not a raw-SQL reimplementation), then insert
+    a new open TimeEntry on a miss — mirroring `clock_in` exactly, including
+    its F-026 tenant filter and its minute-truncated `start_time`. Only ONE
+    of the two racing attempts may survive as an open entry — otherwise the
+    user ends up with two overlapping open entries.
     """
     # Ensure the user has no open entry before the race starts
     admin = admin_engine.connect()
@@ -155,9 +177,14 @@ def test_parallel_clock_in_serializes(app_engine, concurrency_seed, admin_engine
     t1.start(); t2.start(); t1.join(); t2.join()
 
     outcomes = [r[0] for r in results]
-    # Exactly one should have inserted, exactly one should have been rejected
-    # (or errored on the unique lock — acceptable). Two inserts = bug.
     inserted = outcomes.count("inserted")
+    errored = [r for r in results if r[0] == "error"]
+    # The loser must be rejected either by the application-level open-entry
+    # check (outcome "rejected") or by the DB's uq_tenant_user_date_start
+    # unique constraint (outcome "error" / IntegrityError) — never a silent
+    # duplicate and never an unrelated crash.
+    for r in errored:
+        assert r[2] == "IntegrityError", f"Unexpected error type on loser thread: {r}"
     assert inserted == 1, f"Expected exactly 1 insert, got outcomes={outcomes}"
 
     # Verify DB state: exactly one open entry

--- a/backend/tests/test_export_service.py
+++ b/backend/tests/test_export_service.py
@@ -347,3 +347,47 @@ class TestAbsencesOverviewDayBased:
         self._absence(db, user_b, date(2026, 1, 12), AbsenceType.VACATION, 0)
         wb, data = _load_xlsx(generate_yearly_report(db, 2026))
         assert "Abwesenheiten" in wb.sheetnames
+
+
+class TestXlsxMultiAbsenceDay:
+    """Finding 13 (Export-Review 2026-07-14): parity with
+    TestOdsMultiAbsenceDay (test_ods_export_service.py) — the XLSX detail
+    sheet must also render BOTH absences of a mixed day (½ Urlaub + ½
+    Sonstiges), not just the first. `_create_employee_sheet` groups Absences
+    per date into a LIST (I-1/#219) precisely to avoid this; this test would
+    catch a regression to the old date-dict keying on the XLSX side too."""
+
+    def test_monthly_renders_both_absences_on_multitype_day(self, db, test_user):
+        from datetime import datetime as _dt
+        from app.models import Absence, AbsenceType
+
+        db.add(Absence(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID,
+                       date=date(2026, 3, 4), type=AbsenceType.VACATION, hours=4))
+        db.add(Absence(user_id=test_user.id, tenant_id=DEFAULT_TENANT_ID,
+                       date=date(2026, 3, 4), type=AbsenceType.OTHER, hours=4))
+        db.commit()
+
+        result = generate_monthly_report(db, 2026, 3, include_health_data=True)
+        wb, _ = _load_xlsx(result)
+        ws = next(
+            (wb[name] for name in wb.sheetnames if test_user.last_name in name),
+            wb[wb.sheetnames[0]],
+        )
+
+        # Locate the 2026-03-04 row by content (robust against row-offset
+        # drift) rather than a whole-sheet substring search — the sheet's own
+        # "Urlaub genommen (Std):" summary row would satisfy a naive
+        # "Urlaub" in flat-text check regardless of the day-row's content.
+        target_row = None
+        for row in ws.iter_rows(values_only=False):
+            cell0 = row[0].value
+            cell0_date = cell0.date() if isinstance(cell0, _dt) else cell0
+            if cell0_date == date(2026, 3, 4):
+                target_row = row
+                break
+        assert target_row is not None, "no row found for 2026-03-04"
+
+        abwesenheit_cell = target_row[8].value or ""  # Spalte 9 (0-indexed 8) = Abwesenheit
+        assert "Urlaub" in abwesenheit_cell and "Sonstiges" in abwesenheit_cell, (
+            f"mixed-day row must show BOTH absence labels, got: {abwesenheit_cell!r}"
+        )

--- a/backend/tests/test_fix2_whchange_daily_schedule.py
+++ b/backend/tests/test_fix2_whchange_daily_schedule.py
@@ -70,3 +70,50 @@ def test_whchange_ok_for_normal_user(db, default_tenant):
     assert float(result.weekly_hours) == 20.0
     n = db.query(WorkingHoursChange).filter(WorkingHoursChange.user_id == emp.id).count()
     assert n == 1
+
+
+# ---------------------------------------------------------------------------
+# Finding 4 (HIGH, Review 2026-07-14): die Session ist autoflush=False. Ohne ein
+# db.flush() nach db.add(change) UND VOR der Most-Recent-Selbstabfrage sieht
+# diese Abfrage die gerade hinzugefügte Zeile nicht → user.weekly_hours bleibt
+# beim ersten rückwirkenden Antrag unverändert bzw. übernimmt bei einer
+# zweiten, überholenden Änderung den VORHERIGEN statt den neuen Wert.
+# ---------------------------------------------------------------------------
+
+def test_whchange_first_past_dated_change_updates_weekly_hours(db, default_tenant):
+    """Die allererste rückwirkende (effective_from <= heute) Stundenänderung muss
+    user.weekly_hours SOFORT auf den neuen Wert setzen."""
+    admin = _admin(db)
+    emp = _make_user(db, "wh_first", weekly_hours=40.0)
+    result = create_working_hours_change(
+        user_id=str(emp.id),
+        change_data=WorkingHoursChangeCreate(
+            effective_from=date(2020, 1, 1), weekly_hours=20.0,
+        ),
+        db=db, current_user=admin,
+    )
+    assert float(result.weekly_hours) == 20.0
+    assert float(emp.weekly_hours) == 20.0
+
+
+def test_whchange_second_superseding_change_updates_to_new_value(db, default_tenant):
+    """Eine zweite, spätere rückwirkende Änderung muss user.weekly_hours auf
+    IHREN Wert setzen — nicht auf den der ersten (bereits committeten) Änderung."""
+    admin = _admin(db)
+    emp = _make_user(db, "wh_second", weekly_hours=40.0)
+    create_working_hours_change(
+        user_id=str(emp.id),
+        change_data=WorkingHoursChangeCreate(
+            effective_from=date(2020, 1, 1), weekly_hours=20.0,
+        ),
+        db=db, current_user=admin,
+    )
+    result = create_working_hours_change(
+        user_id=str(emp.id),
+        change_data=WorkingHoursChangeCreate(
+            effective_from=date(2020, 6, 1), weekly_hours=30.0,
+        ),
+        db=db, current_user=admin,
+    )
+    assert float(result.weekly_hours) == 30.0
+    assert float(emp.weekly_hours) == 30.0

--- a/backend/tests/test_milog.py
+++ b/backend/tests/test_milog.py
@@ -413,6 +413,44 @@ def test_settlement_aging_full_current_month_soll_eats_seed(db, employee, monkey
     assert res is not None and res["overdue"] is True and abs(res["hours"] - 8.0) < 0.01
 
 
+def test_settlement_aging_direct_call_applies_313_cutoff(db, employee):
+    """FINDING 8 (review 2026-07-14): a DIRECT ``settlement_aging`` call (no
+    ``detailed`` passed by the caller) must apply the #313 Saldo-Stichtag
+    itself — otherwise the running, unfinished month is compared against a
+    FULL month-Soll while only month-to-date Ist exists, fabricating a phantom
+    deficit that eats the FIFO seed and silently drops MILOG_SETTLEMENT_DUE.
+    Real integration (NO monkeypatch of get_overtime_history_detailed): the
+    employee is only employed from 2026-06-01, has an 8h carryover seed
+    (year=2025 → dated 2024-12, age 18 months → overdue), and has clocked
+    exactly the daily target on every workday from 2026-06-01 up to (but not
+    including) 2026-06-15 — i.e. Soll==Ist up to the #313 cutoff (2026-06-14).
+    Without the cutoff, the FULL June Soll (through 06-30) is compared against
+    the partial Ist → a deficit > 8h wipes the seed → None.
+    """
+    from datetime import time as _time, timedelta
+    from app.models import TimeEntry
+
+    employee.milog_working_time_account = True
+    employee.weekly_hours = Decimal("40")
+    employee.work_days_per_week = 5
+    employee.first_work_day = date(2026, 6, 1)
+    db.commit()
+    db.add(YearCarryover(tenant_id=DEFAULT_TENANT_ID, user_id=employee.id, year=2025,
+                         overtime_hours=Decimal("8"), vacation_days=Decimal("0")))
+    d = date(2026, 6, 1)
+    while d < date(2026, 6, 15):
+        if d.weekday() < 5:
+            db.add(TimeEntry(tenant_id=DEFAULT_TENANT_ID, user_id=employee.id, date=d,
+                             start_time=_time(8, 0), end_time=_time(16, 0), break_minutes=0))
+        d += timedelta(days=1)
+    db.commit()
+
+    res = milog_service.settlement_aging(db, employee, date(2026, 6, 15))
+    assert res is not None, "phantom deficit from the untrimmed running month ate the FIFO seed"
+    assert res["overdue"] is True
+    assert abs(res["hours"] - 8.0) < 0.01
+
+
 def test_users_overview_feeds_settlement_cutoff_trimmed_detail(db, admin, employee, monkeypatch):
     """#377 Regression: die Admin-Benutzerübersicht MUSS get_overtime_history_detailed
     MIT dem Saldo-Stichtag aufrufen (Parität zum MA-Dashboard, #313). Ohne cutoff

--- a/backend/tests/test_ods_export_service.py
+++ b/backend/tests/test_ods_export_service.py
@@ -243,6 +243,80 @@ class TestAbsencesOverviewDayBased:
         assert b_rest == round(float(acc_b["remaining_days"]), 1)
 
 
+class TestYearlyOverviewDayBased:
+    """Finding 9 (Review 2026-07-14): die ODS-Jahresübersicht ('Jahresübersicht'-
+    Sheet, generate_yearly_report) muss Urlaub/Krank TAGEBASIERT zählen — exakt
+    wie das 'Abwesenheiten'-Sheet im selben Workbook (absence_days /
+    get_vacation_account['used_days']) — statt Σ(Absence.hours). Die naive
+    Stundensumme liefert für track_hours=False-MA (Stunden bleiben 0, s. GLOSSAR)
+    fälschlich 0 Urlaubs-/Krankheitstage trotz genommener Tage."""
+
+    def _untracked_user(self, db):
+        from app.models import User, UserRole
+        from app.services import auth_service
+        u = User(
+            username="ods_yov_untracked", email="ods_yov_untracked@example.com",
+            password_hash=auth_service.hash_password("x12345678"),
+            first_name="Lei", last_name="Tendya", role=UserRole.EMPLOYEE,
+            weekly_hours=40.0, work_days_per_week=5, vacation_days=30,
+            is_active=True, tenant_id=DEFAULT_TENANT_ID, track_hours=False,
+        )
+        db.add(u)
+        db.commit()
+        db.refresh(u)
+        return u
+
+    def _absence(self, db, user, d, typ, hours, half_day=False):
+        a = Absence(
+            user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+            type=typ, hours=hours, half_day=half_day,
+        )
+        db.add(a)
+        db.commit()
+        return a
+
+    def _overview_cell(self, doc, last_name):
+        """(Urlaub, Krank) aus der 'Jahresübersicht'-Tabelle für die Datenzeile
+        des MA (Spalte 7 = Urlaub, Spalte 8 = Krank, 0-indexed cells[6]/[7])."""
+        from odf.table import Table, TableRow, TableCell
+        from odf.teletype import extractText
+        table = [t for t in doc.spreadsheet.getElementsByType(Table)
+                 if t.getAttribute("name") == "Jahresübersicht"][0]
+        for row in table.getElementsByType(TableRow):
+            cells = row.getElementsByType(TableCell)
+            if cells and last_name in extractText(cells[0]):
+                return (float(cells[6].getAttribute("value")),
+                        float(cells[7].getAttribute("value")))
+        raise AssertionError(f"keine Zeile für {last_name}")
+
+    def test_overview_vacation_sick_are_day_based_for_untracked_user(self, db, default_tenant):
+        from app.services import calculation_service
+        from app.services.ods_export_service import _yearly_overview_sheet, _doc_with_styles
+
+        user = self._untracked_user(db)
+        # track_hours=False → gebuchte Absence.hours sind 0 (GLOSSAR), aber es
+        # SIND echte Tage: 1 voller Urlaubstag + 1 halber Urlaubstag + 1 voller
+        # Krankheitstag.
+        self._absence(db, user, date(2026, 1, 12), AbsenceType.VACATION, 0)
+        self._absence(db, user, date(2026, 1, 13), AbsenceType.VACATION, 0, half_day=True)
+        self._absence(db, user, date(2026, 1, 14), AbsenceType.SICK, 0)
+
+        doc, bold, _normal = _doc_with_styles()
+        _yearly_overview_sheet(doc, db, [user], 2026, bold, include_health_data=True)
+
+        vac, sick = self._overview_cell(doc, "Tendya")
+
+        acc = calculation_service.get_vacation_account(db, user, 2026)
+        assert vac == round(float(acc["used_days"]), 1) == 1.5, (
+            f"Urlaub-Spalte muss tagebasiert sein (1,5 Tage wie das Abwesenheiten-"
+            f"Sheet/get_vacation_account), nicht Σh (0h für track_hours=False); bekam {vac}"
+        )
+        assert sick == 1.0, (
+            f"Krank-Spalte muss tagebasiert sein (1 Tag wie absence_days), nicht "
+            f"Σh (0h für track_hours=False); bekam {sick}"
+        )
+
+
 class TestOdsMultiAbsenceDay:
     def test_monthly_renders_both_absences_on_multitype_day(self, db, test_user):
         # Regression: die ODS-Detailsheets keyten Absences per date-dict → der 2.

--- a/backend/tests/test_ods_export_service.py
+++ b/backend/tests/test_ods_export_service.py
@@ -46,6 +46,23 @@ def _mk_absence(db, user, d, typ=AbsenceType.VACATION, hours=8):
     return a
 
 
+def _find_row_cells(doc, table_name, first_cell_text):
+    """Load a specific TableRow by its literal first-cell text (e.g. a
+    "DD.MM.YYYY" date string) from a named Table inside a parsed ODS `doc`
+    and return all its cell texts. Row-precise counterpart to whole-content
+    substring search — a day-row assertion must not be satisfiable by an
+    unrelated summary row that happens to contain the same words."""
+    from odf.table import Table, TableRow, TableCell
+    from odf.teletype import extractText
+    table = [t for t in doc.spreadsheet.getElementsByType(Table)
+             if t.getAttribute("name") == table_name][0]
+    for row in table.getElementsByType(TableRow):
+        cells = row.getElementsByType(TableCell)
+        if cells and extractText(cells[0]) == first_cell_text:
+            return [extractText(c) for c in cells]
+    raise AssertionError(f"no row with first cell {first_cell_text!r} in table {table_name!r}")
+
+
 class TestGenerateMonthlyOdsReport:
 
     def test_returns_bytesio_with_ods_magic(self, db, test_user):
@@ -73,18 +90,73 @@ class TestGenerateMonthlyOdsReport:
         assert data[:2] == ODS_PK_MAGIC
 
     def test_include_health_data_emits_sick_hours(self, db, test_user):
+        """DSGVO Art. 9 positive case: with include_health_data=True the sick
+        absence must be IDENTIFIABLE — label "Krank" + hours must actually
+        appear in content.xml, not just a valid zip envelope."""
+        import zipfile
         _mk_absence(db, test_user, date(2026, 1, 8), AbsenceType.SICK, 8)
-        # include_health_data=True should not crash
         out = generate_monthly_report(db, 2026, 1, include_health_data=True)
-        assert out.read()[:2] == ODS_PK_MAGIC
+        data = out.read()
+        assert data[:2] == ODS_PK_MAGIC
+        with zipfile.ZipFile(BytesIO(data)) as zf:
+            content = zf.read("content.xml").decode("utf-8", errors="replace")
+        assert "Krank (8.0h)" in content, (
+            "sick label+hours missing from content.xml despite include_health_data=True"
+        )
 
     def test_excludes_sick_leaks_when_health_data_false(self, db, test_user):
         """DSGVO Art. 9: sick absences must not be identifiable by type when
         the admin did not opt into health-data disclosure."""
+        import zipfile
         _mk_absence(db, test_user, date(2026, 1, 8), AbsenceType.SICK, 8)
         out = generate_monthly_report(db, 2026, 1, include_health_data=False)
         data = out.read()
         assert data[:2] == ODS_PK_MAGIC
+        with zipfile.ZipFile(BytesIO(data)) as zf:
+            content = zf.read("content.xml").decode("utf-8", errors="replace")
+        assert "Krank" not in content, (
+            "sick type leaked into content.xml despite include_health_data=False"
+        )
+        assert "Abwesenheit (8.0h)" in content, (
+            "masked label 'Abwesenheit (8.0h)' missing from content.xml"
+        )
+
+    def test_holiday_tenant_scoped(self, db, test_user):
+        """Holidays in the tenant's own set must appear; others must not
+        leak into the export (regression test for the tenant_id-filter fix).
+
+        Uses generate_monthly_report — NOT generate_yearly_report_classic,
+        which never renders a holiday NAME at all (only _monthly_sheet /
+        _yearly_employee_sheet put `holiday.name` into the Abwesenheit
+        column); testing tenant-scoping against the classic report would
+        assert against a function that structurally can't leak the name."""
+        import zipfile
+        from app.models.tenant import Tenant
+
+        other_tenant = Tenant(name="Andere Praxis", slug="andere-praxis-ods-holiday")
+        db.add(other_tenant)
+        db.commit()
+        db.refresh(other_tenant)
+
+        # Holiday for the current tenant
+        db.add(PublicHoliday(
+            date=date(2026, 5, 1), name="Tag der Arbeit (eigene)",
+            year=2026, tenant_id=DEFAULT_TENANT_ID,
+        ))
+        # Same date, a DIFFERENT tenant's holiday with a distinguishable name.
+        db.add(PublicHoliday(
+            date=date(2026, 5, 1), name="Fremdfeiertag XYZ",
+            year=2026, tenant_id=other_tenant.id,
+        ))
+        db.commit()
+
+        out = generate_monthly_report(db, 2026, 5)
+        data = out.read()
+        assert data[:2] == ODS_PK_MAGIC
+        with zipfile.ZipFile(BytesIO(data)) as zf:
+            content = zf.read("content.xml").decode("utf-8", errors="replace")
+        assert "Tag der Arbeit (eigene)" in content, "own tenant's holiday missing from export"
+        assert "Fremdfeiertag XYZ" not in content, "other tenant's holiday leaked into export"
 
 
 class TestGenerateYearlyOdsReport:
@@ -106,23 +178,6 @@ class TestGenerateYearlyClassicOdsReport:
     def test_returns_valid_ods(self, db, test_user):
         out = generate_yearly_report_classic(db, 2026)
         assert out.read()[:2] == ODS_PK_MAGIC
-
-    def test_holiday_tenant_scoped(self, db, test_user):
-        """Holidays in the tenant's own set must appear; others must not
-        leak into the export (regression test for the tenant_id-filter fix)."""
-        # Holiday for the current tenant
-        h_own = PublicHoliday(
-            date=date(2026, 5, 1),
-            name="Tag der Arbeit (eigene)",
-            year=2026,
-            tenant_id=DEFAULT_TENANT_ID,
-        )
-        db.add(h_own)
-        db.commit()
-
-        out = generate_yearly_report_classic(db, 2026)
-        data = out.read()
-        assert data[:2] == ODS_PK_MAGIC
 
 
 class TestFormulaInjection:
@@ -321,13 +376,43 @@ class TestOdsMultiAbsenceDay:
     def test_monthly_renders_both_absences_on_multitype_day(self, db, test_user):
         # Regression: die ODS-Detailsheets keyten Absences per date-dict → der 2.
         # Eintrag eines Misch-Tags (½ Urlaub + ½ Sonstiges) ging verloren.
-        import zipfile
+        #
+        # A whole-content substring search ("Urlaub" in content and "Sonstiges"
+        # in content) is defeated by the sheet's own unconditional summary rows
+        # ("Urlaub genommen (Std):" / "Urlaub Rest (Std):" always contain
+        # "Urlaub" regardless of whether the day-row itself renders it) — so it
+        # would stay green even if the 2nd absence of the mixed day were lost
+        # again. Locate the SPECIFIC day-row instead and assert both labels are
+        # in ITS Abwesenheit cell.
+        from odf.opendocument import load
         _mk_absence(db, test_user, date(2026, 3, 4), AbsenceType.VACATION, hours=4)
         _mk_absence(db, test_user, date(2026, 3, 4), AbsenceType.OTHER, hours=4)
         out = generate_monthly_report(db, 2026, 3, include_health_data=True)
-        with zipfile.ZipFile(out) as zf:
-            content = zf.read("content.xml").decode("utf-8", errors="replace")
-        assert "Urlaub" in content and "Sonstiges" in content
+        doc = load(out)
+        table_name = f"{test_user.last_name} {test_user.first_name}"[:31]
+        cells = _find_row_cells(doc, table_name, "04.03.2026")
+        abwesenheit_cell = cells[8]  # Spalte 9 (0-indexed 8) = Abwesenheit
+        assert "Urlaub" in abwesenheit_cell and "Sonstiges" in abwesenheit_cell, (
+            f"mixed-day row must show BOTH absence labels, got: {abwesenheit_cell!r}"
+        )
+
+    def test_yearly_employee_sheet_renders_both_absences_on_multitype_day(self, db, test_user):
+        """Finding 13 parity: the ODS yearly-employee day-grid
+        (_yearly_employee_sheet, used by generate_yearly_report) must render
+        BOTH absences of a mixed day too — same bug class/fix as the monthly
+        sheet above, but a separate code path (own day-loop, own
+        _absence_cell_parts call)."""
+        from odf.opendocument import load
+        _mk_absence(db, test_user, date(2026, 3, 4), AbsenceType.VACATION, hours=4)
+        _mk_absence(db, test_user, date(2026, 3, 4), AbsenceType.OTHER, hours=4)
+        out = generate_yearly_report(db, 2026, include_health_data=True)
+        doc = load(out)
+        table_name = f"{test_user.last_name} {test_user.first_name}"[:31]
+        cells = _find_row_cells(doc, table_name, "04.03.2026")
+        abwesenheit_cell = cells[8]
+        assert "Urlaub" in abwesenheit_cell and "Sonstiges" in abwesenheit_cell, (
+            f"mixed-day row must show BOTH absence labels, got: {abwesenheit_cell!r}"
+        )
 
     def test_classic_has_overtime_column(self, db, test_user):
         import zipfile

--- a/backend/tests/test_paid_leave_reports.py
+++ b/backend/tests/test_paid_leave_reports.py
@@ -96,6 +96,98 @@ def test_yearly_absences_endpoint_includes_paid_leave(db, test_user, test_admin)
     assert row["total_days"] == pytest.approx(5.0)
 
 
+# ---------------------------------------------------------------------------
+# Finding 2 (HIGH, Review 2026-07-14): yearly-absences zählte SICK/TRAINING/
+# OVERTIME/OTHER/PAID_LEAVE naiv Σh ÷ Ø-Tagessoll statt tagebasiert wie
+# absence_days/get_vacation_account. Das war für track_hours=False-MA (Stunden
+# immer 0 → immer 0.0 Tage trotz gebuchter Abwesenheit) und für ungleichmäßige
+# Tagespläne (Drift ggü. dem tatsächlichen Tagesprinzip §3 BUrlG) falsch.
+# ---------------------------------------------------------------------------
+
+def test_yearly_absences_sick_days_track_hours_false(db, test_admin):
+    """Ein track_hours=False-MA (z. B. leitender Angestellter, #191) hat
+    Absence.hours == 0 (keine Stundenzählung). Trotzdem müssen 2 gebuchte
+    SICK-Tage als 2.0 Tage erscheinen — nicht 0.0 (naive Σ0h ÷ Tagessoll)."""
+    import uuid as _uuid
+    from app.models import User, UserRole
+    from app.services import auth_service as _auth
+
+    untracked = User(
+        id=_uuid.uuid4(), username="untracked_sick", email="untracked_sick@t.local",
+        password_hash=_auth.hash_password("Test2025!Password"),
+        first_name="Chef", last_name="Ohne", role=UserRole.EMPLOYEE,
+        weekly_hours=40.0, vacation_days=30, work_days_per_week=5,
+        is_active=True, tenant_id=DEFAULT_TENANT_ID, track_hours=False,
+    )
+    db.add(untracked)
+    db.commit()
+
+    _mk_absence(db, untracked, date(YEAR, 3, 2), AbsenceType.SICK, hours=0.0)
+    _mk_absence(db, untracked, date(YEAR, 3, 3), AbsenceType.SICK, hours=0.0)
+
+    def override_db():
+        yield db
+
+    _app.dependency_overrides[get_db] = override_db
+    _app.dependency_overrides[get_current_user] = lambda: test_admin
+    _app.dependency_overrides[require_admin] = lambda: test_admin
+    try:
+        client = TestClient(_app)
+        resp = client.get(
+            f"/api/admin/reports/yearly-absences?year={YEAR}&include_health_data=true"
+        )
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()
+    finally:
+        _app.dependency_overrides.clear()
+
+    row = next(r for r in rows if r["user_id"] == str(untracked.id))
+    assert row["sick_days"] == pytest.approx(2.0)
+
+
+def test_yearly_absences_sick_days_uneven_schedule_no_drift(db, test_admin):
+    """Ein MA mit ungleichmäßigem Tagesplan (Mo 8h, Di–Fr 3h, use_daily_schedule)
+    hat einen abweichenden Ø-Tagessoll (20h/5=4h). Ein Montag-Krank-Tag (8h) muss
+    GENAU 1,0 Tag zählen (Tagesprinzip) — die naive Methode teilt 8h ÷ 4h und
+    liefert fälschlich 2,0."""
+    import uuid as _uuid
+    from app.models import User, UserRole
+    from app.services import auth_service as _auth
+
+    uneven = User(
+        id=_uuid.uuid4(), username="uneven_sick", email="uneven_sick@t.local",
+        password_hash=_auth.hash_password("Test2025!Password"),
+        first_name="Uneven", last_name="Schedule", role=UserRole.EMPLOYEE,
+        weekly_hours=20.0, vacation_days=30, work_days_per_week=5,
+        is_active=True, tenant_id=DEFAULT_TENANT_ID, track_hours=True,
+        use_daily_schedule=True,
+        hours_monday=8, hours_tuesday=3, hours_wednesday=3, hours_thursday=3, hours_friday=3,
+    )
+    db.add(uneven)
+    db.commit()
+
+    _mk_absence(db, uneven, date(YEAR, 3, 2), AbsenceType.SICK, hours=8.0)  # Montag
+
+    def override_db():
+        yield db
+
+    _app.dependency_overrides[get_db] = override_db
+    _app.dependency_overrides[get_current_user] = lambda: test_admin
+    _app.dependency_overrides[require_admin] = lambda: test_admin
+    try:
+        client = TestClient(_app)
+        resp = client.get(
+            f"/api/admin/reports/yearly-absences?year={YEAR}&include_health_data=true"
+        )
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()
+    finally:
+        _app.dependency_overrides.clear()
+
+    row = next(r for r in rows if r["user_id"] == str(uneven.id))
+    assert row["sick_days"] == pytest.approx(1.0)
+
+
 def test_monthly_report_reports_vacation_and_sick_in_days(db, test_user, test_admin):
     """Bug-Fix: die Monatsübersicht muss Urlaub/Krank auch in TAGEN liefern (nicht
     nur in Stunden), damit die Anzeige Tage zeigen kann. Krank ist ohne

--- a/backend/tests/test_vacation_request_edit.py
+++ b/backend/tests/test_vacation_request_edit.py
@@ -572,6 +572,73 @@ class TestPostBudgetExcludesHolidays:
         assert resp.status_code == 201, resp.text
 
 
+# ===========================================================================
+# Finding 10: POST + PATCH Budget-Check müssen 'free'-Sondertage (24./31.12.)
+# genau wie Feiertage ausschließen — AC-11-Parität mit
+# admin_vacations.review_vacation_request (holidays |=
+# special_days_service.free_special_days_in_range(...)). Ohne den Ausschluss
+# zählt ein soll-freier Sondertag fälschlich als verbrauchter Urlaubstag und
+# ein Antrag über einen Bereich mit 24./31.12. wird false-positiv als
+# "nicht genügend Urlaubstage" abgelehnt.
+# ===========================================================================
+
+def _set_special_day_free(db, key_prefix="special_day_dec24", counts_as_vacation="false"):
+    from app.models.system_setting import SystemSetting
+    db.add(SystemSetting(key=f"{key_prefix}_mode", tenant_id=DEFAULT_TENANT_ID, value="free"))
+    db.add(SystemSetting(
+        key=f"{key_prefix}_counts_as_vacation", tenant_id=DEFAULT_TENANT_ID,
+        value=counts_as_vacation,
+    ))
+    db.commit()
+
+
+class TestPostBudgetExcludesFreeSpecialDay:
+    """F-10 (POST): Budget = 4 Tage, Bereich Mo 21.12.–Fr 25.12.2026 = 5
+    Wochentage, davon 24.12. als 'free' konfiguriert → 4 billable Tage.
+    Ohne den Ausschluss zählt der Check 5 > 4 → 400 (false positive)."""
+
+    def test_request_spanning_free_day_fits_budget(self, db, default_tenant):
+        _enable_approval(db)
+        user = _user_custom(db, "budgetfree", vacation_days=4)
+        client_gen = _make_client(db, user)
+        client = next(client_gen)
+        _set_special_day_free(db)
+
+        resp = client.post("/api/vacation-requests/", json={
+            "date": "2026-12-21",
+            "end_date": "2026-12-25",
+            "hours": 8.0,
+            "absence_type": "vacation",
+        })
+        # Mit Free-Sondertag-Ausschluss: 4 ≤ 4 → 201. Ohne: 5 > 4 → 400.
+        assert resp.status_code == 201, resp.text
+
+
+class TestEditBudgetExcludesFreeSpecialDay:
+    """F-10 (PATCH): dasselbe Szenario über den Edit-Budget-Check
+    (apply_vacation_request_patch) — muss identisch mit dem POST-Pfad
+    rechnen."""
+
+    def test_edit_spanning_free_day_fits_budget(self, db, default_tenant):
+        user = _user_custom(db, "editbudgetfree", vacation_days=4)
+        vr = _vr(db, user, start=date(2026, 12, 21))
+        _set_special_day_free(db)
+
+        def override_db():
+            yield db
+        _app.dependency_overrides[get_db] = override_db
+        _app.dependency_overrides[get_current_user] = lambda: user
+        try:
+            resp = TestClient(_app).patch(
+                f"/api/vacation-requests/{vr.id}",
+                json={"end_date": date(2026, 12, 25).isoformat()},
+            )
+        finally:
+            _app.dependency_overrides.clear()
+        # Mit Free-Sondertag-Ausschluss: 4 ≤ 4 → 200. Ohne: 5 > 4 → 400.
+        assert resp.status_code == 200, resp.text
+
+
 class TestVacationSelfApproval:
     """Audit A01 (4-Augen-Prinzip): ein Admin darf seinen EIGENEN Urlaubsantrag
     nur dann selbst genehmigen, wenn KEIN weiterer aktiver Admin existiert

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -29,6 +29,7 @@ interface EmployeeReport {
   sick_hours: number;
   sick_days: number;
   exempt_from_arbzg?: boolean;
+  track_hours?: boolean;
 }
 
 interface TimeEntry {
@@ -455,8 +456,14 @@ export default function AdminDashboard() {
   const totalEmployees = report.length;
   // #159: Ø Saldo wahlweise ohne leitende Angestellte (Default) — verhindert
   // dass wenige MA mit vielen Stunden den Schnitt verzerren.
+  // Finding 14 (Review 2026-07-14): track_hours=false-MA (#191, kein Soll/Ist)
+  // haben immer Saldo 0 → IMMER aus dem Schnitt ausschließen (unabhängig vom
+  // "Leitende MA einrechnen"-Toggle, der nur exempt_from_arbzg steuert), sonst
+  // verwässern sie den Durchschnitt Richtung 0.
   const exemptCount = report.filter((emp) => emp.exempt_from_arbzg).length;
-  const avgRows = includeExemptInAvg ? report : report.filter((emp) => !emp.exempt_from_arbzg);
+  const avgRows = report.filter(
+    (emp) => emp.track_hours !== false && (includeExemptInAvg || !emp.exempt_from_arbzg)
+  );
   const avgBalance = avgRows.length > 0
     ? avgRows.reduce((sum, emp) => sum + emp.balance, 0) / avgRows.length
     : 0;


### PR DESCRIPTION
Projektweites Multi-Agent-Review (7 Lanes × adversariale Verifikation) über master (1.14.3) + Fix aller bestätigten Findings bis Low-Severity. 8 Commits, je TDD.

## HIGH (7)
- **closure_split**: `resplit_year_closures` zählte Legacy-`half_day=NULL`-Urlaub als vollen Tag (statt `h/dt_day`) → falsche VACATION/OVERTIME-Klassifizierung bei Bestandsdaten. Drei-Wege-Zweig wie `get_vacation_account` + Decimal.
- **reports.py `/yearly-absences`**: Krank/Fortbildung/ÜStd/Sonstiges/Freistellung stundenbasiert (Σh÷Ø, 8h-Fallback) statt tagebasiert → 0 Tage bei track_hours=False, Drift bei Tagesplan. → `absence_days()`.
- **admin_users `create_working_hours_change`**: fehlendes `db.flush()` vor Self-Lookup (autoflush=False) → `user.weekly_hours` blieb stale (feeds §16-Export, DSGVO-Self-Export, Schichtplan). + `db.flush()`.
- **admin_change_requests**: CR-Genehmigung buchte Urlaub auf `free`-Sondertag (24./31.12.) → Budget fälschlich belastet. Free-Ausschluss ergänzt (4. Buchungspfad).
- **main.py**: `sys.exit(1)` bei kaputtem `LICENSE_DEMO_EXPIRES_AT` → das von CLAUDE.md verbotene Login-Totalausfall-Muster. → Read-Only statt Crash.
- **test_ods_export DSGVO-Masking-Test**: prüfte nur Magic-Bytes, nicht den maskierten Inhalt → hätte „Krank"-Leak nicht gefangen. → content.xml-Assertion.
- **test_concurrency**: einziger Race-Test baute raw-SQL nach statt echten `clock_in`-Lock zu treiben. Umgeschrieben → dabei entdeckt: **`FOR UPDATE` auf 0 Zeilen serialisiert den Cold-Start-Insert-Race gar nicht** (Schutz kam nur vom Unique-Constraint). `clock_in` mit **User-Row-Anchor-Lock** gehärtet (etabliertes absences.py-Muster); Test hat jetzt Zähne (Anchor-entfernt → 2 Einträge → FAIL, auf PG18 verifiziert).

## MEDIUM (7)
`milog_service.settlement_aging` Default-Pfad ignorierte #313-Stichtag · ODS-Jahresübersicht Urlaub/Krank stundenbasiert · Urlaubsantrag-Pre-Check (POST+PATCH) ignorierte free-Sondertage (false-positive 400) · CORS-Middleware innerste → 403/413 ohne CORS-Header (→ zuletzt registriert) · ODS-Misch-Tag-Test halb-tautologisch (Whole-Doc-Substring) → spezifische Zeile · fehlende XLSX-Misch-Tag-Tests · AdminDashboard „Ø Saldo" durch track_hours=false verwässert.

## LOW (8+1)
F-026-Tenant-Filter ergänzt (calc/export Absence+WHChange-Queries) · closure_split float→Decimal · 3 weitere schwache ODS-Tests inhaltlich · tote Imports (extract/NIGHT_THRESHOLD/UUID/AbsenceResponse) · `download_update()` (tot) entfernt · `require_writable()` **behalten** (hatte echten Test-Caller) · dead 404-Guards nach `_get_user_in_tenant` entfernt.

## QA
- Backend-Suite (SQLite) **1325 passed / 49 skipped / 0 failed**.
- Postgres: `test_tenant_rls` 20/20, `test_concurrency` 1/1 (Anchor-Lock mit Zähnen), `test_cross_tenant_api` 18/18 — auf Wegwerf-PG18.
- Frontend: tsc + build clean, vitest **210/210**.
- Jeder Fix TDD (RED→GREEN dokumentiert); adversariale Verifikation vor jedem Fix.

Reine Härtung/Bugfix, keine Migration, keine Feature-Änderung. Auslieferung über /buildrelease (PATCH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
