### PR TITLE
docs(CLAUDE.md): Version 1.15.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.14.3 (Stand 2026-07-14)
+**Aktuelle Version:** 1.15.0 (Stand 2026-07-14)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---


### PR DESCRIPTION
Version-Bump-Nachzug nach Release v1.15.0. Reine Doku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)