### PR TITLE
docs: Berechnungsdoku + Handbücher + In-App-Hilfe auf 1.15.0

### DIFF
--- a/docs/BERECHNUNGEN.md
+++ b/docs/BERECHNUNGEN.md
@@ -1,12 +1,12 @@
 # Stunden- und Urlaubsberechnung – PraxisZeit
 
-> **Stand: Juni 2026 · App-Version 1.8.2**
+> **Stand: Juli 2026 · App-Version 1.15.0**
 > Diese Doku beschreibt **exakt**, wie PraxisZeit Soll-, Ist-, Überstunden- und
 > Urlaubswerte berechnet. Alle Formeln sind aus
 > [`backend/app/services/calculation_service.py`](../backend/app/services/calculation_service.py)
 > hergeleitet. Bei Code-Änderungen an der Berechnung **diese Datei mitpflegen**.
 >
-> Verwandt: [ARC42.md](ARC42.md) · [BACKEND-ARCHITEKTUR.md](BACKEND-ARCHITEKTUR.md) → Berechnungsmodell.
+> Verwandt: [ARC42.md](ARC42.md) · [BACKEND-ARCHITEKTUR.md](BACKEND-ARCHITEKTUR.md) → Berechnungsmodell · [GLOSSAR.md](GLOSSAR.md) → verbindliche Begriffe.
 
 ---
 
@@ -20,10 +20,13 @@
 6. [Abwesenheits-Typen-Matrix](#6-abwesenheits-typen-matrix)
 7. [Saldo & Überstundenkonto](#7-saldo--überstundenkonto)
 8. [Urlaubskonto](#8-urlaubskonto)
-9. [Jahresabschluss / Carryover](#9-jahresabschluss--carryover)
-10. [Sonderfälle](#10-sonderfälle)
-11. [Worked Examples – Vollzeit](#11-worked-examples--vollzeit)
-12. [Worked Examples – Teilzeit](#12-worked-examples--teilzeit)
+9. [Betriebsferien (Company Closures)](#9-betriebsferien-company-closures)
+10. [Minijob / MiLoG-Arbeitszeitkonto](#10-minijob--milog-arbeitszeitkonto)
+11. [Jahresabschluss / Carryover](#11-jahresabschluss--carryover)
+12. [Sonderfälle](#12-sonderfälle)
+13. [Worked Examples – Vollzeit](#13-worked-examples--vollzeit)
+14. [Worked Examples – Teilzeit](#14-worked-examples--teilzeit)
+15. [Worked Example – Minijob (MiLoG-Fixmodus)](#15-worked-example--minijob-milog-fixmodus)
 
 ---
 
@@ -37,6 +40,7 @@
 | **Tagessoll** | Soll-Stunden für einen einzelnen Arbeitstag |
 | **Tagesprinzip** | Urlaub wird in **Tagen** gezählt (§3 BUrlG): 1 freier Arbeitstag = 1 Urlaubstag |
 | **Carryover** | Jahresübertrag von Überstunden und Resturlaub ins Folgejahr |
+| **Saldo-Stichtag „bis heute"** | Für **Live-Anzeigen**: letzter Tag mit abgeschlossenem (ausgestempeltem) Arbeitstag (§7.4, #313). Datei-Exporte/Journal/Jahresabschluss rechnen ohne Stichtag den vollen Zeitraum (§16-Rechtsbeleg). |
 
 **Goldene Regel (CLAUDE.md):** Das Wochensoll wird **nie** direkt aus `user.weekly_hours`
 gelesen, sondern immer über `get_weekly_hours_for_date(db, user, datum)` — nur so werden
@@ -58,6 +62,11 @@ Diese Felder am `User` steuern die gesamte Berechnung:
 | `track_hours` | Soll/Ist-Zählung aktiv? (`false` = leitende Angestellte) | `true` | `true` |
 | `first_work_day` / `last_work_day` | Eintritt/Austritt (Soll/Urlaub anteilig) | optional | optional |
 | `scheduled_start_<wd>` / `scheduled_end_<wd>` | Arbeitszeit-Fenster je Wochentag (#201) | optional | optional |
+| `receives_company_closures` | Nimmt an Betriebsferien teil? (§9, Default `true`, unabhängig von der Rolle) | `true` | `true` |
+| `milog_working_time_account` | Minijob-Arbeitszeitkonto § 2 Abs. 2 MiLoG aktiv (§10, Default `false`) | `false` | `false` |
+| `agreed_monthly_hours` | Vereinbarte Monatszeit für die Minijob-Prüfung (§10.4, optional) | – | – |
+| `use_fixed_monthly_target` | Festes Monats-Soll statt Tages-Summe (Minijob-Baustein 2b, §10.5, Default `false`) | `false` | `false` |
+| `child_sick_days_per_year` | Persönlicher Kind-krank-Jahresanspruch (§45 SGB V, überschreibt den Tenant-Default) | – | – |
 
 > **Historie:** Ändert sich das Wochensoll mitten im Jahr (Teilzeit-Wechsel), wird ein
 > `WorkingHoursChange` mit `effective_from` angelegt. `get_weekly_hours_for_date` liefert für
@@ -96,7 +105,7 @@ Stunden (`hours_monday … hours_friday`). Beispiel `8/8/8/0/0`:
 
 - **Wochenende** (Sa/So): Tagessoll immer `0`.
 - **`track_hours = false`**: Tagessoll immer `0` (keine Stundenzählung).
-- **Sondertage 24./31.12.** (`half_day` / `free`): Tagessoll wird mit Faktor `0,5` bzw. `0` multipliziert (siehe §10.2).
+- **Sondertage 24./31.12.** (`half_day` / `free`): Tagessoll wird mit Faktor `0,5` bzw. `0` multipliziert (siehe §12.2).
 
 ---
 
@@ -138,6 +147,9 @@ Monats-Ist = Σ net_hours(Zeiteinträge im Beschäftigungsfenster)
            + Σ hours(TRAINING + SICK im Beschäftigungsfenster)
 ```
 
+> Im Minijob-Fixmodus (§10.5) kommt eine dritte, ebenfalls gutgeschriebene Quelle
+> hinzu (Feiertag/VACATION/PAID_LEAVE auf einem geplanten Tag) — Details dort.
+
 ---
 
 ## 5. Monats-Soll
@@ -159,6 +171,15 @@ für jeden Tag d im Monat:
 (siehe Matrix §6). D. h. **VACATION, OTHER, PAID_LEAVE** reduzieren das Soll (der MA muss an
 diesen Tagen nicht arbeiten); TRAINING/SICK reduzieren es nicht (sie zählen stattdessen als Ist).
 
+> **Optionaler Stichtag:** `get_monthly_target`/`get_monthly_actual` akzeptieren einen
+> optionalen `up_to_date`-Parameter, der Soll und Ist zusätzlich an einem Datum kappt. Live-
+> Anzeigen füttern hier den **Saldo-Stichtag** aus `get_soll_cutoff_date()` (§7.4); ohne
+> diesen Parameter (Default `None`) gilt die volle Monatslogik oben unverändert — so rechnen
+> Datei-Exporte/Journal/Jahresabschluss (§9–§15 Worked Examples).
+>
+> **Minijob-Fixmodus (`use_fixed_monthly_target`, §10.5):** verzweigt früh auf ein **festes**
+> Monats-Soll (`agreed_monthly_hours`, pro-rata) statt der Per-Tag-Summe oben — Details §10.5.
+
 ---
 
 ## 6. Abwesenheits-Typen-Matrix
@@ -171,7 +192,7 @@ Wie jeder Abwesenheitstyp Soll, Ist und Urlaubskonto beeinflusst:
 | **SICK** (Krank) | ❌ nein | ✅ ja | Tagessoll des Tages | ❌ nein | saldo-neutral (Soll bleibt, Ist gutgeschrieben) |
 | **TRAINING** (Fortbildung) | ❌ nein | ✅ ja | Tagessoll des Tages | ❌ nein | saldo-neutral (zählt als gearbeitet) |
 | **PAID_LEAVE** (bezahlte Freistellung) | ✅ ja | ❌ nein | Tagessoll des Tages | ❌ **nein** | saldo-neutral wie OTHER, aber **kein** Urlaubsverbrauch |
-| **OTHER** (sonstige) | ✅ ja | ❌ nein | Tagessoll des Tages | ❌ nein | saldo-neutral |
+| **OTHER** (sonstige, inkl. unbezahlt entschuldigt) | ✅ ja | ❌ nein | Tagessoll des Tages | ❌ nein | saldo-neutral, aber **unbezahlt** (Lohn gekürzt) |
 | **OVERTIME** (Überstundenausgleich) | ❌ **nein** | ❌ nein (Ist = 0) | **explizite** Stunden | ❌ nein | **Soll bleibt, Ist = 0 h → Überstundenkonto sinkt** um die geplanten Stunden |
 
 > **OVERTIME-Sonderregel (CLAUDE.md):** Beim Überstundenausgleich bleibt das **Soll bestehen**
@@ -181,6 +202,39 @@ Wie jeder Abwesenheitstyp Soll, Ist und Urlaubskonto beeinflusst:
 > **Buchung der `hours`:** Bei Voll-Tag-Typen wird `hours` = **Tagessoll des konkreten Tages**
 > gebucht (nicht der 8-h-Client-Default). Nur OVERTIME behält die explizit eingegebenen Stunden.
 > Halbtag (`half_day`): `hours` = 0,5 × Tagessoll.
+
+### 6.1 Eigene Abwesenheitsgründe (`AbsenceReason`, #312) — Calc bleibt eingefroren
+
+Admins können frei benannte Abwesenheitsgründe anlegen (Name, Farbe, `is_active`). Ein
+solcher Grund ist **nur ein Label-/Farb-Overlay**: gespeichert wird er über `Absence.reason_id`,
+aber **die Berechnung folgt ausschließlich `Absence.type`** — der eingebaute, oben tabellierte
+Typ. Beim Anlegen mappt `base_behavior` den Grund fest auf einen dieser Typen
+(`BEHAVIOR_TO_ABSENCE_TYPE`, `models/absence.py`; nach dem Anlegen unveränderlich):
+
+| `base_behavior` | mappt auf `AbsenceType` | Bedeutung |
+|---|---|---|
+| `worked` | `TRAINING` | zählt als gearbeitet |
+| `paid_free` | `PAID_LEAVE` | bezahlt frei, kein Urlaubsabzug |
+| `overtime_comp` | `OVERTIME` | Überstundenabbau |
+| `unpaid_free` | `OTHER` | **unbezahlt** entschuldigt (#376, z. B. „Kind krank") |
+
+**`unpaid_free` (z. B. „Kind krank"):** entschuldigt **unbezahlt** — Soll↓ (wie jedes
+`OTHER`), kein Ist, kein Urlaubsverbrauch, saldo-neutral, aber der Lohn wird gekürzt. Im
+Calc-Modell ist `unpaid_free` **identisch** zu `paid_free`/`PAID_LEAVE` (beide reduzieren
+Soll und lassen Ist/Saldo unberührt) — der einzige Unterschied ist das Reporting-Label
+(unbezahlt vs. bezahlt). Es gibt **keinen** Soll- oder Ist-Delta zwischen `PAID_LEAVE` und
+einem `unpaid_free`-`OTHER`-Tag.
+
+Für „Kind krank" gilt zusätzlich ein weiches **§45-SGB-V-Limit**: `child_sick_cap()` liefert
+den Jahresanspruch in Tagen (`User.child_sick_days_per_year`, sonst Tenant-Setting
+`child_sick_days_default`, Default 15); `child_sick_days_used()` zählt **tagebasiert** (wie
+§6.2/§8.2) die Absenzen eines als `tracks_child_sick_limit` markierten Grundes. Wird das
+Limit überschritten, erscheint die weiche Warnung `CHILD_SICK_LIMIT` — sie blockiert die
+Buchung **nie**.
+
+**DSGVO Art. 9:** Jede Abwesenheit mit `reason_id` wird in den Kollegen-Feeds
+(`/absences/calendar`, `/absences/team/upcoming`) für **Nicht-Admins** als `"absent"`
+maskiert — ein selbst benannter Grund kann sensibel sein (z. B. „Reha").
 
 ---
 
@@ -194,7 +248,8 @@ Monatssaldo = Monats-Ist − Monats-Soll
 
 ### 7.2 Kumuliertes Überstundenkonto
 
-`get_overtime_account(db, user, jahr, monat)` summiert die Monatssalden **kumulativ**:
+`get_overtime_account(db, user, jahr, monat, cutoff_date=None)` summiert die Monatssalden
+**kumulativ**:
 
 - **Mit Carryover:** Startwert = `YearCarryover.overtime_hours` (neuester ≤ Jahr), Iteration ab
   Januar dieses Jahres → kein Doppelzählen.
@@ -204,14 +259,56 @@ Monatssaldo = Monats-Ist − Monats-Soll
 Konto = Startwert + Σ (Monats-Ist − Monats-Soll)   über alle Monate bis (jahr, monat)
 ```
 
+Der optionale `cutoff_date`-Parameter ist der **Saldo-Stichtag** (§7.4, #313) — Live-Anzeigen
+übergeben ihn, damit der laufende Monat nicht mit einem vollen Monats-Soll gegen ein
+unvollständiges Ist rechnet. `get_overtime_history_detailed`/`get_overtime_history` liefern
+dieselbe Kette **je Monat** (Soll/Ist/Konto in einem Pass) und sind bitgleich zu
+`get_monthly_target`/`get_monthly_actual`/`get_overtime_account` bei gleichem Stichtag.
+
 ### 7.3 Year-to-Date (JTD)
 
-`get_ytd_summary` summiert Tagessoll und Ist vom **1. Januar bis heute** und addiert den
-Carryover des Jahres:
+`get_ytd_summary` summiert Tagessoll und Ist vom **1. Januar** bis **heute** — bzw. bis zum
+**Saldo-Stichtag** (§7.4), wenn ein `cutoff_date` übergeben wird (alle Live-Aufrufer tun das)
+— und addiert den Carryover des Jahres:
 
 ```
 JTD-Überstunden = JTD-Ist − JTD-Soll + carryover_hours(Jahr)
 ```
+
+### 7.4 Saldo-Stichtag „bis heute" (#313)
+
+Ohne Stichtag zeigte das laufende Monats-/JTD-Saldo am 1. eines Monats sofort ein volles
+Monats-Soll gegen (noch) 0 Ist — ein irreführendes „Monatsanfangs-Minus". `get_soll_cutoff_date`
+löst das:
+
+```
+get_soll_cutoff_date(db, user) =
+    heute,    wenn heute bereits ein AUSGESTEMPELTER TimeEntry existiert
+    gestern,  sonst
+```
+
+**Live-Anzeigen, die den Stichtag nutzen** (kappen Soll UND die per-Tag-Zählung von Ist
+gleichermaßen an diesem Datum):
+
+- MA-Dashboard (`/api/dashboard/*`)
+- Admin-Team-Tabelle `GET /admin/reports/monthly` + `GET /admin/reports/weekly` — Umschalter
+  `?soll_basis=bis_heute|monatsende` (Default `bis_heute`), UI-Dropdown „Soll: bis heute /
+  Monatsende"
+- Admin-Benutzerübersicht `GET /admin/users-overview`
+- Überstundenkonto + -Verlauf (`get_overtime_account`, `get_overtime_history[_detailed]`) und
+  dessen Chart
+- Year-to-Date (`get_ytd_summary`)
+
+Vergangene, bereits abgeschlossene Monate liegen komplett **vor** dem Stichtag — ein einziger
+Stichtag trimmt daher effektiv nur den **laufenden** Monat; ältere Monate sehen mit oder ohne
+Stichtag identisch aus.
+
+> **Bewusste Ausnahme — §16-Rechtsbelege rechnen IMMER den vollen Zeitraum:** Alle
+> Datei-Exporte (`export_service`, `ods_export_service`), das Monatsjournal
+> (`journal_service`) und der Jahresabschluss/Carryover (`create_year_closing`, §11) rufen
+> `get_monthly_target`/`get_monthly_actual`/`get_overtime_account` **ohne** `cutoff_date` —
+> diese Dokumente bleiben unverändert nach der vollen Monatslogik, damit ein §16-Beleg nicht
+> von einer Live-Anzeige abweicht.
 
 ---
 
@@ -255,9 +352,18 @@ used_hours += hours                                (nur informativ)
 > Dadurch kostet ein Urlaubstag immer **genau einen Tag seines eigenen Tagessolls** — ein
 > 10-h-Montag kostet nicht mehr als ein 4-h-Mittwoch. Beide = 1,0 Urlaubstag.
 
+**Halbtags-Sondertag (24./31.12. als `half_day`, #394):** Fällt ein Urlaubstag auf einen
+solchen Tag, kostet er nur **0,5** statt 1,0 Urlaubstag — die tagesbasierte Zählung wendet
+dafür den Faktor aus `calculation_service.half_special_day_weight(d, special_cfg)` an. Das
+ist **die eine** Quelle für diesen Faktor, geteilt von `get_vacation_account`, `absence_days`
+(§12.2), der Betriebsferien-Buchung und dem #314-Re-Split (§9.4) sowie allen
+Urlaubsbudget-Pre-Checks — so kann die Halbtags-Regel nie zwischen den Buchungspfaden
+divergieren.
+
 **Zusätzlich:** Ein Sondertag (24./31.12.), der als `free` **und** `counts_as_vacation`
 konfiguriert ist, verbraucht ebenfalls **1 Urlaubstag** je MA (sofern im Beschäftigungsfenster
-und nicht schon als echter Urlaub gebucht).
+und nicht schon als echter Urlaub gebucht) — er ist als kompletter freier Tag konfiguriert,
+nicht als Halbtag, und kostet daher den vollen Tag.
 
 ### 8.3 Rest
 
@@ -271,50 +377,303 @@ remaining_hours = budget_hours − used_hours     (informativ)
 Beim Anlegen eines Urlaubs/Antrags wird **tagebasiert** geprüft:
 
 ```
-benötigte_Tage = Anzahl_buchbarer_Arbeitstage × (0,5 wenn Halbtag, sonst 1,0)
+benötigte_Tage = Σ über buchbare Arbeitstage d von
+                   [ (0,5 wenn Halbtag-Antrag, sonst 1,0) × half_special_day_weight(d) ]
 ```
 „Buchbare Arbeitstage" = Werktage im Zeitraum mit Tagessoll > 0 (Feiertage/Wochenenden/
 Null-Soll-Tage zählen nicht). Ein 3-Tage-Teilzeit-MA, der „eine ganze Woche" Urlaub nimmt,
-verbraucht so nur **3** Urlaubstage.
+verbraucht so nur **3** Urlaubstage. Der Faktor `half_special_day_weight(d)` ist **derselbe
+zentrale Helper** wie in §8.2/§12.2: ein Antragstag, der auf einen als „Halbtag" konfigurierten
+24./31.12. fällt, trägt nur **0,5** statt 1,0 zum Bedarf bei (Vollzeit-Woche mit 24.12.-Halbtag →
+`1,0 + 1,0 + 0,5 = 2,5`). Alle vier Buchungspfade (`absences`, `vacation_requests` ×2,
+`admin_change_requests`) wenden ihn an. Dieser Check ist **hart** (400 bei Überziehung) — anders
+als die Betriebsferien-Buchung (§9.5), die bewusst nicht cappt.
 
 ---
 
-## 9. Jahresabschluss / Carryover
+## 9. Betriebsferien (Company Closures)
+
+Ein Admin legt eine Betriebsferien-Periode (Von–Bis + Name + Verrechnung,
+`POST /api/company-closures`) an. PraxisZeit bucht daraufhin **automatisch** für jeden
+teilnehmenden MA eine Abwesenheit an jedem seiner Arbeitstage im Zeitraum. Teilnahme steuert
+`User.receives_company_closures` (Bool, Default `true`, **unabhängig von der Rolle**, §2 —
+ein Admin, der zugleich Stunden trackt, nimmt so teil; reine Verwaltungs-Accounts lassen sich
+per Flag abwählen).
+
+### 9.1 Wer/was wird gebucht
+
+**Nicht** gebucht wird an:
+
+- Wochenenden
+- gesetzlichen Feiertagen
+- individuell freien Wochentagen (Teilzeit-Tagesplan, Tagessoll an diesem Wochentag = 0)
+- als `free` konfigurierten Sondertagen (24./31.12. — ein soll-freier Tag darf keinen
+  Urlaubstag kosten)
+- Tagen außerhalb `[first_work_day, last_work_day]` (#298 — künftige oder bereits
+  ausgetretene MA werden übersprungen, kein „genommener Urlaub" vor dem Eintritt)
+- Tagen, an denen der MA bereits **irgendeine** Abwesenheit hat (eine Fremd-Absence wird
+  nie überschrieben)
+
+Jede generierte Abwesenheit ist ein **Einzeltag** (`end_date = None`, #394) mit
+`note = "Betriebsferien: <Name>"` und einer `closure_id`-Verknüpfung (nicht die ganze
+Closure-Spanne — sonst würde die Abwesenheitsliste je Zeile „24.12–31.12." zeigen).
+
+### 9.2 Verrechnung je Schließung (`counts_as_vacation`)
+
+| Option | `Absence.type` | Urlaubsabzug? | Saldo-Effekt |
+|---|:---:|:---:|---|
+| **Als Urlaub werten** (Standard) | `VACATION` | ✅ 1 Urlaubstag je Arbeitstag | saldo-neutral (Soll↓, Urlaubskonto↓) |
+| **Bezahlte Freistellung** | `PAID_LEAVE` | ❌ kein Abzug | saldo-neutral (wie ein Feiertag) |
+
+### 9.3 Halbtags-Sondertag in Betriebsferien (#394)
+
+Fällt ein Closure-Arbeitstag auf einen als `half_day` konfigurierten Sondertag (24./31.12.,
+„halber Feiertag"), kostet er nur **0,5 Urlaubstage** statt 1:
+
+```
+gebuchte hours          = 0,5 × Tagessoll des Tages
+half_day (Feld)          = False    (die generierte Absence selbst ist KEIN Halbtag)
+Urlaubs-/Konto-Kosten     = 0,5 × Tagessoll  über half_special_day_weight(), NICHT über half_day
+```
+
+> ⚠️ Der naheliegende Weg (`half_day=True` an der generierten Absence setzen) wäre ein
+> **Doppel-Halbieren** (Sondertag-Faktor 0,5 × Halbtags-Faktor 0,5 = 0,25) und würde ein
+> Phantom-Defizit erzeugen. Richtig: `half_day=False` (das Tagessoll ist durch den
+> Sondertag-Faktor bereits auf die Hälfte reduziert — kein Rest-Defizit), die 0,5-Kosten für
+> die Urlaubs-/Konto-Zählung kommen zentral über den einen Helper
+> `calculation_service.half_special_day_weight(d, cfg)` (§8.2).
+
+### 9.4 Betriebsferien über Jahresurlaub hinaus → Überstundenausgleich (#314)
+
+Ohne Einstellung bucht eine Betriebsferien-Schließung **immer** `VACATION` — reicht das
+Jahresbudget nicht, entsteht **Minus-Urlaub** (bewusst zulässig, §9.5).
+
+Globales Tenant-Setting **`closure_overtime_after_vacation`** (Bool, Default **aus**,
+Admin-Einstellungen) ändert dieses Verhalten für Schließungen mit `counts_as_vacation = true`:
+
+```
+Closure-Arbeitstage CHRONOLOGISCH (nach Datum) sortiert, pro MA:
+für jeden Tag:
+    Tageskosten = 1,0  (oder 0,5 bei Halbtags-Sondertag, §9.3)
+    wenn verbleibendes Jahres-Urlaubsbudget ≥ Tageskosten:
+        type = VACATION;  Budget -= Tageskosten
+    sonst:
+        type = OVERTIME   (Überstundenausgleich: Soll bleibt, Ist = 0 → Konto sinkt, darf ins Minus)
+```
+
+Nur für **Stunden-getrackte** MA (`track_hours = True`) — untracked MA (kein
+Überstundenkonto) bleiben immer `VACATION`.
+
+**Re-Save wirkt rückwirkend & idempotent:** Ein **nachträglich** aktivierter Schalter bucht
+bereits gespeicherte Betriebsferien nicht automatisch um — dafür muss die Schließung erneut
+gespeichert werden (`PUT /api/company-closures/{id}`, auch ein reines Umbenennen genügt).
+Das löst `resplit_year_closures()` (`services/closure_split_service.py`) aus: **alle**
+Closure-Tage des betroffenen Jahres werden **kalenderchronologisch über alle Schließungen
+dieses Jahres hinweg** neu klassifiziert (nicht nur die gerade gespeicherte einzelne
+Schließung) — der Budget-Snapshot zieht zuerst den privaten Urlaubsverbrauch + freie
+Sondertage des Jahres vom Jahresbudget ab, danach werden die Closure-Tage der Reihe nach
+verbraucht; der Überschuss landet auf der **letzten** Schließung des Jahres. Derselbe
+Re-Split läuft außerdem bei jedem Anlegen/Ändern/Stornieren von Privaturlaub und beim
+Löschen einer Schließung (das Budget wird dadurch wieder frei).
+
+### 9.5 Bewusst KEIN Budget-Cap
+
+Anders als der Direkt- oder Antragspfad für privaten Urlaub (Anlegen einer Abwesenheit,
+Genehmigen eines Urlaubsantrags — beide lehnen eine das Budget überziehende Buchung **hart**
+mit `400` ab, §8.4), prüft die Betriebsferien-Buchung das Resturlaubsbudget **nicht als
+Blocker**: Der Arbeitgeber kann Pflichturlaub anordnen, auch wenn er das Budget übersteigt
+(Schalter aus → Minus-Urlaub; Schalter an → Überstundenausgleich, §9.4). Ein MA kann
+umgekehrt nicht freiwillig überziehen.
+
+---
+
+## 10. Minijob / MiLoG-Arbeitszeitkonto
+
+Opt-in-Feature für geringfügig Beschäftigte mit Arbeitszeitkonto nach § 2 Abs. 2 MiLoG
+(#377). Reine **LESE-Schicht** über `calculation_service` (`services/milog_service.py`) —
+das auditierte Soll/Ist-Modell wird dafür nicht verändert. Alle Warnungen sind **weich**
+(informativ) und blockieren nie das Stempeln oder Buchen.
+
+### 10.1 Gesetzlicher Mindestlohn (Konstante)
+
+`app/core/minimum_wage.py` hält eine datumsabhängige Stufentabelle (chronologisch erweitert,
+Werte nie geraten):
+
+| Gültig ab | €/h |
+|---|---|
+| 01.01.2025 | 12,82 |
+| **01.01.2026** | **13,90** |
+| 01.01.2027 | 14,60 |
+
+Angezeigt über `/api/system/info`, rein informativ — PraxisZeit speichert **keine
+Lohndaten** und prüft keinen 603-€-Grenzwert.
+
+### 10.2 Baustein 1 — 50-%-Warnung (`MILOG_ACCOUNT_50`)
+
+Opt-in je MA: `User.milog_working_time_account = true`. Vergleichsgröße ist die
+**vereinbarte Monatszeit** — flach, **nicht** das schwankende Tages-Soll:
+
+```
+agreed_monthly = User.agreed_monthly_hours              (Baustein 2a, §10.4, falls gesetzt)
+                 sonst  get_weekly_hours_for_date(...) × 13/3   (52 Wochen / 12 Monate)
+
+Konto-Plusstunden = max(0, Monats-Ist − agreed_monthly)
+Warnung MILOG_ACCOUNT_50, wenn Konto-Plusstunden > agreed_monthly / 2
+```
+
+**Beispiel:** 10 h/Woche vereinbart → `agreed_monthly` = 10 × 13/3 ≈ **43,33 h**, Grenze
+(Cap) = **21,67 h**. Erfasstes Monats-Ist = 66 h → Konto-Plusstunden = 66 − 43,33 = 22,67 h
+> 21,67 h → `MILOG_ACCOUNT_50`.
+
+> Beide Seiten des 50-%-Vergleichs nutzen bewusst dieselbe **flache** Basis — würde eine
+> Seite das (feiertags-/urlaubs-/teilmonats-getrimmte) Tages-Soll nutzen und die andere die
+> flache `agreed_monthly`, kippt der Vergleich bei kurzen/langen Monaten fälschlich.
+
+### 10.3 Baustein 1/3 — 12-Monats-Ausgleichsfrist (`MILOG_SETTLEMENT_DUE`)
+
+§ 2 Abs. 2 S. 2 MiLoG verlangt einen Ausgleich von Zeitguthaben binnen 12 Kalendermonaten.
+`milog_service.settlement_aging()` führt dafür ein **FIFO** über die **Soll-basierten**
+Monats-Deltas (`Ist − Soll`, aus `get_overtime_history_detailed`, mit dem #313-Saldo-Stichtag
+gefüttert):
+
+```
+für jeden Monat (chronologisch):
+    Delta = Monats-Ist − Monats-Soll
+    Delta > 0 → neue „Einlage" (Alterung ab diesem Monat)
+    Delta < 0 → verbraucht die ÄLTESTEN offenen Einlagen zuerst (FIFO)
+
+älteste offene Einlage > 12 Monate alt   → MILOG_SETTLEMENT_DUE (überfällig)
+älteste offene Einlage 11–12 Monate alt  → „bald fällig"
+```
+
+Der letzte `YearCarryover` wird als ältester offener Posten geseedet, damit Alt-Guthaben aus
+Vorjahren nicht unsichtbar bleibt.
+
+> ⚠️ **Bewusst Soll-basiert, NICHT gegen die flache `agreed_monthly` gerechnet:** Das
+> tatsächliche Monats-Soll (`target`) ist bereits um Feiertage, soll-mindernde
+> Abwesenheiten (Urlaub, bezahlte Freistellung), Beschäftigungs-Teilmonate und den
+> Saldo-Stichtag bereinigt — Urlaub ist **kein** Freizeitausgleich und darf das Arbeitszeit­
+> konto nicht belasten. Die flache `agreed_monthly` ist ausschließlich die vertragliche
+> Bezugsgröße für die **50-%-Prüfung** (§10.2), nicht für dieses Aging.
+
+Beide Warnungen tragen den Hinweis „sofern die Stunden zur Mindestlohnhöhe vergütet werden"
+— ohne gespeicherte Lohndaten kann PraxisZeit den tatsächlichen Mindestlohnbezug nicht prüfen.
+
+### 10.4 Baustein 2a — Vereinbarte Monatszeit direkt hinterlegen
+
+`User.agreed_monthly_hours` (optional): überschreibt die aus `weekly_hours` abgeleitete
+flache 13/3-Monatszeit für die 50-%-Prüfung (§10.2) exakt. Ohne gesetzten Wert bleibt die
+Ableitung aus den Wochenstunden aktiv.
+
+### 10.5 Baustein 2b — Festes Monats-Soll (`use_fixed_monthly_target`)
+
+Opt-in je MA (`User.use_fixed_monthly_target = true`), setzt zwingend `agreed_monthly_hours
+> 0` **und** `track_hours = true` **und** `milog_working_time_account = true` voraus
+(Schema-Guard bei Anlage **und** Änderung — ein isoliertes Deaktivieren des Konto-Flags bei
+aktivem Fixmodus wird mit `400` blockiert). **Für alle anderen MA ändert sich nichts**
+(byte-identisches Verhalten — der Modus ist rein opt-in).
+
+**Monats-Soll wird FEST statt aus Tagen summiert:**
+
+```
+Monats-Soll = agreed_monthly_hours
+              (bei Ein-/Austritt im Monat kalendertag-anteilig, pro-rata)
+```
+
+Die geplanten Tagesstunden (`hours_monday …`) treiben das Soll in diesem Modus **nicht
+mehr** — sie sind nur noch das Anwesenheitsmuster und die Basis für die Gutschriften unten.
+
+**Gutschrift bezahlter Fehltage (Monats-Ist):** Ein Feiertag, ein VACATION- oder ein
+PAID_LEAVE-Tag auf einem **geplanten** Tag (`hours_<wd> > 0`) schreibt die geplanten
+Tagesstunden dem Ist gut (das Konto bleibt neutral):
+
+```
+Monats-Ist += Σ geplante Tagesstunden an (Feiertag ∪ VACATION ∪ PAID_LEAVE)-Tagen
+              mit hours_<wd> > 0, ohne konkurrierenden TimeEntry
+```
+
+> SICK/TRAINING sind **nicht** in dieser Gutschrift enthalten — sie schreiben ihre `hours`
+> bereits über den normalen §3-EntgFG-Pfad (§4.2) dem Ist gut; ein zweites Mal addieren
+> wäre eine Doppelgutschrift.
+
+**Minderung unbezahlter Fehltage (Soll):** Ein unbezahlter Fehltag (`OTHER`, z. B. „Kind
+krank" §6.1) auf einem geplanten Tag **mindert das feste Soll** statt das Ist gutzuschreiben
+(unbezahlt entschuldigt — nichts zum Gutschreiben):
+
+```
+Monats-Soll -= Σ geplante Tagesstunden an OTHER-Tagen mit hours_<wd> > 0
+```
+
+**Weiche Warnung `MILOG_MONTHLY_EXCEEDED`**, wenn das Monats-Ist die vereinbarte Monatszeit
+übersteigt (reine Fix-Soll-Plausibilität, unabhängig von §10.2/§10.3).
+
+**Bekannte Grenze:** Fällt ein **ganzer Monat** aus (z. B. Urlaub/Krankheit über den ganzen
+Monat) und liegen die geplanten Tagesstunden deutlich unter der vereinbarten Monatszeit
+(flexibler Rest), deckt die Gutschrift nur den geplanten Anteil ab — der verbleibende
+flexible Rest bleibt ein Konto-Defizit, das der Arbeitgeber manuell korrigieren muss.
+Einzelne Fehltage (der Regelfall) sind vollautomatisch korrekt.
+
+> **§16-Datei-Exporte im Fixmodus:** Die Monats-/Jahres-Detailsheets
+> (`export_service`/`ods_export_service`) tragen für Fixmodus-MA einen eigenen Branch, der
+> die Summenzeilen „Soll/Ist/Saldo" aus `get_monthly_target`/`get_monthly_actual` zieht
+> (statt das per-Tag-Soll selbst zu rekonstruieren) — sonst widerspräche sich das
+> §16-Dokument selbst.
+
+Ein vollständiges Zahlenbeispiel: §15.
+
+---
+
+## 11. Jahresabschluss / Carryover
 
 `create_year_closing(db, jahr, users)` erzeugt für jedes Mitglied einen `YearCarryover` fürs
 Folgejahr (`jahr + 1`):
 
 ```
-carryover.overtime_hours = get_overtime_account(user, jahr, 12)      # Saldo am 31.12.
+carryover.overtime_hours = get_overtime_account(user, jahr, 12)      # Saldo am 31.12., OHNE Stichtag
 carryover.vacation_days  = get_vacation_account(user, jahr).remaining_days   # Resturlaub
 ```
 
 Diese Werte gehen als Startwerte ins Folgejahr ein (Überstundenkonto-Start bzw. zusätzliche
 Budget-Tage). ⚠️ Offen (#191): Carryover für `track_hours = false` (leitende Angestellte).
 
+> **Rückwirkende Änderungen an einem bereits abgeschlossenen Jahr** (z. B. Storno eines
+> genehmigten Urlaubs, Löschen einer Betriebsferien-Schließung) machen dessen Carryover
+> stale — PraxisZeit rechnet ihn **nicht automatisch neu** (das würde manuelle
+> Carryover-Anpassungen überschreiben), sondern liefert eine Warnung
+> (`stale_year_closing_warning`), die einen erneuten Jahresabschluss empfiehlt.
+
 ---
 
-## 10. Sonderfälle
+## 12. Sonderfälle
 
-### 10.1 Leitende Angestellte (`track_hours = false`)
+### 12.1 Leitende Angestellte (`track_hours = false`)
 
 - **Kein Soll/Ist**: Tagessoll = 0, keine Überstundenrechnung.
-- **Urlaub trotzdem tagebasiert**: jeder VACATION-Tag = **1 Tag** (Halbtage nicht
-  unterscheidbar → zählen als voller Tag), jeder `free`+`counts_as_vacation`-Sondertag = 1 Tag.
-  Alle Stundenwerte bleiben 0; Budget folgt normaler Pro-rata- + Carryover-Logik.
+- **Urlaub trotzdem tagebasiert**: jeder VACATION-Tag = **1 Tag** (Halbtage `half_day=True`
+  zählen 0,5, ein Halbtags-Sondertag zusätzlich × 0,5, siehe §8.2/§9.3), jeder
+  `free`+`counts_as_vacation`-Sondertag = 1 Tag. Alle Stundenwerte bleiben 0; Budget folgt
+  normaler Pro-rata- + Carryover-Logik.
 - Response trägt `track_hours: false` (UI blendet Stundenspalten aus).
 
-### 10.2 Sondertage 24.12. / 31.12. (#146)
+### 12.2 Sondertage 24.12. / 31.12. (#146)
 
 Tenant-Setting je Tag: `working_day` (Faktor 1), `half_day` (Faktor **0,5**) oder `free`
 (Faktor **0**). Bei `free` zusätzlich `counts_as_vacation` (zieht 1 Urlaubstag, §8.2). Der
 Faktor wird **nach** Wochenende/Feiertag/Abwesenheit angewandt, damit kein Tag doppelt behandelt wird.
 
-### 10.3 Eintritt/Austritt (#193/#195)
+**Halbtags-Sondertag (`half_day`, #394):** kostet in **jeder** tagebasierten Urlaubs-/
+Absenz-Zählung nur **0,5** statt 1,0 — egal ob privat gebuchter Urlaub (§8.2), eine
+Betriebsferien-Buchung (§9.3) oder ein exportierter Bericht (`absence_days()`). Alle diese
+Stellen fragen denselben zentralen Helper `calculation_service.half_special_day_weight(d,
+cfg)` ab, damit der Faktor nie zwischen den Pfaden divergiert.
+
+### 12.3 Eintritt/Austritt (#193/#195)
 
 Tage **vor** `first_work_day` oder **nach** `last_work_day` tragen weder Soll noch Ist
 (`_within_employment_window`). Das gilt symmetrisch an allen Per-Tag-Schleifen (Monats-Soll,
-Überstundenkonto, JTD und Ist-Seite) → keine Phantom-Überstunden durch Einträge außerhalb des Fensters.
+Überstundenkonto, JTD und Ist-Seite) **und** an der Betriebsferien-Buchung (#298, §9.1) →
+keine Phantom-Überstunden durch Einträge außerhalb des Fensters und keine Closure-Absence
+vor dem Eintritt.
 
 > ⚠️ **Ist `first_work_day` NICHT gesetzt** und existiert kein Carryover, beginnt
 > `get_overtime_account` am 1. des Monats des **ersten Zeiteintrags** und `get_ytd_summary` am
@@ -324,10 +683,11 @@ Tage **vor** `first_work_day` oder **nach** `last_work_day` tragen weder Soll no
 
 ---
 
-## 11. Worked Examples – Vollzeit
+## 13. Worked Examples – Vollzeit
 
 > **Annahmen für alle Monatsbeispiele:** Beispielmonat mit **22 Werktagen (Mo–Fr)**, davon
-> **1 gesetzlicher Feiertag**. Werte gerundet auf 2 Nachkommastellen.
+> **1 gesetzlicher Feiertag**. Werte gerundet auf 2 Nachkommastellen. Wie in §7.4 beschrieben,
+> gilt hier — wie in Datei-Exporten/Journal — der **volle Monat** (kein Saldo-Stichtag).
 
 ### VZ-Profil
 
@@ -339,7 +699,7 @@ Tage **vor** `first_work_day` oder **nach** `last_work_day` tragen weder Soll no
 | **Tagessoll** | 40 / 5 = **8,00 h** |
 | `vacation_days` | 30 |
 
-### Beispiel 11.1 – Monatssaldo mit Feiertag und 4 Urlaubstagen
+### Beispiel 13.1 – Monatssaldo mit Feiertag und 4 Urlaubstagen
 
 ```
 Werktage im Monat              = 22
@@ -357,7 +717,7 @@ Monats-Ist   = 14 × 8,00 + 3 × 8,50 = 112,00 + 25,50 = 137,50 h
 Monatssaldo  = 137,50 − 136,00      = +1,50 h  (Mehrarbeit)
 ```
 
-### Beispiel 11.2 – Krankheit statt Arbeit
+### Beispiel 13.2 – Krankheit statt Arbeit
 
 Statt eines Arbeitstags ist der MA 1 Tag krank (SICK):
 
@@ -368,7 +728,7 @@ SICK zählt als Ist             → 8,00 h gutgeschrieben (Tagessoll)
 Saldo-Effekt des Kranktags     = 0 h  (8 h Soll, 8 h gutgeschrieben)
 ```
 
-### Beispiel 11.3 – Überstundenausgleich (OVERTIME)
+### Beispiel 13.3 – Überstundenausgleich (OVERTIME)
 
 MA nimmt 1 Tag Überstundenausgleich, gebucht mit 8,00 h:
 
@@ -378,7 +738,7 @@ Ist des Tages                  = 0,00 h   (OVERTIME zählt nicht als Ist)
 → Überstundenkonto sinkt       um 8,00 h
 ```
 
-### Beispiel 11.4 – Urlaubskonto Vollzeit
+### Beispiel 13.4 – Urlaubskonto Vollzeit
 
 ```
 Tagessoll (Budget)  = 40 / 5            = 8,00 h
@@ -395,7 +755,7 @@ remaining_hours = 240 − 32              = 208,00 h
 
 ---
 
-## 12. Worked Examples – Teilzeit
+## 14. Worked Examples – Teilzeit
 
 ### TZ-A: Gleichmäßig 20 h / 5 Tage
 
@@ -407,7 +767,7 @@ remaining_hours = 240 − 32              = 208,00 h
 | `vacation_days` (Empfehlung 30×5/5) | 30 |
 
 ```
-Monat (17 Soll-Tage wie 11.1):
+Monat (17 Soll-Tage wie 13.1):
 Monats-Soll  = 17 × 4,00 h = 68,00 h
 
 Urlaub: 4 volle Tage à 4,00 h
@@ -492,15 +852,72 @@ manuelles Nachrechnen alter Monate nötig.
 
 ---
 
+## 15. Worked Example – Minijob (MiLoG-Fixmodus)
+
+MJ-Profil: `track_hours = true`, `use_daily_schedule = true` mit `hours_monday = 5` (alle
+übrigen Wochentage `0`, der MA arbeitet nur montags), `milog_working_time_account = true`,
+`agreed_monthly_hours = 40`, `use_fixed_monthly_target = true`. Das Monats-Soll ist damit
+**immer 40,00 h**, unabhängig davon, wie viele Montage der Kalendermonat hat oder wie die
+geplante Stunde tatsächlich genutzt wird.
+
+### 15.1 Feiertag auf einem geplanten Tag → Gutschrift, Soll bleibt
+
+Ein gesetzlicher Feiertag fällt in diesem Monat auf einen geplanten Montag (`hours_monday =
+5`). Der MA hat an den übrigen Montagen 33,00 h real erfasst:
+
+```
+Monats-Soll (fest)        = 40,00 h                          (agreed_monthly_hours, unverändert)
+
+Feiertag auf geplantem Montag (5,00 h)
+  → Ist-Gutschrift        = +5,00 h                          (fixed_month_credit)
+
+Monats-Ist  = Σ Zeiteinträge (33,00 h) + Feiertags-Gutschrift (5,00 h) = 38,00 h
+Monatssaldo = 38,00 − 40,00 h                                 = −2,00 h
+```
+
+Das feste Soll (40,00 h) ändert sich durch den Feiertag **nicht** — nur das Ist bekommt die
+geplanten Stunden gutgeschrieben, statt an diesem Tag 0 h zu zählen.
+
+### 15.2 Unbezahlter Fehltag → Soll-Minderung
+
+An einem anderen geplanten Montag (`hours_monday = 5`) bucht der MA einen unbezahlten
+Fehltag (`OTHER`, z. B. „Kind krank", §6.1). An den restlichen geplanten Montagen erfasst er
+35,00 h:
+
+```
+Monats-Soll (fest)        = 40,00 h
+OTHER an geplantem Montag (5,00 h) mindert das Soll:
+  Monats-Soll             = 40,00 − 5,00 h                    = 35,00 h    (fixed_month_unpaid_reduction)
+
+Monats-Ist  = Σ Zeiteinträge (35,00 h)                        = 35,00 h    (kein Gutschriftstag, da unbezahlt)
+Monatssaldo = 35,00 − 35,00 h                                 = 0,00 h     (saldo-neutral)
+```
+
+Der unbezahlte Fehltag verschwindet damit korrekt sowohl aus dem Soll als auch aus dem Ist —
+das Konto bleibt neutral, aber der Lohn wird für diesen Tag gekürzt (Reporting, keine
+Lohndaten in PraxisZeit).
+
+---
+
 ## Quellen im Code
 
 | Funktion | Datei |
 |---|---|
 | `get_weekly_hours_for_date`, `get_daily_target(_for_date)` | `services/calculation_service.py` |
-| `get_monthly_target` / `_actual` / `_balance` | `services/calculation_service.py` |
-| `get_overtime_account`, `get_ytd_summary` | `services/calculation_service.py` |
-| `get_vacation_account`, `create_year_closing` | `services/calculation_service.py` |
+| `get_range_target`/`_actual`, `get_monthly_target` / `_actual` / `_balance` | `services/calculation_service.py` |
+| `get_soll_cutoff_date` (#313 Saldo-Stichtag) | `services/calculation_service.py` |
+| `get_overtime_account`, `get_overtime_history[_detailed]`, `get_ytd_summary` | `services/calculation_service.py` |
+| `get_vacation_account`, `absence_days`, `half_special_day_weight` (#394) | `services/calculation_service.py` |
+| `child_sick_cap`, `child_sick_days_used` (#376) | `services/calculation_service.py` |
+| `fixed_monthly_target`, `fixed_month_credit`, `fixed_month_unpaid_reduction` (#377 Baustein 2b) | `services/calculation_service.py` |
+| `create_year_closing`, `stale_year_closing_warning` | `services/calculation_service.py` |
 | `TimeEntry.net_hours` | `models/time_entry.py` |
-| Sondertag-Faktoren | `services/special_days_service.py` |
+| Sondertag-Faktoren (`special_day_target_factor`, `vacation_deduction_dates_for_year`) | `services/special_days_service.py` |
 | Arbeitszeit-Fenster | `services/work_window_service.py` |
 | `hours`-Buchung (Tagessoll/Halbtag/OVERTIME) | `routers/absences.py`, `routers/admin_vacations.py` |
+| Betriebsferien-CRUD + Buchung (`_create_closure_absences`) | `routers/company_closures.py` |
+| Betriebsferien-Split VACATION↔OVERTIME (#314) | `services/closure_split_service.py` |
+| Eigene Abwesenheitsgründe, `BEHAVIOR_TO_ABSENCE_TYPE` (#312/#376) | `models/absence.py` |
+| Mindestlohn-Konstante (#377) | `core/minimum_wage.py` |
+| Minijob-Warnungen `MILOG_ACCOUNT_50` / `MILOG_SETTLEMENT_DUE` / `MILOG_MONTHLY_EXCEEDED` | `services/milog_service.py` |
+| `soll_basis`-Umschalter (Admin-Reports) | `routers/reports.py` |

--- a/docs/handbuch/CHEATSHEET-ADMIN.md
+++ b/docs/handbuch/CHEATSHEET-ADMIN.md
@@ -126,7 +126,7 @@ Klick auf Pfeil → Detailansicht des Mitarbeiters
 - Bezeichnung + Von–Bis + **Verrechnung** → Speichern
 - → Alle MA **mit „Nimmt an Betriebsferien teil"** (Standard) erhalten automatisch Einträge an ihren **Arbeitstagen** – rollenunabhängig (auch Admins, die MA sind)
 - **Nicht gebucht:** Wochenende, Feiertage, freie Wochentage (Teilzeit), „Frei"-Sondertage (24./31.12.), außerhalb des Beschäftigungszeitraums (Eintritt/Austritt), Tage mit vorhandener Abwesenheit
-- **Verrechnung:** *Als Urlaub werten* (**Standard**, zieht 1 Urlaubstag je Tag) **oder** *Bezahlte Freistellung* (kein Urlaubsabzug, saldoneutral)
+- **Verrechnung:** *Als Urlaub werten* (**Standard**, zieht 1 Urlaubstag je Tag, an einem Halbtags-Sondertag 24./31.12. nur 0,5, #394) **oder** *Bezahlte Freistellung* (kein Urlaubsabzug, saldoneutral)
 - Nachträglich Berechtigte: Option setzen → Einträge werden **automatisch** für laufende und künftige Betriebsferien nachgetragen (Neu-Speichern nicht nötig)
 - Löschen: Einträge werden bei allen MA automatisch entfernt
 
@@ -181,7 +181,7 @@ Erscheinen beim Buchen unter „Eigene Gründe". Im Team-Kalender für Kolleg:in
 
 **Kind krank (#376):** Ein „unbezahlt frei"-Grund mit gesetztem **Kind-krank-Limit** zählt gegen den §45-SGB-V-Jahresanspruch (Default 15 Tage, pro MA überschreibbar). Überschreitung → **weiche Warnung** beim Buchen (nie blockierend). Verbrauch je MA in der **Benutzerübersicht**.
 **Minijob/MiLoG (#377):** Opt-in „Arbeitszeitkonto (§2 Abs.2 MiLoG)" je MA → weiche Warnungen bei >50 % Monats-Plus + 12-Monats-Ausgleichsfrist. Mindestlohn 13,90 €/h (2026), 14,60 €/h (2027).
-**Feste Monatsarbeitszeit (#377 Baustein 2b):** zusätzliches Opt-in je MA (nur bei aktivem Arbeitszeitkonto, „Vereinbarte Monatsarbeitszeit" wird Pflicht) → Monats-Soll fix = vereinbarte Monatszeit (pro-rata bei Ein-/Austritt) statt Tagessoll-Summe. Geplante Tagesstunden = reine Gutschrift-Basis: Feiertag/Urlaub/bez. Freistellung auf geplantem Tag → Ist-Gutschrift; unbezahlt (Sonstiges) → Soll-Minderung. Weiche Warnung bei Ist > vereinbart. **Grenze:** ganze Fehlmonate bei deutlich unter der Monatszeit liegenden Tagesstunden gleicht die Automatik nur teilweise aus (Rest = manuelle Korrektur); einzelne Fehltage sind korrekt.
+**Feste Monatsarbeitszeit (#377 Baustein 2b):** zusätzliches Opt-in je MA (nur bei aktivem Arbeitszeitkonto **+** Stundenzählung, „Vereinbarte Monatsarbeitszeit" wird Pflicht) → Monats-Soll fix = vereinbarte Monatszeit (kalendertag-anteilig bei Ein-/Austritt) statt Tagessoll-Summe. Geplante Tagesstunden = reine Gutschrift-Basis: Feiertag/Urlaub/bez. Freistellung auf geplantem Tag → Ist-Gutschrift (Krank/Fortbildung laufen separat, keine Doppelgutschrift); unbezahlt (Sonstiges) → Soll-Minderung. Weiche Warnung bei Ist > vereinbart. **Grenze:** ganze Fehlmonate bei deutlich unter der Monatszeit liegenden Tagesstunden gleicht die Automatik nur teilweise aus (Rest = manuelle Korrektur); einzelne Fehltage sind korrekt.
 
 ---
 

--- a/docs/handbuch/CHEATSHEET-MITARBEITER.md
+++ b/docs/handbuch/CHEATSHEET-MITARBEITER.md
@@ -133,6 +133,8 @@ Hat Ihre Praxis Heiligabend / Silvester als frei oder halben Tag eingestellt, si
 
 **Grüner Saldo (+)** = Überstunden · **Roter Saldo (–)** = Fehlstunden
 
+*Monatssaldo und Überstunden zählen nur bis zum letzten abgeschlossenen Arbeitstag (kein Monatsanfangs-Minus am 1.).*
+
 ---
 
 ## Ohne Stundenzählung
@@ -173,6 +175,7 @@ Zusätzlicher Schutz per Einmal-Code aus einer Authenticator-App (z. B. Google A
 | Eintrag lässt sich nicht bearbeiten | Zu alt → Änderungsantrag stellen |
 | „angerechnet ab HH:MM" beim Eintrag | Soll-Zeit-Fenster: nur bis Puffer angerechnet (echte Zeit bleibt) |
 | Stunden-/Überstundenkacheln fehlen | Kein Fehler – bei Ihnen ohne Stundenzählung |
+| Gelber Hinweis unter „Überstundenkonto" | Minijob-Arbeitszeitkonto (§ 2 Abs. 2 MiLoG): Konto zu weit im Plus oder Ausgleichsfrist läuft bald ab – kein Fehler, im Zweifel mit Admin klären |
 | Passwort vergessen | Administrator kontaktieren |
 
 ---

--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -1,6 +1,6 @@
 # PraxisZeit – Handbuch für Administratoren
 
-**Version 2.5 | Stand: Juni 2026 (für PraxisZeit 1.11.0)**
+**Version 2.6 | Stand: Juli 2026 (für PraxisZeit 1.15.0)**
 
 ---
 
@@ -93,7 +93,7 @@ Das Admin-Dashboard zeigt alle aktiven Mitarbeiter mit ihren aktuellen Monatsdat
 **Soll-Basis umschalten (#313):** Über das Dropdown **„Soll: bis heute / Monatsende"** in der Monatsübersicht steuern Sie, wie das Monats-**Soll** gezählt wird:
 - **bis heute** (Standard): nur bis zum **letzten abgeschlossenen Arbeitstag** des laufenden Monats — so startet der Saldo nicht mit einem Monatsanfangs-Minus.
 - **Monatsende**: der **volle** Monat.
-Für **abgeschlossene** Monate sind beide identisch. (Technisch: der Bericht `/admin/reports/monthly` nimmt den Parameter `soll_basis=bis_heute|monatsende`.) Die heruntergeladenen §16-Exporte bleiben bewusst voll-Monat.
+Für **abgeschlossene** Monate sind beide identisch. (Technisch: der Bericht `/admin/reports/monthly` nimmt den Parameter `soll_basis=bis_heute|monatsende`.) Der Stichtag betrifft **ausschließlich** diese Live-Übersichten (MA-Dashboard, Admin-Team-Tabelle, Benutzerübersicht, Überstundenkonto samt Diagramm, Jahres-bis-heute-Summe). Die heruntergeladenen §16-Exporte, das **Monatsjournal** und der **Jahresabschluss** (Carryover) rechnen bewusst immer den **vollen** Monat bzw. das volle Jahr – das sind Rechtsbelege, die sich nicht rückwirkend ändern sollen, je nachdem, an welchem Tag man sie sich ansieht.
 
 **Suche:** Nutzen Sie das Suchfeld, um nach einem bestimmten Mitarbeiter zu filtern.
 
@@ -843,7 +843,7 @@ Mitarbeiter können nicht nur Zeiteinträge korrigieren, sondern auch **Abwesenh
 
 ## 18. Berechnungsgrundlagen (Anhang)
 
-> Dieser Anhang erklärt **vollständig und exakt**, wie PraxisZeit Soll-, Ist-, Überstunden- und Urlaubswerte ermittelt – auf dem tatsächlichen Rechenstand der Software (Version 1.9.0). Die ausführliche, code-nahe Referenz mit allen durchgerechneten Beispielen (Teilzeit, individueller Tagesplan, Pro-rata, Historie) steht in [`docs/BERECHNUNGEN.md`](../BERECHNUNGEN.md).
+> Dieser Anhang erklärt **vollständig und exakt**, wie PraxisZeit Soll-, Ist-, Überstunden- und Urlaubswerte ermittelt – auf dem tatsächlichen Rechenstand der Software (Version 1.15.0). Die ausführliche, code-nahe Referenz mit allen durchgerechneten Beispielen (Teilzeit, individueller Tagesplan, Pro-rata, Historie) steht in [`docs/BERECHNUNGEN.md`](../BERECHNUNGEN.md).
 
 ### 18.1 Grundbegriffe
 
@@ -1016,4 +1016,4 @@ Details: [`docs/SCHICHTPLANUNG.md`](../SCHICHTPLANUNG.md).
 ---
 
 *PraxisZeit – Zeiterfassungssystem für Arztpraxen und kleine Unternehmen*
-*Stand: Juni 2026 (für PraxisZeit 1.11.0)*
+*Stand: Juli 2026 (für PraxisZeit 1.15.0)*

--- a/docs/handbuch/HANDBUCH-MITARBEITER.md
+++ b/docs/handbuch/HANDBUCH-MITARBEITER.md
@@ -1,6 +1,6 @@
 # PraxisZeit – Mitarbeiter-Handbuch
 
-**Version:** 2.3 · **Stand:** Juni 2026 (PraxisZeit 1.9.0)
+**Version:** 2.5 · **Stand:** Juli 2026 (PraxisZeit 1.15.0)
 **System:** PraxisZeit Zeiterfassungssystem
 **Zugangsdaten:** Benutzername und Passwort vom Administrator
 
@@ -65,11 +65,13 @@ Das Dashboard zeigt Ihnen auf einen Blick:
 | **Überstundenkonto** | Kumulierter Jahressaldo aller Monate |
 | **Urlaubskonto** | Budget, verbrauchte und verbleibende Urlaubstage |
 
-> **Monatssaldo nur bis zum letzten Arbeitstag:** Im **laufenden** Monat wird das Soll nur bis zum **letzten abgeschlossenen Arbeitstag** gezählt – Sie starten den Monat also **nicht** mit einem dicken Minus, sondern der Saldo baut sich Tag für Tag auf. Der heutige Tag zählt mit, sobald Sie **ausgestempelt** haben. Für **abgeschlossene** Monate entspricht der Saldo wie gewohnt dem vollen Monat.
+> **Monatssaldo nur bis zum letzten Arbeitstag:** Im **laufenden** Monat wird das Soll nur bis zum **letzten abgeschlossenen Arbeitstag** gezählt – Sie starten den Monat also **nicht** mit einem dicken Minus, sondern der Saldo baut sich Tag für Tag auf. Der heutige Tag zählt mit, sobald Sie **ausgestempelt** haben. Für **abgeschlossene** Monate entspricht der Saldo wie gewohnt dem vollen Monat. Das **Überstundenkonto** übernimmt für den laufenden Monat denselben Stichtag – auch hier entsteht am Monatsanfang kein künstliches Minus.
 
 > **Zeitanzeige:** Stunden werden im Format H:MM angezeigt (z. B. „8:30" für 8 Stunden 30 Minuten). Negative Salden werden mit einem Minus-Zeichen dargestellt (z. B. „-2:15").
 
 > **Hinweis:** Falls Ihre Praxis für Sie **keine Stundenzählung** führt, fehlen die Kacheln **Tagessaldo**, **Monatssaldo** und **Überstundenkonto** – das ist bei Ihnen so eingestellt und kein Fehler. Ihr **Urlaubskonto** wird trotzdem geführt. Mehr dazu in [Abschnitt 6](#6-wenn-für-sie-keine-stunden-gezählt-werden).
+
+> **Minijob mit festem Monats-Soll:** Führt Ihre Praxis Sie als Minijob-Kraft mit einer **festen vereinbarten Monatsarbeitszeit** (statt eines aus Wochenstunden berechneten Solls), zeigt Ihr **Monatssaldo** jeden Monat dasselbe feste Soll (bei unterjährigem Ein-/Austritt anteilig gekürzt). Feiertage sowie Urlaub oder bezahlte Freistellung an einem für Sie geplanten Arbeitstag werden Ihnen dabei automatisch mit den geplanten Stunden gutgeschrieben; unbezahlt freie Tage mindern das Monatssoll entsprechend. Unter dem **Überstundenkonto** kann in diesem Fall ein gelber Hinweis erscheinen, wenn die vereinbarte Zeit deutlich überschritten wird oder ein Zeitguthaben zu lange nicht ausgeglichen wurde (§ 2 Abs. 2 MiLoG) – das ist eine reine Information und blockiert nichts. Ob dieses Modell für Sie gilt, legt Ihre Praxisleitung fest.
 
 ### Monatsübersicht (Tabelle)
 
@@ -80,7 +82,7 @@ Zeigt die vergangenen Monate mit Soll, Ist, Saldo und kumuliertem Überstundenko
 
 ### Jahresübersicht
 
-Zeigt die Abwesenheitstage des laufenden Jahres nach Typ (Urlaub, Krank, Fortbildung, Sonstiges).
+Zeigt die Abwesenheitstage des laufenden Jahres nach Typ (Urlaub, Krank, Fortbildung, Überstundenausgleich, Sonstiges).
 
 ### Geplante Abwesenheiten im Team
 
@@ -276,6 +278,8 @@ Die Seite zeigt zwei Tabs:
 
 > **Sondertage 24./31.12.:** Hat Ihre Praxis Heiligabend oder Silvester als arbeitsfrei oder halben Tag eingestellt, sind diese Tage im Kalender entsprechend markiert (grau „Heiligabend (frei)" bzw. „Silvester (½ Tag)") – ähnlich einem Feiertag.
 
+> **Datenschutz bei Kollegen-Abwesenheiten:** Im Team-Kalender sehen Sie bei **Kolleginnen und Kollegen** nur Urlaub und Fortbildung mit ihrem echten Typ. Krankheit, bezahlte Freistellung, Sonstiges und alle eigenen (individuellen) Abwesenheitsgründe werden bei anderen Personen neutral als **„Abwesend"** angezeigt. Ihre **eigenen** Abwesenheiten sehen Sie natürlich immer mit dem echten Typ, ebenso Administratorinnen und Administratoren.
+
 ---
 
 ### 4.1 Abwesenheit eintragen
@@ -288,9 +292,11 @@ Klicken Sie auf **+ Abwesenheit eintragen**.
 
 1. **Datum** – Beginn der Abwesenheit
 2. **Zeitraum** – Aktivieren Sie diese Option für mehrere Tage; Wochenenden und Feiertage werden automatisch ausgeschlossen
-3. **Typ** – Urlaub / Krank / Fortbildung / Sonstiges
-4. **Notiz** – Optional
-5. **Speichern**
+3. **Halber Tag** – Nur bei einzelnen Tagen wählbar (nicht bei Zeitraum, nicht bei Krank oder Überstundenausgleich); lässt den Tag nur zur Hälfte zählen (**0,5 statt 1,0 Tag**)
+4. **Typ** – Urlaub / Krank / Fortbildung / Überstundenausgleich / Sonstiges
+5. **Stunden** – Bei Urlaub, Krank, Fortbildung und Sonstigem ist das Feld vorausgefüllt und wird ohnehin durch Ihr Tagessoll ersetzt; nur bei **Überstundenausgleich** zählt der hier eingetragene Wert – er wird von Ihrem Überstundenkonto abgezogen
+6. **Notiz** – Optional
+7. **Speichern**
 
 > **Hinweis zu Urlaubstagen:**
 > Das System berechnet automatisch, wie viele Urlaubstage eingetragen werden und zieht diese von Ihrem Budget ab.
@@ -302,6 +308,7 @@ Klicken Sie auf **+ Abwesenheit eintragen**.
 | **Urlaub** | Genehmigter Erholungsurlaub |
 | **Krank** | Krankheitstage – Krankmeldung nach Praxisregelung einreichen |
 | **Fortbildung** | Externe Schulungen, Seminare, Pflichtfortbildungen |
+| **Überstundenausgleich** | Abbau angesammelter Überstunden – Ihr Soll bleibt bestehen, das Überstundenkonto sinkt um die eingetragenen Stunden |
 | **Sonstiges** | Arzttermine, Behördengänge, sonstige Freistellungen |
 
 > **Eigene Gründe:** Hat Ihre Praxis zusätzliche Abwesenheitsgründe eingerichtet (z. B. „Schule"), erscheinen diese bei der Typ-Auswahl unter **„Eigene Gründe"**. Wählen Sie sie wie einen normalen Typ aus.
@@ -350,6 +357,7 @@ In der Listenansicht Ihrer Abwesenheiten befindet sich der Button **Löschen**. 
 PraxisZeit führt Urlaub **nach Arbeitstagen** (Tagesprinzip nach § 3 BUrlG) – **nicht** nach Stunden:
 
 - **Ein freier Arbeitstag = genau 1 Urlaubstag**, unabhängig davon, wie viele Stunden Sie an diesem Tag arbeiten würden. Ein 9-Stunden-Tag kostet genauso viel Urlaub wie ein 4-Stunden-Tag: **einen Tag**.
+- **Ein halber Tag zählt 0,5 Urlaubstage.** Aktivieren Sie beim Eintragen (nur bei einzelnen Tagen) die Option **Halber Tag** – siehe [Abschnitt 4.1](#41-abwesenheit-eintragen).
 - Eine **freie Woche** kostet so viele Urlaubstage, wie Sie Arbeitstage in der Woche haben (5-Tage-Woche → 5 Tage, 3-Tage-Woche → 3 Tage).
 - Ihr **Jahresanspruch** richtet sich nach der Zahl Ihrer Arbeitstage pro Woche (z. B. 5 Tage → 30 Tage, 3 Tage → anteilig 18 Tage). Den genauen Wert legt Ihr Administrator fest.
 - Das **Urlaubskonto** auf dem Dashboard zeigt jederzeit Budget, genommene und verbleibende Tage.
@@ -364,6 +372,10 @@ Wie sich das auf Ihr Konto auswirkt, legt Ihre Praxisleitung fest:
 
 - **Als bezahlte Freistellung:** Es wird **kein** Urlaubstag abgezogen, Ihr Überstundenkonto bleibt unberührt (wie ein Feiertag).
 - **Als Urlaub:** Jeder Schließtag wird Ihrem **Urlaubskonto** als Urlaubstag abgezogen. Reicht Ihr Resturlaub nicht für die gesamte Schließung, wird – je nach Einstellung Ihrer Praxis – zunächst Ihr Urlaub aufgebraucht und die restlichen Schließtage als **Überstundenabbau** gebucht: Ihr **Überstundenkonto sinkt** (es kann dabei auch ins Minus gehen), aber es entsteht **kein Minus-Urlaub**. Ist diese Einstellung nicht aktiv, können bei längerer Schließung **Minus-Urlaubstage** entstehen.
+
+> Fällt in Ihre Betriebsferien ein als „halber Feiertag" eingestellter Sondertag (z. B. Heiligabend als ½-Tag), wird dafür nur ein **halber** Urlaubs- bzw. Überstundentag verrechnet – passend zum halben Tagessoll dieses Tages.
+
+> Betriebsferien werden bewusst **ohne Budget-Grenze** gebucht: Anders als bei einer selbst eingetragenen Urlaubsbuchung oder einem Urlaubsantrag (die bei zu wenig Resturlaub jeweils abgelehnt werden) kann Ihre Praxisleitung Betriebsferien auch dann anordnen, wenn Ihr Resturlaub dafür nicht reicht.
 
 > Bei Fragen zur konkreten Verrechnung Ihrer Betriebsferien wenden Sie sich an Ihre Praxisleitung.
 
@@ -399,6 +411,8 @@ Ihr **Ist** ist Ihre tatsächlich erfasste Arbeitszeit: **(Ende − Beginn) − 
 | **Fortbildung** | zählt wie Arbeitszeit |
 | **Bezahlte Freistellung / Sonstiges** | Soll des Tages entfällt, **kein** Urlaubsabzug |
 | **Überstundenausgleich** | Soll bleibt, der Tag zählt als 0 Stunden → Ihr Überstundenkonto sinkt |
+
+> **Eigene Abwesenheitsgründe** (z. B. „Kind krank", „Schule") sind nur ein Etikett mit eigenem Namen und eigener Farbe – rechnerisch verhalten sie sich wie eine der obigen Zeilen, je nachdem wie Ihre Praxis den Grund eingerichtet hat. „Kind krank" verhält sich z. B. wie „Sonstiges" (Soll entfällt, kein Urlaubsabzug), ist aber – anders als eine bezahlte Freistellung – **unbezahlt**. Details in [Abschnitt 4.1](#41-abwesenheit-eintragen).
 
 > **Betriebsferien** wirken je nach Einstellung Ihrer Praxis als Urlaub oder als bezahlte Freistellung – Details in [Abschnitt 4.5](#45-betriebsferien-praxisschließung).
 
@@ -537,7 +551,13 @@ A: Tragen Sie im Feld **Pause (Min.)** ein, wie viele Minuten Sie heute Pause ge
 A: Ihre Praxis hat für diesen Wochentag eine Soll-Arbeitszeit hinterlegt. Wenn Sie deutlich vor dem Soll-Beginn ein- oder nach dem Soll-Ende ausstempeln, wird nur bis zu einem kleinen Puffer (Standard 15 Min.) angerechnet. Ihre tatsächliche Stempelzeit bleibt aber gespeichert. Siehe [Abschnitt 3.3](#33-soll-arbeitszeiten-und-anrechnung).
 
 **F: Wie berechnet sich mein Urlaubsanspruch?**
-A: Ihr Urlaubsbudget richtet sich nach Ihrer vertraglichen Wochenstundenzahl. Bei Teilzeit wird es anteilig berechnet. Verbraucht wird **tagebasiert**: 1 freier Arbeitstag = 1 Urlaubstag (siehe [Abschnitt 4.4](#44-so-wird-ihr-urlaub-berechnet)).
+A: Ihr Urlaubsbudget richtet sich nach Ihrer vertraglichen Wochenstundenzahl. Bei Teilzeit wird es anteilig berechnet. Verbraucht wird **tagebasiert**: 1 freier Arbeitstag = 1 Urlaubstag, ein halber Tag = 0,5 Urlaubstage (siehe [Abschnitt 4.4](#44-so-wird-ihr-urlaub-berechnet)).
+
+**F: Ich kann beim Eintragen einer Abwesenheit den Typ „Überstundenausgleich" wählen – was passiert dabei?**
+A: Damit bauen Sie angesammelte Überstunden ab. Ihr Soll für den Tag bleibt bestehen, der Tag zählt aber mit 0 Ist-Stunden – die von Ihnen im Feld **Stunden** eingetragene Zahl wird direkt von Ihrem Überstundenkonto abgezogen. Es entsteht **kein** Urlaubsabzug.
+
+**F: Was bewirkt die Option „Halber Tag" beim Eintragen einer Abwesenheit?**
+A: Sie ist nur bei einzelnen Tagen wählbar (nicht bei Zeitraum, Krank oder Überstundenausgleich) und lässt den Tag nur zur Hälfte zählen – bei Urlaub also **0,5** statt 1,0 Tage, z. B. für einen Arzttermin am Vormittag, an dem Sie nachmittags arbeiten.
 
 **F: Bei mir fehlen die Stunden- und Überstundenkacheln. Ist das kaputt?**
 A: Nein. Für manche Mitarbeitende führt die Praxis keine Stundenzählung. Dann entfallen Soll/Ist, Überstunden und der Stempel-Button; Urlaub und Krankheit werden weiter tagebasiert geführt. Mehr dazu in [Abschnitt 6](#6-wenn-für-sie-keine-stunden-gezählt-werden).
@@ -546,7 +566,7 @@ A: Nein. Für manche Mitarbeitende führt die Praxis keine Stundenzählung. Dann
 A: Ein negativer Wert bedeutet, dass Sie weniger gearbeitet haben als Ihre Sollstunden.
 
 **F: Kann ich eine Abwesenheit für mehrere Tage eintragen?**
-A: Ja. Im Abwesenheitsformular aktivieren Sie die Option **Zeitraum** und geben Start- und Enddatum ein. Das System trägt nur Werktage (Mo–Fr) ein und überspringt Wochenenden und Feiertage.
+A: Ja. Im Abwesenheitsformular aktivieren Sie die Option **Zeitraum** und geben Start- und Enddatum ein. Das System trägt nur Werktage (Mo–Fr) ein und überspringt Wochenenden, Feiertage sowie als arbeitsfrei eingestellte Sondertage (z. B. Heiligabend).
 
 **F: Wie stelle ich einen Korrekturantrag für einen alten Eintrag?**
 A: Navigieren Sie zu **Zeiterfassung → Tab „Einträge"**, suchen Sie den betroffenen Eintrag und klicken Sie auf den **Änderungsantrag**-Button in der Aktionsspalte. Bei entsperrten Einträgen nutzen Sie direkt den **Bearbeiten**-Button.
@@ -574,6 +594,8 @@ PraxisZeit unterstützt die Einhaltung des **Arbeitszeitgesetzes (ArbZG)**:
 
 Vollständiger Gesetzestext: [https://www.gesetze-im-internet.de/arbzg/](https://www.gesetze-im-internet.de/arbzg/BJNR117100994.html)
 
+> **Minijob-Arbeitszeitkonto:** Für Mitarbeitende mit einem Minijob-Arbeitszeitkonto unterstützt PraxisZeit zusätzlich die Vorgaben aus **§ 2 Abs. 2 MiLoG** (Mindestlohngesetz) mit weichen Hinweisen am Überstundenkonto – siehe [Abschnitt 2](#2-dashboard--die-übersicht).
+
 ---
 
 ## Schichtplan (falls Ihre Praxis ihn nutzt)
@@ -592,4 +614,4 @@ legt Ihr Administrator fest.
 
 ---
 
-*PraxisZeit – Zeiterfassungssystem | Mitarbeiter-Handbuch v2.4 | Juni 2026 (PraxisZeit 1.11.0)*
+*PraxisZeit – Zeiterfassungssystem | Mitarbeiter-Handbuch v2.5 | Juli 2026 (PraxisZeit 1.15.0)*

--- a/frontend/public/help/CHEATSHEET-ADMIN.md
+++ b/frontend/public/help/CHEATSHEET-ADMIN.md
@@ -21,18 +21,20 @@
 - Vorname / Nachname, E-Mail (optional)
 - Wochenstunden, Arbeitstage/Woche, Urlaubstage
 - Rolle: Mitarbeiter:in oder Admin
-- Optional: **Stundenzählung aktiv** (s. u.), **ArbZG-Prüfungen aussetzen (§18)** (separate Checkbox – s. u.), Nachtarbeitnehmer (§6), **Nimmt an Betriebsferien teil** (Standard an), **Soll-Arbeitszeiten je Wochentag** (s. u.), Erster/Letzter Arbeitstag (Soll nur in diesem Zeitraum), individuelle Tagesstunden, Abteilung/Bereich, Anfangssaldo Überstunden
+- Optional: **Stundenzählung aktiv** (s. u.), **ArbZG-Prüfungen aussetzen (§18)** (separate Checkbox – s. u.), Nachtarbeitnehmer (§6), **Nimmt an Betriebsferien teil** (Standard an), **Soll-Arbeitszeiten je Wochentag** (s. u.), Erster/Letzter Arbeitstag (Soll nur in diesem Zeitraum), individuelle Tagesstunden, Abteilung/Bereich, **Kalenderfarbe**, Anfangssaldo Überstunden
 
 > **Urlaub (Tagesprinzip):** 1 freier Arbeitstag = 1 Urlaubstag (unabhängig von Tagesstunden/Wochentag). Halbtag = 0,5. Anspruch anteilig: `30 × Arbeitstage/5`. Verbrauch tagebasiert, Stunden nur intern.
 
 > **Benutzerübersicht (#194)** zeigt je MA Urlaubskonto **und** aktuellen Überstundensaldo in der Spalte **„Überstunden (JTD)"**; „—" bei Mitarbeitern ohne Stundenzählung.
+
+> **Monatsjournal (#311):** Buch-Symbol in der Aktionsspalte öffnet das Journal; Überschrift jetzt **„Monatsjournal: Vorname Nachname"**.
 
 ### Stundenzählung an/aus (#191)
 
 Checkbox **„Stundenzählung aktiv"** (Standard an). Aus = **Mitarbeiter ohne Stundenzählung** (NIE „leitende Angestellte" nennen!).
 - Keine Soll-/Ist-/Überstundenberechnung → Spalte „Überstunden (JTD)" zeigt **„—"**.
 - Felder Anfangssaldo / individuelle Tagesstunden entfallen.
-- **Urlaub + Krank zählen trotzdem – tagebasiert** (1 Tag = 1 Tag, Sondertage = 1 Tag; Halbtag zählt hier als voller Tag). Anspruch anteilig + Vorjahresübernahme bleiben.
+- **Urlaub + Krank zählen trotzdem – tagebasiert** (1 Tag = 1 Tag; „Frei"-Sondertag = 1 Tag, „halber Feiertag" 24./31.12. = 0,5 Tag seit #394). Anspruch anteilig + Vorjahresübernahme bleiben.
 
 > **Abgrenzung – zwei getrennte Checkboxen, nicht verwechseln:**
 > - **„Stundenzählung aktiv"** = ob Soll-/Ist-/Überstunden geführt werden. Hat **nichts** mit §18 zu tun.
@@ -55,6 +57,13 @@ Pro MA je Wochentag (Mo–Fr) optionaler **Soll-Beginn / Soll-Ende** (Bereich �
 **Benutzer öffnen** → Status „Inaktiv"
 → Daten 2 Jahre aufbewahren (§16 ArbZG)
 
+### DSGVO: Anonymisierung & endgültige Löschung (Art. 17)
+**Reihenfolge:** Deaktivieren → **14-Tage-Sperrfrist** → Anonymisieren → endgültig löschen
+- **Anonymisieren** (nach 14-Tage-Sperrfrist): entfernt persönliche Daten (Name/E-Mail/Lichtbild/2FA), **Zeiteinträge bleiben** (§16 ArbZG), Abwesenheiten weg
+- **Endgültig löschen (Purge):** vollständige Löschung – erst möglich, wenn die jüngste Aufzeichnung **≥ 730 Tage** alt ist (sonst blockiert)
+- Anonymisierte Nutzer können erst **nach 730 Tagen** endgültig gelöscht werden; alles wird im Änderungsprotokoll vermerkt
+- **Inaktive anzeigen** einblenden → System zeigt Sperrfrist + ob Anonymisierung/Löschung möglich
+
 ---
 
 ## Admin-Dashboard
@@ -69,17 +78,21 @@ Pro MA je Wochentag (Mo–Fr) optionaler **Soll-Beginn / Soll-Ende** (Bereich �
 
 Klick auf Pfeil → Detailansicht des Mitarbeiters
 
+**Monat ↔ Woche (#329):** Umschalter „Monat / Woche" oben → Wochenansicht zeigt die KW (z. B. „22.–28.06.2026 (KW 26)"), Pfeile blättern wochenweise. Auswahl bleibt pro Browser/Gerät gespeichert.
+**Soll-Basis (#313):** Dropdown „Soll: bis heute / Monatsende (volle Woche)". „bis heute" (Standard) zählt Soll nur bis zum letzten abgeschlossenen Arbeitstag → kein Monatsanfangs-Minus. Nur Live-Anzeigen; Datei-Exporte bleiben voller Monat.
+
 ---
 
 ## Berichte & Exporte
 
 | Bericht | Inhalt | Formate |
 |---------|--------|---------|
-| **Monatsreport** | Tägliche Einträge aller MA | Excel + CSV |
-| **Jahresreport Classic** | 12 Monate kompakt | Excel + CSV |
-| **Jahresreport Detailliert** | 365 Tage, ~5s | Excel + CSV |
+| **Monatsreport** | Tägliche Einträge aller MA | Excel (.xlsx) + ODS (.ods) + PDF (.pdf) |
+| **Jahresreport Classic** | 12 Monate kompakt | Excel (.xlsx) + ODS (.ods) |
+| **Jahresreport Detailliert** | 365 Tage, ~5s | Excel (.xlsx) + ODS (.ods) |
 
-**Exportieren:** Berichte → Typ & Zeitraum wählen → Excel oder CSV klicken
+**Exportieren:** Berichte → Typ & Zeitraum wählen → Format klicken (**PDF nur beim Monatsreport**)
+**Krankheitsdaten:** Checkbox „Krankheitsdaten einschließen" (Art. 9 DSGVO) → nimmt Krank-Daten auf, jeder solche Export wird protokolliert
 **Aufbewahrungspflicht: 2 Jahre** (§16 ArbZG)
 
 ---
@@ -94,6 +107,7 @@ Klick auf Pfeil → Detailansicht des Mitarbeiters
 
 **Genehmigen:** Grüner Button → Abwesenheiten werden automatisch eingetragen
 **Ablehnen:** Roter Button → optionalen Ablehnungsgrund eingeben
+**Stornieren:** Filter „Genehmigt" → Antrag → **„Urlaub stornieren"** (nur wenn Zeitraum noch nicht begonnen) → Abwesenheiten werden **automatisch entfernt**, Antrag wird „Zurückgezogen"
 
 ---
 
@@ -109,10 +123,18 @@ Klick auf Pfeil → Detailansicht des Mitarbeiters
 ## Betriebsferien
 
 **Abwesenheiten → Tab Betriebsferien → Neue Betriebsferien**
-- Bezeichnung + Von–Bis → Speichern
-- → Alle MA **mit „Nimmt an Betriebsferien teil"** (Standard) erhalten automatisch Abwesenheitseinträge (keine Urlaubstage!) – rollenunabhängig (auch Admins, die MA sind)
-- Nachträglich Berechtigte: Option setzen, dann Betriebsferien **einmal erneut speichern** → Einträge werden nachgetragen
+- Bezeichnung + Von–Bis + **Verrechnung** → Speichern
+- → Alle MA **mit „Nimmt an Betriebsferien teil"** (Standard) erhalten automatisch Einträge an ihren **Arbeitstagen** – rollenunabhängig (auch Admins, die MA sind)
+- **Nicht gebucht:** Wochenende, Feiertage, freie Wochentage (Teilzeit), „Frei"-Sondertage (24./31.12.), außerhalb des Beschäftigungszeitraums (Eintritt/Austritt), Tage mit vorhandener Abwesenheit
+- **Verrechnung:** *Als Urlaub werten* (**Standard**, zieht 1 Urlaubstag je Tag, an einem Halbtags-Sondertag 24./31.12. nur 0,5, #394) **oder** *Bezahlte Freistellung* (kein Urlaubsabzug, saldoneutral)
+- Nachträglich Berechtigte: Option setzen → Einträge werden **automatisch** für laufende und künftige Betriebsferien nachgetragen (Neu-Speichern nicht nötig)
 - Löschen: Einträge werden bei allen MA automatisch entfernt
+
+**Länger als der Jahresurlaub (#314)** – Schalter *Einstellungen → Betriebsferien & Urlaub → „Überzählige Betriebsferien als Überstundenabbau"* (global, Standard **aus**):
+- **AUS:** alles Urlaub → Überschuss = **Minus-Urlaub** (Pflichturlaub)
+- **AN:** erst Urlaub, dann **Überstundenabbau** (Konto sinkt, darf ins Minus) → **nie** Minus-Urlaub
+- Zuteilung **chronologisch nach Datum** (frühere Schließung zuerst, Überstunden-Tage auf die **letzte** Schließung) – unabhängig von der Eingabereihenfolge; privater Urlaub wird **zuerst** verbraucht
+- Wirkt beim **Anlegen/erneuten Speichern** → bestehende Betriebsferien einmal öffnen + neu speichern
 
 ---
 
@@ -128,6 +150,8 @@ Jeder Bereich hat einen eigenen **Speichern**-Button.
 | **Pflicht-Pause-Ausnahme** | Genehmigungspflicht für §4-Ausnahmen (s. o.) |
 | **Soll-Arbeitszeit-Fenster** | Puffer (Min.) für Soll-Zeiten, Default 15 (s. o.) |
 | **Onboarding / Willkommens-Tour** | Erst-Login-Tour für neue Nutzer an/aus (Standard **an**) |
+| **Eigene Abwesenheitsgründe** | Bezeichnung + Farbe + Basis-Verhalten (#312) – s. u. |
+| **Betriebsferien & Urlaub** | „Überzählige Betriebsferien als Überstundenabbau" (#314, Standard aus – s. Betriebsferien) |
 | **Farben** | Farbe je An-/Abwesenheitstyp |
 
 ### Sondertage 24./31.12. (#188)
@@ -141,6 +165,23 @@ Heiligabend + Silvester sind **keine** gesetzlichen Feiertage → pro Tag getren
 | **Frei** | Tagessoll 0 (wie Feiertag) | **grau** |
 
 Bei „Frei" zusätzlich **Anrechnung:** Urlaub (vom Konto) oder Bezahlte Freistellung (kein Abzug). Wirkt auf Soll, Urlaubskonto und Kalender.
+
+### Eigene Abwesenheitsgründe (#312)
+
+Frei benannte Gründe (z. B. „Schule" für Azubis) mit Farbe + **Basis-Verhalten** (nach Anlegen **fix**):
+
+| Basis-Verhalten | Wirkung |
+|-----------------|---------|
+| **zählt als gearbeitet** | Stunden als Arbeitszeit gutgeschrieben (wie Fortbildung) |
+| **bezahlt frei** | Tagessoll 0, **kein** Urlaubsabzug |
+| **unbezahlt frei** | Tagessoll 0, **kein** Urlaubsabzug, aber **unbezahlt** (Lohn gekürzt) – z. B. Kind krank (§45 SGB V) |
+| **Überstundenabbau** | Überstundenkonto sinkt um Tagessoll |
+
+Erscheinen beim Buchen unter „Eigene Gründe". Im Team-Kalender für Kolleg:innen als **„abwesend"** maskiert (Datenschutz); nur Admins sehen die Bezeichnung. Deaktivierbar.
+
+**Kind krank (#376):** Ein „unbezahlt frei"-Grund mit gesetztem **Kind-krank-Limit** zählt gegen den §45-SGB-V-Jahresanspruch (Default 15 Tage, pro MA überschreibbar). Überschreitung → **weiche Warnung** beim Buchen (nie blockierend). Verbrauch je MA in der **Benutzerübersicht**.
+**Minijob/MiLoG (#377):** Opt-in „Arbeitszeitkonto (§2 Abs.2 MiLoG)" je MA → weiche Warnungen bei >50 % Monats-Plus + 12-Monats-Ausgleichsfrist. Mindestlohn 13,90 €/h (2026), 14,60 €/h (2027).
+**Feste Monatsarbeitszeit (#377 Baustein 2b):** zusätzliches Opt-in je MA (nur bei aktivem Arbeitszeitkonto **+** Stundenzählung, „Vereinbarte Monatsarbeitszeit" wird Pflicht) → Monats-Soll fix = vereinbarte Monatszeit (kalendertag-anteilig bei Ein-/Austritt) statt Tagessoll-Summe. Geplante Tagesstunden = reine Gutschrift-Basis: Feiertag/Urlaub/bez. Freistellung auf geplantem Tag → Ist-Gutschrift (Krank/Fortbildung laufen separat, keine Doppelgutschrift); unbezahlt (Sonstiges) → Soll-Minderung. Weiche Warnung bei Ist > vereinbart. **Grenze:** ganze Fehlmonate bei deutlich unter der Monatszeit liegenden Tagesstunden gleicht die Automatik nur teilweise aus (Rest = manuelle Korrektur); einzelne Fehltage sind korrekt.
 
 ---
 
@@ -254,6 +295,20 @@ Pause nicht eingehalten? Statt Blockade → Eintrag mit **Pflicht-Begründung** 
 **IT-Support:** ____________________________
 
 **Arbeitsrechtliche Fragen:** ____________________________
+
+---
+
+## Schichtplanung (optional)
+
+- **Aus per Default.** Aktivieren: **Einstellungen → Schichtplanung → Speichern**.
+- **Stammdaten:** Standorte (optional) + Arbeitsplätze (mit Farbe) anlegen.
+- **Plan:** beliebig viele Wochenpläne; Slots per Drag & Drop / Klick, Mitarbeitende auf Slot ziehen, Mindestbesetzung optional.
+- **Aktiv schalten** → für alle sichtbar (mehrere Pläne gleichzeitig aktiv möglich).
+- **Einweisungen:** Matrix MA × Arbeitsplätze; nicht eingewiesene Zuweisung → weiche Warnung (blockiert nicht). MA sehen ihre Einweisungen im Profil.
+- **KW-/Jahresplanung (#305 M2):** pro Plan optionales Aktiv-Datums-Fenster („von/bis") + Jahres-Zeitstrahl. **Automatisch füllen** verteilt eingewiesene, verfügbare MA greedy auf die Slots (Zielwoche, ausgewogen nach Auslastung/Überstunden) → Entwurf, aktiviert den Plan **nicht**.
+- **Woche/Tag-Umschalter** (#321); im Slot-Dialog **„Auf Wochentage kopieren"** → Schicht inkl. Zuweisungen auf weitere Tage (#322).
+- **Auslastung (#330):** unter jedem Namen „zugewiesene Std / Wochenarbeitszeit" (z. B. „15,25 / 17 h") – grün ±30 Min, gelb ±1 Std, sonst rot.
+- Reines Planungswerkzeug – **keine** Wirkung auf Zeiterfassung/ArbZG/Urlaub/Überstunden. Details: `docs/SCHICHTPLANUNG.md`.
 
 ---
 

--- a/frontend/public/help/CHEATSHEET-MITARBEITER.md
+++ b/frontend/public/help/CHEATSHEET-MITARBEITER.md
@@ -23,6 +23,14 @@ Benutzernamen + Passwort eingeben → **Anmelden**
 **Dashboard → Einstempeln** startet die Zeit live; später **Ausstempeln** beendet
 sie und speichert den Eintrag automatisch. Alternativ Zeiten manuell erfassen:
 
+### Pause beim Ausstempeln
+Beim **Ausstempeln** Feld **Pause (Min.)** ausfüllen → **Jetzt ausstempeln**.
+- Bei **mehr als 6 h** verlangt das Gesetz eine Pause (§4 ArbZG).
+- Reicht die Pause nicht → gelber Hinweis. Zwei Wege:
+  1. **Pause nachtragen** (Minuten korrigieren), oder
+  2. **kurz begründen**, warum keine Pause möglich war (z. B. „Notfall, keine Vertretung") → **dokumentierte Ausnahme**
+- Erst danach ist das Ausstempeln fertig (flüchtiger Hinweis reicht nicht mehr).
+
 ### Neuen Zeiteintrag erstellen
 **Zeiterfassung** → Tab **Einträge** → **+ Neuer Eintrag**
 - Datum, Startzeit (Von), Endzeit (Bis)
@@ -45,7 +53,13 @@ Aktionsspalte in der Einträge-Tabelle:
 
 ### Tagesgrenze (§3 ArbZG)
 - Warnung ab **8 Stunden** Nettoarbeitszeit
-- Gesperrt ab **10 Stunden** Nettoarbeitszeit
+- Ab **10 Stunden** netto: manuelle Eingabe gesperrt; Live-Ausstempeln nur Warnung (Zeit ist bereits geleistet)
+
+### Soll-Arbeitszeit-Fenster
+*Nur aktiv, wenn die Praxis für Sie Soll-Zeiten hinterlegt hat – sonst zählt alles wie gewohnt.*
+- Zu früh ein- / zu spät ausgestempelt → angerechnet wird nur bis zum **Puffer** (Std. 15 Min.).
+- Hinweis z. B. *„gestempelt 07:30 · angerechnet ab 07:45"*.
+- Ihre **echte Stempelzeit bleibt gespeichert** (§16 ArbZG); fürs Stundenkonto zählt nur die angerechnete Zeit.
 
 ---
 
@@ -59,6 +73,8 @@ Wenn ein Eintrag gesperrt / zu alt ist:
 3. **Antrag stellen**
 
 Für Löschung: **Löschantrag**-Button → Begründung → Bestätigen
+
+**Pflicht-Pause nicht möglich?** Erfüllen die korrigierten Zeiten die Pausenregel nicht, wird der Antrag nicht abgelehnt: Zusatzfeld **„Begründung"** ausfüllen (z. B. „Notfall, keine Vertretung") → **Mit dokumentierter Ausnahme senden**. Die Abweichung geht zur Genehmigung an den Admin.
 
 ---
 
@@ -88,12 +104,21 @@ Zurückziehen: Button **Zurückziehen** bei offenen Anträgen
 | Zeitraum | Checkbox „Zeitraum" + Enddatum |
 | Speichern | Wochenenden/Feiertage werden übersprungen |
 
+> **Eigene Gründe:** Richtet Ihre Praxis weitere Gründe ein (z. B. „Schule"), erscheinen sie bei „Typ wählen" unter **„Eigene Gründe"**.
+
 **Löschen:** Kalender-Eintrag anklicken → Löschen-Symbol
+
+### Sondertage 24./31.12.
+Hat Ihre Praxis Heiligabend / Silvester als frei oder halben Tag eingestellt, sind diese im Kalender markiert (z. B. „Heiligabend (frei)" / „Silvester (½ Tag)") – wie ein Feiertag.
 
 ### Bei aktiver Urlaubsgenehmigungspflicht
 - Urlaub-Speichern → **Antrag** (kein direkter Eintrag)
 - Tab **„Meine Anträge"** zeigt Status
 - Offene Anträge können zurückgezogen werden
+
+### Urlaubsberechnung
+- **1 freier Arbeitstag = 1 Urlaubstag** (egal wie viele Stunden der Tag hat)
+- Freie Woche = Anzahl Ihrer Arbeitstage; Konto zeigt Resttage
 
 ---
 
@@ -108,6 +133,17 @@ Zurückziehen: Button **Zurückziehen** bei offenen Anträgen
 
 **Grüner Saldo (+)** = Überstunden · **Roter Saldo (–)** = Fehlstunden
 
+*Monatssaldo und Überstunden zählen nur bis zum letzten abgeschlossenen Arbeitstag (kein Monatsanfangs-Minus am 1.).*
+
+---
+
+## Ohne Stundenzählung
+
+Für manche Mitarbeitende führt die Praxis **keine Stundenzählung**:
+- Kein Soll/Ist, keine Überstunden, kein Stempel-Button → Kacheln Tagessaldo / Monatssaldo / Überstunden fehlen.
+- **Urlaub & Krank werden trotzdem geführt** – tagebasiert (1 freier Arbeitstag = 1 Tag). Urlaubskonto bleibt sichtbar.
+- Das ist eine bewusste Einstellung Ihrer Praxis, **kein Fehler**.
+
 ---
 
 ## Passwort ändern
@@ -119,13 +155,27 @@ Zurückziehen: Button **Zurückziehen** bei offenen Anträgen
 
 ---
 
+## Zwei-Faktor-Authentifizierung (2FA)
+
+Zusätzlicher Schutz per Einmal-Code aus einer Authenticator-App (z. B. Google Authenticator, Authy).
+
+**Aktivieren:** Profil → Karte „Zwei-Faktor-Authentifizierung" → **2FA aktivieren** → QR-Code scannen (oder Schlüssel manuell eintragen) → 6-stelligen Code eingeben → **Bestätigen**
+**Login:** Benutzername + Passwort → danach **6-stelligen Code** aus der App
+**Deaktivieren:** **2FA deaktivieren** → aktuelles **Passwort** bestätigen
+> App/Handy verloren? → Administrator kontaktieren
+
+---
+
 ## Häufige Probleme
 
 | Problem | Lösung |
 |---------|--------|
-| Eintrag nicht speicherbar | Pause prüfen (§4 ArbZG Pflicht!) |
+| Pause zu kurz beim Ausstempeln | Pause nachtragen **oder** kurz begründen (dokumentierte Ausnahme) |
 | Zeiteintrag zu lang | Max. 10h netto (§3 ArbZG) |
 | Eintrag lässt sich nicht bearbeiten | Zu alt → Änderungsantrag stellen |
+| „angerechnet ab HH:MM" beim Eintrag | Soll-Zeit-Fenster: nur bis Puffer angerechnet (echte Zeit bleibt) |
+| Stunden-/Überstundenkacheln fehlen | Kein Fehler – bei Ihnen ohne Stundenzählung |
+| Gelber Hinweis unter „Überstundenkonto" | Minijob-Arbeitszeitkonto (§ 2 Abs. 2 MiLoG): Konto zu weit im Plus oder Ausgleichsfrist läuft bald ab – kein Fehler, im Zweifel mit Admin klären |
 | Passwort vergessen | Administrator kontaktieren |
 
 ---
@@ -135,6 +185,14 @@ Zurückziehen: Button **Zurückziehen** bei offenen Anträgen
 **Name:** ____________________________
 
 **E-Mail / Telefon:** ____________________________
+
+---
+
+## Schichtplan (falls aktiv)
+
+- Menü **Schichtplan**: aktive Wochenpläne ansehen (wer wann wo).
+- **Dashboard → „Deine Einteilung heute"**: Ihre heutigen Einsätze mit Zeit.
+- Nur Planung – ändert **nicht** Ihre Arbeitszeiten/Urlaub/Überstunden. Einteilung macht der Admin.
 
 ---
 

--- a/frontend/public/help/HANDBUCH-ADMIN.md
+++ b/frontend/public/help/HANDBUCH-ADMIN.md
@@ -1,6 +1,6 @@
 # PraxisZeit – Handbuch für Administratoren
 
-**Version 2.4 | Stand: Juni 2026 (für PraxisZeit 1.8.2)**
+**Version 2.6 | Stand: Juli 2026 (für PraxisZeit 1.15.0)**
 
 ---
 
@@ -30,6 +30,7 @@
 16. [Änderungsanträge für Abwesenheiten](#16-änderungsanträge-für-abwesenheiten)
 17. [Rechtliche Grundlagen](#17-rechtliche-grundlagen)
 18. [Berechnungsgrundlagen (Anhang)](#18-berechnungsgrundlagen-anhang)
+19. [Datensicherung (Backup & Restore)](#19-datensicherung-backup--restore)
 
 ---
 
@@ -76,7 +77,7 @@ Das Admin-Dashboard zeigt alle aktiven Mitarbeiter mit ihren aktuellen Monatsdat
 | **Ist** | Tatsächlich geleistete Stunden |
 | **Saldo** | Differenz Ist – Soll (H:MM, + = Überstunden, – = Fehlstunden) |
 | **Übersto. Kum.** | Kumulierter Jahressaldo |
-| **Urlaub** | Verbleibende Urlaubsstunden (Ampelfarbe) |
+| **Urlaub** | Verbleibende Urlaubstage (Ampelfarbe) |
 | **Krank** | Kranktage im aktuellen Monat |
 
 ### Statistiken (oben)
@@ -86,6 +87,13 @@ Das Admin-Dashboard zeigt alle aktiven Mitarbeiter mit ihren aktuellen Monatsdat
 - **Monat:** Aktuell angezeigter Monat
 
 **Monat wechseln:** Mit den Pfeilen `<` und `>` wechseln Sie den angezeigten Monat.
+
+**Monat ↔ Woche umschalten (#329):** Über den Umschalter **„Monat / Woche"** oben neben dem Zeitraum wechseln Sie zwischen der Monats- und einer **Wochenansicht**. In der Wochenansicht steht statt „Juni 2026" die Kalenderwoche, z. B. **„22.–28.06.2026 (KW 26)"**; mit den Pfeilen blättern Sie wochenweise. Die Spalten sind dieselben wie im Monat. So erhalten Sie eine schnelle Plausibilitätsübersicht, wer zu viel oder zu wenig gearbeitet hat. Ihre Auswahl (Monat oder Woche) bleibt **pro Browser/Gerät** gespeichert. In der Wochenansicht heißt die zweite Option der Soll-Basis entsprechend **„volle Woche"** statt „Monatsende".
+
+**Soll-Basis umschalten (#313):** Über das Dropdown **„Soll: bis heute / Monatsende"** in der Monatsübersicht steuern Sie, wie das Monats-**Soll** gezählt wird:
+- **bis heute** (Standard): nur bis zum **letzten abgeschlossenen Arbeitstag** des laufenden Monats — so startet der Saldo nicht mit einem Monatsanfangs-Minus.
+- **Monatsende**: der **volle** Monat.
+Für **abgeschlossene** Monate sind beide identisch. (Technisch: der Bericht `/admin/reports/monthly` nimmt den Parameter `soll_basis=bis_heute|monatsende`.) Der Stichtag betrifft **ausschließlich** diese Live-Übersichten (MA-Dashboard, Admin-Team-Tabelle, Benutzerübersicht, Überstundenkonto samt Diagramm, Jahres-bis-heute-Summe). Die heruntergeladenen §16-Exporte, das **Monatsjournal** und der **Jahresabschluss** (Carryover) rechnen bewusst immer den **vollen** Monat bzw. das volle Jahr – das sind Rechtsbelege, die sich nicht rückwirkend ändern sollen, je nachdem, an welchem Tag man sie sich ansieht.
 
 **Suche:** Nutzen Sie das Suchfeld, um nach einem bestimmten Mitarbeiter zu filtern.
 
@@ -139,6 +147,12 @@ Die Liste zeigt alle aktiven Mitarbeiter mit:
 
 **Filter:** Aktivieren Sie **„Inaktive anzeigen"** oder **„Ausgeblendete anzeigen"** um deaktivierte Mitarbeiter einzublenden.
 
+**Monatsjournal (#311):** Über das Buch-Symbol in der Aktionsspalte öffnen Sie das **Monatsjournal** des Mitarbeiters. Die Überschrift trägt jetzt den Namen der Person – **„Monatsjournal: Vorname Nachname"** –, damit beim Wechsel zwischen Mitarbeitern sofort klar ist, wessen Journal angezeigt wird.
+
+**„Login als …" – Ansicht als Mitarbeiter:in (#370):** Über das Anmelde-Symbol in der Aktionsspalte (nur bei **aktiven Mitarbeitenden**, nicht bei Admins) öffnen Sie die Anwendung aus der Perspektive dieser Person – praktisch, um das individuelle Dashboard zu beurteilen oder ein gemeldetes Problem nachzustellen. Die Ansicht ist **ausschließlich lesend**: Stempeln, Anträge stellen und jegliche Änderungen sind gesperrt (der Server weist Schreibversuche ab). Ein dauerhaftes Hinweisbanner am oberen Rand zeigt **„Sie sehen PraxisZeit als … – nur Lesen"**; über **„Zurück zu Admin"** kehren Sie jederzeit zu Ihrem eigenen Konto zurück.
+
+> **Datenschutz:** Jede „Login als"-Sitzung wird protokolliert (welcher Admin, welche Person, Beginn und Ende) – Rechenschaftspflicht nach Art. 5 Abs. 2 DSGVO. Da keine Änderungen möglich sind, kann keine Aktion fälschlich der/dem Mitarbeitenden zugerechnet werden (§ 16 ArbZG).
+
 ### Neuen Mitarbeiter anlegen
 
 ![Neuen Benutzer anlegen](screenshots/16-admin-benutzer-formular.png)
@@ -168,6 +182,7 @@ Klicken Sie auf **„Neuer Mitarbeiter:in"** und füllen Sie das Formular aus:
 | **Individuelle Tagesstunden** | Abweichende Stundenverteilung Mo–Fr statt einheitlich (nur bei aktiver Stundenzählung) |
 | **Abteilung/Bereich** | Optionale Zuordnung (Freitext); ermöglicht Filterung im Abwesenheitskalender |
 | **Anfangssaldo Überstunden** | Übernommener Überstundensaldo zum Startjahr (kann +/- sein; nur bei aktiver Stundenzählung) |
+| **Übertrag Urlaubstage** | Alt-/Vorjahres-Resturlaub, der dem **Urlaubsbudget des Startjahres** zugerechnet wird (z. B. beim Systemwechsel bei unterjährigem Eintritt der Resturlaub aus den Monaten vor dem Eintritt). Minus und Kommastellen möglich; gilt für **alle** MA (auch ohne Stundenzählung). |
 | **Soll-Arbeitszeiten je Wochentag** | Optionaler Soll-Beginn / Soll-Ende pro Wochentag (Mo–Fr) – siehe eigener Abschnitt „Soll-Arbeitszeiten" unten. |
 
 > **Wichtig – zwei getrennte Einstellungen, bitte nicht verwechseln:**
@@ -189,7 +204,7 @@ Klicken Sie auf **„Neuer Mitarbeiter:in"** und füllen Sie das Formular aus:
 **Was sich ändert, wenn die Stundenzählung deaktiviert ist:**
 - **Keine Soll-/Ist-Stundenberechnung** und **keine Überstundenberechnung.** In der Benutzerübersicht erscheint in der Spalte „Überstunden (JTD)" ein „—".
 - Die Felder „Anfangssaldo Überstunden", „Individuelle Tagesstunden" und das Soll-/Ist-Dashboard entfallen für diese Person.
-- **Urlaub und Krankheit werden trotzdem geführt** – und zwar **tagebasiert**: 1 genommener freier Arbeitstag = 1 Urlaubstag (Sondertage wie Heiligabend zählen ebenfalls als 1 Tag). Der Urlaubsanspruch bleibt anteilig nach Arbeitstagen und behält die Vorjahresübernahme.
+- **Urlaub und Krankheit werden trotzdem geführt** – und zwar **tagebasiert**: 1 genommener freier Arbeitstag = 1 Urlaubstag. Ein „Frei + zählt als Urlaub"-Sondertag (z. B. Heiligabend) zählt 1 Tag; ein als **„halber Feiertag"** konfigurierter Sondertag (24./31.12.) zählt **0,5 Tage** (seit #394). Der Urlaubsanspruch bleibt anteilig nach Arbeitstagen und behält die Vorjahresübernahme.
 
 **Wofür gedacht:** z. B. Personen, deren Arbeitszeit nicht erfasst, deren Urlaub aber dennoch verwaltet werden soll.
 
@@ -231,6 +246,27 @@ Setzen Sie den Status auf **„Inaktiv"**. Deaktivierte Mitarbeiter können sich
 
 > **Rechtlicher Hinweis (§16 ArbZG):** Arbeitszeitaufzeichnungen müssen **mindestens 2 Jahre** aufbewahrt werden. Löschen Sie daher niemals Mitarbeiterdaten – deaktivieren Sie die Konten.
 
+### DSGVO: Anonymisierung & endgültige Löschung (Art. 17)
+
+Für das **Recht auf Löschung** (Art. 17 DSGVO) gibt es zwei Stufen, die das gesetzliche Spannungsfeld zwischen Löschpflicht und der **Aufbewahrungspflicht** für Arbeitszeitaufzeichnungen (§16 ArbZG) auflösen. Beide setzen voraus, dass das Konto **zuvor deaktiviert** wurde.
+
+**Ablauf in Kürze:**
+
+1. **Deaktivieren** Sie den/die Mitarbeiter:in (Status „Inaktiv"). Damit startet eine **14-tägige Sperrfrist**.
+2. Nach Ablauf der Sperrfrist kann **anonymisiert** werden.
+3. **Endgültig löschen** lässt sich ein Datensatz erst, wenn die **730-tägige (2-Jahre-)Aufbewahrungsfrist** abgelaufen ist.
+
+| Aktion | Was passiert | Voraussetzung |
+|--------|--------------|---------------|
+| **Anonymisieren** | Personenbezogene Daten werden entfernt (Name → „Gelöschter Benutzer", Benutzername/E-Mail, Lichtbild, Abteilung, 2FA-Geheimnis). Die **Zeiteinträge bleiben** erhalten (Pflicht nach §16 ArbZG), Abwesenheiten werden gelöscht. Der Datensatz selbst und die Aufzeichnungen bleiben bestehen. | Konto deaktiviert **und** 14-tägige Sperrfrist abgelaufen |
+| **Endgültig löschen (Purge)** | **Vollständige, unwiderrufliche Löschung** des Benutzers samt aller zugehörigen Daten (Zeiteinträge, Abwesenheiten, Anträge). | Konto deaktiviert **und** die jüngste aufbewahrungspflichtige Aufzeichnung (Zeiteintrag oder Abwesenheit) ist **mindestens 730 Tage** alt |
+
+- Die **Anonymisierung** ist der Regelweg, wenn die Aufbewahrungsfrist noch läuft: Die Person wird anonymisiert, die gesetzlich aufzubewahrenden Aufzeichnungen bleiben aber erhalten.
+- Die **endgültige Löschung** wird vom System blockiert, solange noch aufbewahrungspflichtige Aufzeichnungen jünger als 730 Tage existieren. Ein anonymisierter Benutzer kann also **erst nach Ablauf der 730 Tage** endgültig gelöscht werden.
+- Beide Vorgänge werden im **Änderungsprotokoll** dokumentiert (DSGVO-Rechenschaftspflicht, Art. 5 Abs. 2).
+
+> **Wo?** Blenden Sie über **„Inaktive anzeigen"** die deaktivierten Konten ein. Das System zeigt je Konto die verbleibende Sperrfrist sowie an, ob eine Anonymisierung bzw. endgültige Löschung bereits möglich ist.
+
 ---
 
 ## 5. Abwesenheitskalender
@@ -239,7 +275,7 @@ Setzen Sie den Status auf **„Inaktiv"**. Deaktivierte Mitarbeiter können sich
 
 ### Kalenderansicht
 
-Abwesenheiten werden farbcodiert nach Typ dargestellt (z. B. Urlaub, Krankheit, Fortbildung, Überstundenausgleich, Sonstiges). Die genauen Farben sind unter **Einstellungen → „Farben"** je Typ frei konfigurierbar (→ [Abschnitt 13](#farben)). Jeder Mitarbeitende hat zusätzlich eine **eigene Kalenderfarbe**, die er im eigenen Profil wählt.
+Abwesenheiten werden farbcodiert nach Typ dargestellt (z. B. Urlaub, Krankheit, Fortbildung, Überstundenausgleich, Sonstiges). Die genauen Farben sind unter **Einstellungen → „Farben"** je Typ frei konfigurierbar (→ [Abschnitt 13](#farben)). Jeder Mitarbeitende hat zusätzlich eine **eigene Kalenderfarbe** im Teamkalender. Diese kann der Mitarbeiter selbst unter **Profil → Kalenderfarbe** wählen oder der Administrator im **Benutzerformular** (Feld **Kalenderfarbe**) für ihn vorgeben.
 
 **Sondertage und Feiertage im Kalender:**
 - **Gesetzliche Feiertage** und arbeitsfreie **Sondertage** (24./31.12. im Modus „Frei") werden **grau** hinterlegt und sind nicht buchbar.
@@ -267,14 +303,14 @@ Betriebsferien werden als gesonderte Einträge angezeigt und betreffen alle akti
 ### Monatsreport
 
 - **Inhalt:** Tägliche Zeiteinträge aller Mitarbeiter im gewählten Monat
-- **Format:** Excel (.xlsx) oder CSV
+- **Format:** Excel (.xlsx), ODS (.ods) oder PDF (.pdf)
 - **Details pro Mitarbeiter:** Datum, Wochentag, Start, Ende, Pause, Ist-Stunden, Soll-Stunden, Abwesenheitstyp, Monatssaldo
 
 **Verwendung:** Gehaltsabrechnung, monatliche Kontrolle, Dokumentation
 
 ### Jahresreport Classic
 
-- **Format:** Excel (.xlsx) oder CSV, ca. 17 KB
+- **Format:** Excel (.xlsx) oder ODS (.ods)
 - **Inhalt:** Pro Mitarbeiter eine Zeile pro Monat
 - **Details:** Soll, Ist, Saldo, Urlaubstage, Krankheitstage, Fortbildungstage
 
@@ -282,18 +318,20 @@ Betriebsferien werden als gesonderte Einträge angezeigt und betreffen alle akti
 
 ### Jahresreport Detailliert
 
-- **Format:** Excel (.xlsx) oder CSV, ca. 108 KB
+- **Format:** Excel (.xlsx) oder ODS (.ods)
 - **Inhalt:** Jeden Tag des Jahres pro Mitarbeiter
 - **Hinweis:** Generierungszeit 3–5 Sekunden
 
 **Verwendung:** Detaillierte Jahresauswertung, Steuerberater, Betriebsprüfung
 
+> **Hinweis:** Das **PDF**-Format gibt es nur für den **Monatsreport**. Die Jahresreports stehen als **Excel** und **ODS** zur Verfügung.
+
 ### Bericht erstellen
 
 1. Wählen Sie den **Berichtstyp**
 2. Wählen Sie **Monat** oder **Jahr**
-3. Optional: **„Krankheiten einstellen"** – legt fest, ab welchem Datum § 3 EntgFG (Kranktage als gearbeitete Zeit) gilt
-4. Klicken Sie auf **Excel** oder **CSV**
+3. Optional: **„Krankheitsdaten einschließen" (Art. 9 DSGVO)** – nimmt Krankheitsstunden bzw. -tage in den Export auf. Krankheitsdaten sind besondere Kategorien personenbezogener Daten (Art. 9 DSGVO); jeder Export mit dieser Option wird im **Änderungsprotokoll** vermerkt.
+4. Klicken Sie auf das gewünschte Format – **Excel (.xlsx)**, **ODS (.ods)** oder (beim Monatsreport) **PDF (.pdf)**
 5. Die Datei wird automatisch heruntergeladen
 
 > **Rechtlicher Hinweis (§16 ArbZG):** Exportieren Sie regelmäßig (mindestens jährlich) und sichern Sie die Dateien sicher für **2 Jahre**.
@@ -321,7 +359,14 @@ Oben auf der Seite befindet sich ein Toggle **„Urlaubsanträge genehmigungspfl
 2. Klicken Sie auf **„Genehmigen"** (grüner Button)
 3. Das System trägt automatisch Abwesenheiten für alle Werktage ein (Wochenenden und Feiertage ausgeschlossen)
 
-> **Achtung:** Eine Genehmigung ist unwiderruflich. Zum Stornieren müssen die erstellten Abwesenheitseinträge manuell gelöscht werden.
+### Genehmigten Antrag stornieren
+
+Eine Genehmigung lässt sich rückgängig machen, solange der Urlaubszeitraum **noch nicht begonnen hat** (Beginn in der Zukunft). Wechseln Sie dazu in den Filter **„Genehmigt"**, öffnen Sie den Antrag und klicken Sie auf **„Urlaub stornieren"**.
+
+- Die durch die Genehmigung erzeugten **Abwesenheitseinträge werden automatisch entfernt** – ein manuelles Löschen ist nicht nötig.
+- Der Antrag wird auf **„Zurückgezogen"** gesetzt und bleibt für die Nachvollziehbarkeit im Änderungsprotokoll erhalten.
+
+> **Hinweis:** Bereits begonnene oder vergangene Urlaube können nicht storniert werden. Offene Anträge können vor der Entscheidung jederzeit storniert werden.
 
 ### Antrag ablehnen
 
@@ -424,14 +469,44 @@ Navigieren Sie zu **Abwesenheiten → Tab „Betriebsferien"** und klicken Sie a
 
 1. **Bezeichnung** (z. B. „Weihnachtsschließzeit 2026")
 2. **Von** (Startdatum) und **Bis** (Enddatum)
-3. Speichern
+3. **Verrechnung** wählen (siehe nächster Abschnitt)
+4. Speichern
 
 **Was passiert automatisch:**
-- Alle aktiven Mitarbeiter **mit der Option „Nimmt an Betriebsferien teil"** (Standard) erhalten für jeden Werktag Abwesenheitseinträge – unabhängig von der Rolle, also auch Admins, die zugleich als Mitarbeiter geführt werden. Reine Verwaltungs-Accounts können die Option in der Benutzerverwaltung abwählen.
-- Urlaubstage werden **nicht** verbraucht
-- Wochenenden und gesetzliche Feiertage werden übersprungen
+- Alle aktiven Mitarbeiter **mit der Option „Nimmt an Betriebsferien teil"** (Standard) erhalten für jeden ihrer **tatsächlichen Arbeitstage** im Zeitraum einen Abwesenheitseintrag – unabhängig von der Rolle, also auch Admins, die zugleich als Mitarbeiter geführt werden. Reine Verwaltungs-Accounts können die Option in der Benutzerverwaltung abwählen.
+- Vorhandene Arbeitszeit-Einträge an diesen Tagen werden ersetzt (im Änderungsprotokoll dokumentiert).
 
-> **Tipp – nachträglich Berechtigte ergänzen:** Aktivieren Sie die Option bei einem Mitarbeiter erst nach dem Anlegen der Betriebsferien, **speichern Sie die betreffenden Betriebsferien einmal erneut** (Bearbeiten → Speichern) – die Abwesenheiten werden dann für die nun berechtigten Personen nachgetragen.
+**Es wird _kein_ Eintrag gebucht an:**
+- Wochenenden und gesetzlichen **Feiertagen**
+- **freien Wochentagen** von Teilzeitkräften mit individuellem Tagesplan (Tagessoll an diesem Wochentag = 0)
+- als **„Frei" konfigurierten Sondertagen** (24./31.12.)
+- Tagen **außerhalb des Beschäftigungszeitraums**: noch nicht eingetretene (Eintrittsdatum in der Zukunft) oder bereits ausgetretene Mitarbeiter bekommen für die betreffenden Tage **keine** Betriebsferien-Einträge
+- Tagen, an denen die Mitarbeiterin bereits eine andere Abwesenheit hat (diese wird nicht überschrieben)
+
+### Verrechnung: Urlaub oder bezahlte Freistellung
+
+Beim Anlegen legen Sie unter **„Verrechnung"** fest, wie die Schließtage verbucht werden:
+
+| Auswahl | Wirkung |
+|---|---|
+| **Als Urlaub werten** (Standard) | Jeder gebuchte Schließtag wird vom **Urlaubskonto** der Mitarbeiter abgezogen (1 Tag pro Arbeitstag, Tagesprinzip). |
+| **Bezahlte Freistellung** | Wie ein Feiertag: das Tagessoll entfällt, es wird **kein** Urlaubstag abgezogen und das **Überstundenkonto** bleibt unberührt (saldoneutral). |
+
+> **Tipp – nachträglich Berechtigte ergänzen:** Aktivieren Sie die Option „Nimmt an Betriebsferien teil" bei einem Mitarbeiter und speichern Sie die Benutzer-Änderung. Die Abwesenheiten werden **automatisch** für alle laufenden und künftigen Betriebsferien nachgetragen – ein erneutes Speichern der Betriebsferien ist nicht mehr nötig, und bereits erfasste Arbeitszeiten bleiben erhalten. (Bereits abgelaufene Betriebsferien werden bewusst nicht rückwirkend ergänzt.)
+
+### Betriebsferien länger als der Jahresurlaub (#314)
+
+Sind die **als Urlaub** zählenden Betriebsferien länger als das **Resturlaub-Budget** einer Mitarbeiterin, hängt das Verhalten vom globalen Schalter **„Überzählige Betriebsferien als Überstundenabbau"** ab (unter **Einstellungen → „Betriebsferien & Urlaub"**, standardmäßig **aus**):
+
+- **Schalter AUS (Standard):** Alle Schließtage zählen als Urlaub. Übersteigen die Betriebsferien den Resturlaub, entstehen **Minus-Urlaubstage** (Pflichturlaub – die Schließung wird zwingend gebucht).
+- **Schalter AN:** Pro Mitarbeiter wird **erst der Urlaub aufgezehrt, dann auf Überstundenabbau** umgestellt. Die überzähligen Tage werden als **Überstundenausgleich** gebucht (das Soll bleibt, der Tag zählt als 0 Stunden → das Überstundenkonto sinkt um das Tagessoll und **darf ins Minus gehen**). So entsteht **nie Minus-Urlaub**.
+
+Wenn der Schalter aktiv ist, gilt zusätzlich:
+
+- **Kalenderreihenfolge:** Der Jahresurlaub wird den Betriebsferien **chronologisch nach Datum** zugeteilt (frühere Schließung zuerst) – **unabhängig davon, in welcher Reihenfolge Sie die Betriebsferien eingegeben haben**. Die Überstunden-Tage landen damit immer auf der **letzten** Schließung des Jahres.
+- **Privater Urlaub** im selben Jahr reduziert den für die Betriebsferien verfügbaren Urlaub mit – auch wenn er erst später im Jahr (z. B. im Sommer) gebucht ist. Urlaub wird also immer **zuerst** verbraucht, die Betriebsferien greifen nur auf den verbleibenden Rest zu.
+
+> **Wichtig – nachträglich aktivierter Schalter:** Der Schalter wirkt **beim Anlegen bzw. erneuten Speichern** von Betriebsferien. Für **bereits eingetragene** Betriebsferien öffnen Sie diese einmal unter „Betriebsferien" und **speichern erneut** – dann werden die Tage nach derselben Regel neu berechnet (Urlaub zuerst, danach Überstundenabbau).
 
 ### Betriebsferien löschen
 
@@ -441,11 +516,20 @@ Klicken Sie auf das Löschen-Symbol. Die Abwesenheitseinträge werden bei allen 
 
 ## 12. Import
 
-Unter **Import** können Sie Zeiteinträge oder Abwesenheitsdaten aus externen Quellen (z. B. CSV-Dateien) in das System importieren.
+Unter **Import** übernehmen Sie historische **Zeiteinträge** aus einer **TimeRec-Datei im `.xls`-Format**. Der Bereich ist für die einmalige Datenübernahme bei der Einführung von PraxisZeit gedacht (z. B. Altdaten aus der bisherigen Zeiterfassung).
 
-Dieser Bereich ist für die initiale Datenübernahme oder die Massenbefüllung bei der Einführung von PraxisZeit vorgesehen.
+> **Wichtig:** Importiert werden **ausschließlich Zeiteinträge** (Arbeitszeiten). **Abwesenheiten** (Urlaub, Krank usw.) werden **nicht** importiert. Es gibt **keine** Vorlagendatei zum Herunterladen und es werden **keine** CSV- oder `.xlsx`-Dateien unterstützt – nur das echte `.xls`-Format (BIFF) mit einem Tabellenblatt namens **„Zeiterfassung"**.
 
-**Vorgehensweise:** Laden Sie die Vorlagendatei herunter, befüllen Sie sie gemäß der Vorgaben und laden Sie die Datei wieder hoch.
+**Anforderungen an die Datei:**
+
+- Format **`.xls`** (TimeRec-Export), maximal **5 MB**
+- Tabellenblatt **„Zeiterfassung"** mit den Spalten Datum, Tag, Total, Ein, Aus, Tagesnotiz
+
+**Vorgehensweise (Assistent in drei Schritten):**
+
+1. **Hochladen:** Wählen Sie den/die **Mitarbeiter:in** aus, dem/der die Einträge zugeordnet werden, und laden Sie die `.xls`-Datei hoch (Drag & Drop oder Klick). Klicken Sie auf **„Datei analysieren"**.
+2. **Vorschau:** Das System zeigt alle gefundenen Einträge in einer Tabelle mit Datum, Von/Bis, Pause und Netto-Stunden. **Konflikte** (bereits vorhandene Einträge am selben Tag) werden rot, **ArbZG-Warnungen** (z. B. Ruhezeit, Höchstarbeitszeit) gelb markiert. Über die Option **„Konflikte überschreiben"** entscheiden Sie, ob vorhandene Einträge ersetzt werden – andernfalls werden sie übersprungen. Klicken Sie auf **„Import bestätigen"**.
+3. **Ergebnis:** Sie sehen, wie viele Einträge importiert, überschrieben oder übersprungen wurden sowie die ArbZG-Warnungen. Der Import wird im **Änderungsprotokoll** dokumentiert.
 
 ---
 
@@ -494,6 +578,16 @@ Der Schalter **„Genehmigung erforderlich"** steuert, ob Urlaubsanträge von ei
 
 Diese Einstellung lässt sich alternativ auch direkt im Bereich „Abwesenheitsanträge" umschalten.
 
+<a id="betriebsferien-urlaub"></a>
+### Betriebsferien & Urlaub
+
+Der Schalter **„Überzählige Betriebsferien als Überstundenabbau"** steuert, was passiert, wenn als Urlaub zählende Betriebsferien länger sind als der Resturlaub einer Mitarbeiterin (Standard: **aus**):
+
+- **Aus:** Alle Schließtage zählen als Urlaub. Reicht der Resturlaub nicht, entstehen **Minus-Urlaubstage**.
+- **Ein:** Zuerst wird der Urlaub aufgezehrt, die überzähligen Tage werden als **Überstundenausgleich** gebucht (das Überstundenkonto darf ins Minus gehen) – statt Minus-Urlaub.
+
+Die Option ist **global** und gilt nur für Betriebsferien, die als Urlaub gewertet werden. Sie wirkt **beim Anlegen bzw. erneuten Speichern** von Betriebsferien; bereits eingetragene Betriebsferien aktualisieren Sie durch erneutes Speichern (→ [Abschnitt 11](#11-betriebsferien-verwalten)).
+
 <a id="pflicht-pause-ausnahme"></a>
 ### Pflicht-Pause-Ausnahme
 
@@ -514,6 +608,56 @@ Im Bereich **„Soll-Arbeitszeit-Fenster"** legen Sie im Feld **„Puffer für S
 ### Farben
 
 Im Bereich **„Farben"** legen Sie für jeden Anwesenheits- und Abwesenheitstyp eine eigene Farbe fest (Arbeit/Anwesenheit, Fortbildung, Urlaub, Krank, Überstundenausgleich, Sonstiges, Bezahlte Freistellung). Die Farben werden im Kalender, in den Übersichten und bei der Zeiterfassung verwendet. Eine kleine „Aa"-Vorschau zeigt, ob die Schrift auf der gewählten Farbe lesbar bleibt.
+
+### Eigene Abwesenheitsgründe (#312)
+
+Im Bereich **„Eigene Abwesenheitsgründe"** legen Sie zusätzliche, frei benannte Gründe an (z. B. **„Schule"** für Auszubildende mit Berufsschultagen) – mit eigener Farbe. Jeder Grund hat ein **Basis-Verhalten**, das die Berechnung bestimmt:
+
+| Basis-Verhalten | Wirkung |
+|---|---|
+| **Zählt als gearbeitet** | Die geplanten Stunden werden als Arbeitszeit gutgeschrieben (wie Fortbildung) – passend für **Berufsschule** (Arbeitszeit nach § 15 JArbSchG), es entstehen keine Stundenverluste. |
+| **Bezahlt frei** | Das Tagessoll wird auf 0 gesetzt (saldoneutral), **kein** Urlaubsabzug – der Arbeitgeber zahlt weiter. |
+| **Unbezahlt frei** | Das Tagessoll wird auf 0 gesetzt (saldoneutral), **kein** Urlaubsabzug, aber **unbezahlt** (Lohn gekürzt) – für **Kind krank** (§45 SGB V) oder unbezahlten Sonderurlaub. |
+| **Überstundenabbau** | Das Überstundenkonto sinkt um das Tagessoll. |
+
+Das Basis-Verhalten ist **nach dem Anlegen fix**. Gründe lassen sich umbenennen, umfärben und deaktivieren (deaktivierte stehen beim Buchen nicht mehr zur Auswahl, bleiben aber an bestehenden Abwesenheiten erhalten). Beim Eintragen einer Abwesenheit erscheinen die eigenen Gründe unter **„Eigene Gründe"** in der Typ-Auswahl.
+
+> **Datenschutz:** Da ein eigener Grund sensibel sein kann (z. B. „Reha"), werden Abwesenheiten mit eigenem Grund im Team-Kalender für andere Mitarbeitende nur als **„abwesend"** angezeigt – nur Admins sehen die Bezeichnung.
+
+#### Kind krank & Sonderurlaub-Vorlagen (#376)
+
+Über die Schaltflächen unter **„Vorlagen (1-Klick aktivieren)"** legen Sie gängige Gründe direkt an – **Kind krank** (unbezahlt frei), **Todesfall naher Angehöriger**, **Eigene Hochzeit**, **Geburt eines Kindes**, **Umzug (betrieblich)**, **Arztbesuch**, **Pflege naher Angehöriger**. Das voreingestellte Verhalten (bezahlt/unbezahlt) können Sie je Betrieb frei anpassen – die rechtliche Einordnung (z. B. ob § 616 BGB im Arbeitsvertrag ausgeschlossen ist) liegt bei Ihnen.
+
+**Kind-krank-Jahreslimit (§45 SGB V):** Für den Grund **„Kind krank"** zählt PraxisZeit die genommenen Tage pro Kalenderjahr. Den Standard-Jahresanspruch stellen Sie unter **Einstellungen → „Kind-krank-Standardanspruch"** ein (Voreinstellung 15 Tage); pro Mitarbeiter:in lässt sich im Benutzerformular ein **individueller Wert** hinterlegen (Feld „Kind-krank-Tage/Jahr", leer = Standard). Wird der Anspruch beim Buchen überschritten, erscheint ein **Hinweis** – die Abwesenheit wird **trotzdem erfasst** (nicht blockiert), da der Fehltag dokumentiert werden muss (die Krankenkasse zahlt Kinderkrankengeld ggf. nicht mehr). Den Verbrauch je Mitarbeiter:in sehen Sie in der **Benutzerübersicht**.
+
+> **Hinweis:** PraxisZeit bildet die reine Zeiterfassung ab. Die Meldung an Krankenkasse und Lohnbuchhaltung erfolgt außerhalb der Software.
+
+### Minijob / Arbeitszeitkonto (§ 2 Abs. 2 MiLoG) (#377)
+
+Für Minijobber:innen, die **auf Arbeitszeitkonto** geführt werden („sonstige flexible Arbeitszeitregelung"), aktivieren Sie im Benutzerformular die Checkbox **„Arbeitszeitkonto (§ 2 Abs. 2 MiLoG)"**. PraxisZeit prüft dann zwei gesetzliche Grenzen als **weiche Hinweise** (nichts wird blockiert):
+
+- **50-%-Regel:** Die auf das Konto eingestellten Plusstunden dürfen pro Monat **50 % der vertraglich vereinbarten Arbeitszeit** nicht übersteigen. Bei aktivem Arbeitszeitkonto erscheint das Feld **„Vereinbarte Monatsarbeitszeit (h)"** — tragen Sie dort die vereinbarte Monatszahl direkt ein (z. B. **33** → max. 16,5 h Konto/Monat). Bleibt das Feld leer, wird die Monatszeit wie bisher aus den Wochenstunden abgeleitet (× 13/3, z. B. 7,62 h/Woche ≈ 33 h/Monat). Die eingegebene Monatszahl ist die vertragliche Bezugsgröße für die **50-%-Prüfung**. Das **12-Monats-Aging** bleibt bewusst Soll-basiert (rechnet gegen das tatsächliche Monats-Soll, damit Urlaub/Feiertage das Konto nicht belasten). Der Hinweis erscheint beim Buchen/Ausstempeln, im **eigenen Überstundenkonto** der/des MA und in der **Benutzerübersicht**.
+- **12-Monats-Ausgleichsfrist:** Konto-Stunden müssen binnen 12 Kalendermonaten ausgeglichen werden — bei Überfälligkeit ein Hinweis.
+
+Der **aktuelle gesetzliche Mindestlohn** (§ 1 MiLoG) wird unter **Einstellungen → „Gesetzlicher Mindestlohn"** angezeigt.
+
+> **Wichtig:** Die 50-%-Grenze bindet nur die **mindestlohnwirksamen** Stunden. Wird über dem Mindestlohn vergütet, sind mehr Stunden möglich — der Hinweis ist dann ggf. unkritisch, bitte prüfen. PraxisZeit speichert **keine Lohndaten** und prüft daher **nicht** die 603-€-Verdienstgrenze; das bleibt der Lohnbuchhaltung vorbehalten. Die vereinbarte **Monatsarbeitszeit** kann im Feld „Vereinbarte Monatsarbeitszeit (h)" direkt eingegeben werden (siehe oben); sie ist die vertragliche Bezugsgröße für die **50-%-Prüfung**. Das **12-Monats-Aging** bleibt bewusst Soll-basiert (siehe oben) und ändert sich dadurch nicht.
+
+#### Feste Monatsarbeitszeit (Minijob-Modus, #377 Baustein 2b)
+
+Für Minijobber:innen mit einer **fest vereinbarten Monatsarbeitszeit**, die jeden Monat **gleich** sein soll (statt aus Wochenstunden/Arbeitstagen zu schwanken), aktivieren Sie zusätzlich zum Arbeitszeitkonto die Checkbox **„Feste Monatsarbeitszeit (Monats-Soll = vereinbarte Monatsarbeitszeit)"**. Sie erscheint nur, wenn „Arbeitszeitkonto (§ 2 Abs. 2 MiLoG)" bereits aktiv ist, und macht das Feld „Vereinbarte Monatsarbeitszeit (h)" zur **Pflichtangabe**.
+
+Mit aktivem Modus gilt:
+
+- **Monats-Soll ist fix:** Statt der Tagessoll-Summe über die Arbeitstage des Monats zählt jeden Monat exakt die vereinbarte Monatsarbeitszeit als Soll — egal ob der Monat 4 oder 5 Montage hat. Bei unterjährigem Ein-/Austritt wird das Soll **anteilig nach Kalendertagen** des Beschäftigungsfensters im Monat berechnet.
+- **Individuelle Tagesstunden werden zur geplanten Anwesenheit:** Die Tagesstunden-Matrix (Mo–Fr, unter „Individuelle Tagesstunden") heißt in diesem Modus „Geplante Anwesenheit" und steuert **nicht mehr das Soll**, sondern nur noch, wie viele Stunden an Feiertags-/Fehltagen gutgeschrieben werden. Sie darf frei bzw. lückenhaft gesetzt sein (z. B. nur Montag und Mittwoch).
+- **Feiertag, Urlaub oder bezahlte Freistellung auf einem geplanten Tag** schreiben die geplanten Stunden dieses Wochentags dem **Ist** gut, als wäre gearbeitet worden (Konto-Wirkung: neutral statt Minus). Krankheit und Fortbildung waren bereits vorher als Ist gutgeschrieben und ändern sich nicht.
+- **Unbezahlt entschuldigte Tage** (Typ „Sonstiges", z. B. ein „unbezahlt frei"-Grund wie Kind krank) **mindern stattdessen das feste Monats-Soll** um die geplanten Stunden — es gibt keine Vergütungspflicht, also auch keine Ist-Gutschrift.
+- Übersteigt das erfasste Monats-Ist (inkl. Gutschriften) die vereinbarte Monatsarbeitszeit, erscheint eine **weiche Warnung** (nicht blockierend) — beim Buchen, im eigenen Überstundenkonto und in der Benutzerübersicht, wie die übrigen MiLoG-Hinweise.
+
+> **⚠️ Bekannte Grenze — volle Fehlmonate:** Liegen die geplanten Tagesstunden deutlich **unter** der vereinbarten Monatszeit (weil ein Teil der Zeit flexibel, ohne festen Plan, gearbeitet wird), deckt die automatische Gutschrift bei einem **einzelnen** Fehltag (Feiertag, ein Urlaubstag) korrekt den geplanten Anteil ab. Fällt jedoch ein **kompletter Monat** durch Urlaub oder Krankheit ganz aus, wird nur der geplante Anteil gutgeschrieben — der **flexible Rest** bleibt als Konto-Defizit stehen. In diesem seltenen Fall ist eine **manuelle Korrektur** durch den Betrieb nötig (z. B. über das Überstundenkonto oder den Jahresübertrag). Für den Regelfall einzelner Fehltage ist die Berechnung vollautomatisch korrekt.
+
+Ist der Modus **nicht** aktiviert, bleibt das Verhalten für alle Mitarbeitenden unverändert (das bestehende Tages-Soll-Modell).
 
 ---
 
@@ -699,7 +843,7 @@ Mitarbeiter können nicht nur Zeiteinträge korrigieren, sondern auch **Abwesenh
 
 ## 18. Berechnungsgrundlagen (Anhang)
 
-> Dieser Anhang erklärt **vollständig und exakt**, wie PraxisZeit Soll-, Ist-, Überstunden- und Urlaubswerte ermittelt – auf dem tatsächlichen Rechenstand der Software (Version 1.8.2). Die ausführliche, code-nahe Referenz mit allen durchgerechneten Beispielen (Teilzeit, individueller Tagesplan, Pro-rata, Historie) steht in [`docs/BERECHNUNGEN.md`](../BERECHNUNGEN.md).
+> Dieser Anhang erklärt **vollständig und exakt**, wie PraxisZeit Soll-, Ist-, Überstunden- und Urlaubswerte ermittelt – auf dem tatsächlichen Rechenstand der Software (Version 1.15.0). Die ausführliche, code-nahe Referenz mit allen durchgerechneten Beispielen (Teilzeit, individueller Tagesplan, Pro-rata, Historie) steht in [`docs/BERECHNUNGEN.md`](../BERECHNUNGEN.md).
 
 ### 18.1 Grundbegriffe
 
@@ -758,17 +902,30 @@ PraxisZeit geht jeden Kalendertag des Monats durch und addiert das Tagessoll –
 
 ### 18.7 Urlaubskonto (Tagesprinzip)
 
-- **Budget** = Jahresanspruch in Tagen (anteilig bei unterjährigem Eintritt/Austritt) + Resturlaub-Carryover.
-- **Verbrauch:** Nur Urlaub belastet das Budget. Jeder freie Arbeitstag kostet **1 Tag** (Halbtag 0,5) – unabhängig von der Stundenzahl des Tages.
+Urlaub wird grundsätzlich **in Tagen** geführt, nicht in Stunden (Tagesprinzip § 3 BUrlG). **Resturlaub = Anspruch − Verbrauch.**
+
+**Anspruch (Budget):**
+- **Jahresanspruch in Tagen** + Resturlaub-Vortrag (Carryover) aus dem Jahresabschluss.
+- **Anteilig (pro rata)** bei unterjährigem Eintritt/Austritt – nach den tatsächlichen Beschäftigungsmonaten.
+- **Teilzeit nach Arbeitstagen/Woche:** Anspruch = `30 × Arbeitstage pro Woche ÷ 5`. Wer weniger Tage pro Woche arbeitet, hat anteilig weniger Urlaubstage; wer 5 (kürzere) Tage arbeitet, behält den vollen Tagesanspruch von 30. Beispielwerte: 5 Tage → 30; 4 Tage → 24; 3 Tage → 18. Der Wert ist beim Anlegen **überschreibbar**.
+
+**Verbrauch:**
+- Nur **Urlaub** belastet das Budget (bezahlte Freistellung, Krank, Fortbildung **nicht**). Jeder freie Arbeitstag kostet **1 Tag** (Halbtag 0,5) – unabhängig von der Stundenzahl des Tages.
+- Als **„Frei" + „zählt als Urlaub"** konfigurierte **Sondertage 24./31.12.** kosten je **1 Urlaubstag** – auch ohne eigenen Abwesenheitseintrag.
 - **Budget-Check** beim Antrag zählt **buchbare Arbeitstage** (Tagessoll > 0). Eine ganze Urlaubswoche kostet einen 3-Tage-Mitarbeiter nur 3 Tage.
-- Jahresanspruch-Vorschlag: `30 × Arbeitstage ÷ 5` (5 Tage → 30; 3 Tage → 18), überschreibbar.
+
+**Beschäftigungsfenster:** Vor dem ersten / nach dem letzten Arbeitstag entstehen **weder Anspruch noch Verbrauch**.
+
+**Live-Anzeige:** Die Konto-Anzeigen rechnen „bis heute" (Stichtag, siehe Abschnitt 18.6); rechtsverbindliche Datei-Exporte rechnen den vollen Zeitraum.
 
 ### 18.8 Sonderfälle
 
-- **Mitarbeiter ohne Stundenzählung (leitende Angestellte):** kein Soll/Ist/Überstunden; Urlaub trotzdem tagebasiert (jeder Urlaubs-/Sondertag = 1 Tag).
+- **Mitarbeiter ohne Stundenzählung (leitende Angestellte):** kein Soll/Ist/Überstunden; Urlaub trotzdem tagebasiert (voller Urlaubstag / „Frei"-Sondertag = 1 Tag, „halber Feiertag" 24./31.12. = 0,5 Tag seit #394).
 - **Sondertage 24./31.12.:** je Tag Arbeitstag / Halbtag (Faktor 0,5) / Frei (Faktor 0). „Frei + zählt als Urlaub" zieht 1 Urlaubstag.
 - **Eintritt/Austritt:** vor dem ersten / nach dem letzten Arbeitstag entstehen weder Soll noch Ist; der Urlaubsanspruch wird anteilig berechnet.
 - **Rückwirkende Stundenänderung:** alte Monate rechnen mit dem damals gültigen Wochensoll (Stundenhistorie / Wirkungsdatum).
+- **Betriebsferien:** je nach Verrechnung Urlaubsabzug oder bezahlte Freistellung; bei aktivem Schalter „Überzählige Betriebsferien als Überstundenabbau" zuerst Urlaub, dann Überstundenausgleich (kein Minus-Urlaub) – Details in [Abschnitt 11](#11-betriebsferien-verwalten).
+- **Feste Monatsarbeitszeit (Minijob-Modus, #377 Baustein 2b):** für MA mit aktiviertem Modus gilt statt 18.4/18.5 ein **festes** Monats-Soll (= vereinbarte Monatsarbeitszeit, kalendertag-pro-rata bei Ein-/Austritt); Feiertag/Urlaub/bezahlte Freistellung auf einem geplanten Tag schreiben die geplanten Stunden dem Ist gut, unbezahlte Fehltage mindern stattdessen das feste Soll. Details, Voraussetzungen und die bekannte Fehlmonat-Grenze in [Abschnitt 13 → „Feste Monatsarbeitszeit"](#13-einstellungen).
 
 ### 18.9 Durchgerechnetes Beispiel (Vollzeit)
 
@@ -786,5 +943,77 @@ Urlaubskonto = 30 − 4                     = 26 Tage übrig
 
 ---
 
+## 19. Datensicherung (Backup & Restore)
+
+Unter **Admin → Datensicherung** (ab Version 1.9.0) verwalten Sie Backups ohne Kommandozeile — in der Docker- **und** der nativen Installation:
+
+- **Jetzt sichern** — erstellt umgehend ein vollständiges, komprimiertes Backup (`praxiszeit_<Zeitstempel>.sql.gz`, Plain-SQL mit `--clean --if-exists`).
+- **Geplante Sicherung** — tägliche automatische Sicherung zur eingestellten Stunde aktivieren, mit Aufbewahrungsdauer (Tage) und optionalem Speicherort.
+- **Liste** — vorhandene Sicherungen **herunterladen** (für eine externe Kopie) oder löschen.
+
+**Wo:** Docker im Volume `praxiszeit_backups`, native im `data/backups/`-Verzeichnis.
+
+**§16 ArbZG:** Zeitaufzeichnungen mindestens **2 Jahre** aufbewahren — Aufbewahrungsdauer entsprechend setzen, eine Kopie **außerhalb** des Servers vorhalten und vor jedem Update zusätzlich sichern.
+
+> **Native:** Die *geplante* Sicherung läuft weiterhin über den OS-Timer (systemd/launchd/Task); der *manuelle* Trigger und die Liste funktionieren überall.
+
+**Wiederherstellung** (idempotent dank `--clean --if-exists`, kein manuelles Leeren der DB nötig) und alle Kommandozeilen-Varianten: siehe [`docs/BACKUP.md`](../BACKUP.md).
+
+---
+
+## Schichtplanung (optional, standardmäßig deaktiviert)
+
+Mit der **Schichtplanung** erstellen Sie wöchentliche Einsatzpläne (wer steht
+wann an welchem Arbeitsplatz). Sie ist ein **reines Planungswerkzeug** und
+verändert **nicht** Zeiterfassung, Soll/Ist-Stunden, ArbZG-Prüfungen, Urlaub
+oder Überstunden.
+
+**Aktivieren:** **Einstellungen → Schichtplanung → „Schichtplanung aktivieren"
+→ Speichern.** Das Modul ist nach der Installation **aus**; nur Admins können es
+einschalten. Erst danach erscheinen die Menüpunkte und das Dashboard-Widget.
+
+**Geplante Wochentage (#371):** Direkt darunter (nur bei aktiver Schichtplanung)
+legen Sie fest, **welche Wochentage** der Planer anzeigt und plant – Standard
+**Mo–Fr**. Samstag/Sonntag oder ein Schließtag (z. B. Donnerstag) lassen sich
+einzeln zu-/abschalten (mindestens ein Tag muss aktiv bleiben). Ein abgeschalteter
+Tag verschwindet aus der Wochenansicht, nimmt keine neuen Slots auf und wird von
+der Auto-Generierung übersprungen; bereits angelegte Slots bleiben erhalten und
+kehren beim Reaktivieren des Tages zurück.
+
+**Stammdaten:** **Standorte** (optional) und **Arbeitsplätze** (Tresen, Labor,
+Springer … mit Farbe) anlegen. **Schichtpläne:** beliebig viele benannte
+Wochenpläne („Normalzustand", „Azubis Schulferien" …). Im **Wochen-Editor**
+Zeitslots per **Drag & Drop** oder Klick-Dialog über die Woche verteilen,
+**Mitarbeitende** per Drag auf einen Slot ziehen, optional eine
+**Mindestbesetzung** setzen (unterbesetzte Slots werden markiert – weiche
+Warnung, blockiert nicht).
+
+**Aktiv schalten** macht einen Plan für alle sichtbar; **mehrere Pläne können
+gleichzeitig aktiv** sein. Mitarbeitende sehen ihre heutige Einteilung im
+Dashboard.
+
+Im Reiter **Einweisungen** legen Sie per Matrix (Mitarbeiter × Arbeitsplätze)
+fest, wer für welchen Arbeitsplatz eingewiesen ist. Beim Zuweisen einer nicht
+eingewiesenen Person erscheint die weiche Warnung „nicht eingewiesen" (blockiert
+nicht); Mitarbeitende sehen ihre Einweisungen im Profil.
+
+Über **Bearbeiten** setzen Sie pro Plan optional ein **Aktiv-Datums-Fenster**
+(„von/bis"), in dem der Plan automatisch aktiv wird (Jahresübersicht als
+Zeitstrahl). **Automatisch füllen** verteilt eingewiesene, verfügbare
+Mitarbeitende greedy auf die Slots (Zielwoche wählbar, ausgewogen nach
+Auslastung/Überstunden) — als Entwurf zum Review, ohne den Plan zu aktivieren.
+
+Mit dem **Woche/Tag**-Umschalter im Editor zeigen Sie wahlweise die ganze Woche
+oder einen einzelnen Wochentag in voller Breite an (#321). Beim **Bearbeiten**
+eines Slots kopiert **„Auf Wochentage kopieren"** die Schicht inkl. Zuweisungen
+auf weitere Wochentage – praktisch für wiederkehrende Schichten (#322). In der
+Mitarbeiterliste des Editors steht unter jedem Namen die **Auslastung** der
+zugewiesenen Schichtstunden zur Wochenarbeitszeit (z. B. **„15,25 / 17 h"**):
+grün bei ±30 Minuten zur Vertragszeit, gelb bei ±1 Stunde, sonst rot – das
+erleichtert eine ausgewogene Einteilung (#330).
+Details: [`docs/SCHICHTPLANUNG.md`](../SCHICHTPLANUNG.md).
+
+---
+
 *PraxisZeit – Zeiterfassungssystem für Arztpraxen und kleine Unternehmen*
-*Stand: Juni 2026 (Version 2.4, für PraxisZeit 1.8.2)*
+*Stand: Juli 2026 (für PraxisZeit 1.15.0)*

--- a/frontend/public/help/HANDBUCH-MITARBEITER.md
+++ b/frontend/public/help/HANDBUCH-MITARBEITER.md
@@ -1,6 +1,6 @@
 # PraxisZeit – Mitarbeiter-Handbuch
 
-**Version:** 2.1 · **Stand:** April 2026
+**Version:** 2.5 · **Stand:** Juli 2026 (PraxisZeit 1.15.0)
 **System:** PraxisZeit Zeiterfassungssystem
 **Zugangsdaten:** Benutzername und Passwort vom Administrator
 
@@ -11,17 +11,23 @@
 1. [Anmelden](#1-anmelden)
 2. [Dashboard – Die Übersicht](#2-dashboard--die-übersicht)
 3. [Zeiterfassung](#3-zeiterfassung)
-   - 3.1 [Arbeitszeit eintragen](#31-arbeitszeit-eintragen)
-   - 3.2 [Eintrag bearbeiten oder löschen](#32-eintrag-bearbeiten-oder-löschen)
-   - 3.3 [Korrekturantrag stellen](#33-korrekturantrag-stellen)
-   - 3.4 [Anträge verwalten (Anträge-Tab)](#34-anträge-verwalten-anträge-tab)
+   - 3.1 [Ein- und Ausstempeln (Stoppuhr)](#31-ein--und-ausstempeln-stoppuhr)
+   - 3.2 [Arbeitszeit von Hand eintragen](#32-arbeitszeit-von-hand-eintragen)
+   - 3.3 [Soll-Arbeitszeiten und Anrechnung](#33-soll-arbeitszeiten-und-anrechnung)
+   - 3.4 [Eintrag bearbeiten oder löschen](#34-eintrag-bearbeiten-oder-löschen)
+   - 3.5 [Korrekturantrag stellen](#35-korrekturantrag-stellen)
+   - 3.6 [Anträge verwalten (Anträge-Tab)](#36-anträge-verwalten-anträge-tab)
 4. [Abwesenheiten](#4-abwesenheiten)
    - 4.1 [Abwesenheit eintragen](#41-abwesenheit-eintragen)
    - 4.2 [Urlaubsantrag stellen (bei Genehmigungspflicht)](#42-urlaubsantrag-stellen-bei-genehmigungspflicht)
    - 4.3 [Abwesenheit löschen](#43-abwesenheit-löschen)
-5. [Profil & Passwort](#5-profil--passwort)
-6. [Mobil-Nutzung](#6-mobil-nutzung)
-7. [Häufige Fragen (FAQ)](#7-häufige-fragen-faq)
+   - 4.4 [So wird Ihr Urlaub berechnet](#44-so-wird-ihr-urlaub-berechnet)
+   - 4.5 [Betriebsferien (Praxisschließung)](#45-betriebsferien-praxisschließung)
+5. [So berechnet PraxisZeit Ihre Stunden und Ihren Urlaub](#5-so-berechnet-praxiszeit-ihre-stunden-und-ihren-urlaub)
+6. [Wenn für Sie keine Stunden gezählt werden](#6-wenn-für-sie-keine-stunden-gezählt-werden)
+7. [Profil & Passwort](#7-profil--passwort)
+8. [Mobil-Nutzung](#8-mobil-nutzung)
+9. [Häufige Fragen (FAQ)](#9-häufige-fragen-faq)
 
 ---
 
@@ -59,7 +65,13 @@ Das Dashboard zeigt Ihnen auf einen Blick:
 | **Überstundenkonto** | Kumulierter Jahressaldo aller Monate |
 | **Urlaubskonto** | Budget, verbrauchte und verbleibende Urlaubstage |
 
+> **Monatssaldo nur bis zum letzten Arbeitstag:** Im **laufenden** Monat wird das Soll nur bis zum **letzten abgeschlossenen Arbeitstag** gezählt – Sie starten den Monat also **nicht** mit einem dicken Minus, sondern der Saldo baut sich Tag für Tag auf. Der heutige Tag zählt mit, sobald Sie **ausgestempelt** haben. Für **abgeschlossene** Monate entspricht der Saldo wie gewohnt dem vollen Monat. Das **Überstundenkonto** übernimmt für den laufenden Monat denselben Stichtag – auch hier entsteht am Monatsanfang kein künstliches Minus.
+
 > **Zeitanzeige:** Stunden werden im Format H:MM angezeigt (z. B. „8:30" für 8 Stunden 30 Minuten). Negative Salden werden mit einem Minus-Zeichen dargestellt (z. B. „-2:15").
+
+> **Hinweis:** Falls Ihre Praxis für Sie **keine Stundenzählung** führt, fehlen die Kacheln **Tagessaldo**, **Monatssaldo** und **Überstundenkonto** – das ist bei Ihnen so eingestellt und kein Fehler. Ihr **Urlaubskonto** wird trotzdem geführt. Mehr dazu in [Abschnitt 6](#6-wenn-für-sie-keine-stunden-gezählt-werden).
+
+> **Minijob mit festem Monats-Soll:** Führt Ihre Praxis Sie als Minijob-Kraft mit einer **festen vereinbarten Monatsarbeitszeit** (statt eines aus Wochenstunden berechneten Solls), zeigt Ihr **Monatssaldo** jeden Monat dasselbe feste Soll (bei unterjährigem Ein-/Austritt anteilig gekürzt). Feiertage sowie Urlaub oder bezahlte Freistellung an einem für Sie geplanten Arbeitstag werden Ihnen dabei automatisch mit den geplanten Stunden gutgeschrieben; unbezahlt freie Tage mindern das Monatssoll entsprechend. Unter dem **Überstundenkonto** kann in diesem Fall ein gelber Hinweis erscheinen, wenn die vereinbarte Zeit deutlich überschritten wird oder ein Zeitguthaben zu lange nicht ausgeglichen wurde (§ 2 Abs. 2 MiLoG) – das ist eine reine Information und blockiert nichts. Ob dieses Modell für Sie gilt, legt Ihre Praxisleitung fest.
 
 ### Monatsübersicht (Tabelle)
 
@@ -70,7 +82,7 @@ Zeigt die vergangenen Monate mit Soll, Ist, Saldo und kumuliertem Überstundenko
 
 ### Jahresübersicht
 
-Zeigt die Abwesenheitstage des laufenden Jahres nach Typ (Urlaub, Krank, Fortbildung, Sonstiges).
+Zeigt die Abwesenheitstage des laufenden Jahres nach Typ (Urlaub, Krank, Fortbildung, Überstundenausgleich, Sonstiges).
 
 ### Geplante Abwesenheiten im Team
 
@@ -113,9 +125,37 @@ Die Seite gliedert sich in **drei Tabs**:
 
 ---
 
-### 3.1 Arbeitszeit eintragen
+### 3.1 Ein- und Ausstempeln (Stoppuhr)
 
-Klicken Sie oben rechts auf **+ Neuer Eintrag**.
+Am einfachsten erfassen Sie Ihre Arbeitszeit live mit der Stempeluhr. Sie finden den **Einstempeln**-Button auf dem Dashboard (am Smartphone zusätzlich über den großen Knopf unten in der Mitte).
+
+**So stempeln Sie ein:**
+
+1. Klicken bzw. tippen Sie auf **Einstempeln**.
+2. Die Uhr beginnt zu laufen und zeigt Ihre heutige Arbeitszeit live an.
+
+**So stempeln Sie aus:**
+
+1. Klicken bzw. tippen Sie auf **Ausstempeln**.
+2. Es erscheint ein Feld **Pause (Min.)** – tragen Sie hier ein, wie viele Minuten Pause Sie heute gemacht haben (z. B. `30`).
+3. Klicken bzw. tippen Sie auf **Jetzt ausstempeln**.
+
+> **Wichtig – Pause nacherfassen (§ 4 ArbZG):**
+> Wenn Sie an einem Tag **mehr als 6 Stunden** gearbeitet haben, schreibt das Gesetz eine Pause vor (mind. 30 Min. bei mehr als 6 h, mind. 45 Min. bei mehr als 9 h). Tragen Sie deshalb beim Ausstempeln Ihre tatsächliche Pause ein.
+>
+> Reicht die eingetragene Pause nicht aus, erscheint ein gelber Hinweis. Sie haben dann **zwei Möglichkeiten**:
+> 1. **Pause oben nachtragen** – wenn Sie tatsächlich länger Pause gemacht haben, korrigieren Sie einfach die Minuten.
+> 2. **Begründung angeben** – falls eine Pause wirklich nicht möglich war, schreiben Sie in das Textfeld kurz, warum (z. B. „Notfall, keine Vertretung"). Diese **dokumentierte Ausnahme** wird gespeichert, und Sie können danach normal ausstempeln.
+>
+> Anders als früher genügt also kein flüchtiger Hinweis mehr – Sie müssen entweder die Pause eintragen **oder** die Ausnahme begründen, bevor das Ausstempeln abgeschlossen wird.
+
+> **Verschrieben?** Mit **Abbrechen** schließen Sie das Pausenfeld wieder, ohne auszustempeln – die Uhr läuft weiter.
+
+---
+
+### 3.2 Arbeitszeit von Hand eintragen
+
+Wenn Sie nicht gestempelt haben (z. B. einen vergangenen Tag nachtragen möchten), klicken Sie oben rechts auf **+ Neuer Eintrag**.
 
 ![Zeiteintrag Formular](screenshots/04-ma-zeiteintrag-formular.png)
 
@@ -135,13 +175,27 @@ Klicken Sie auf **Speichern**. Mit **Abbrechen** (oben rechts) verwerfen Sie das
 > PraxisZeit prüft Eingaben automatisch auf ArbZG-Einhaltung:
 >
 > - **> 8 Stunden Netto:** Hinweis gem. [§ 3 ArbZG](https://www.gesetze-im-internet.de/arbzg/__3.html)
-> - **> 10 Stunden Netto:** Eintrag wird blockiert (Tageshöchstgrenze)
+> - **> 10 Stunden Netto:** Bei **manueller Eingabe** (wie hier) wird der Eintrag blockiert (Tageshöchstgrenze). Beim **Live-Ausstempeln** wird stattdessen nur gewarnt — die Zeit ist dann bereits geleistet und § 16-aufzeichnungspflichtig.
 > - **Zu kurze Pause:** Warnung gem. [§ 4 ArbZG](https://www.gesetze-im-internet.de/arbzg/__4.html):
 >   bei > 6h → mind. 30 Min.; bei > 9h → mind. 45 Min.
 
 ---
 
-### 3.2 Eintrag bearbeiten oder löschen
+### 3.3 Soll-Arbeitszeiten und Anrechnung
+
+Manche Praxen hinterlegen für einzelne Wochentage **feste Soll-Arbeitszeiten** (z. B. „Montag 8:00–17:00"). Ist das bei Ihnen eingestellt, gilt:
+
+- **Zu früh eingestempelt:** Stempeln Sie deutlich **vor Ihrem Soll-Beginn** ein, wird die Zeit davor nicht als Arbeitszeit angerechnet. Ein kleiner **Puffer** (Standard 15 Minuten) ist erlaubt. Sie sehen dann den Hinweis: *„Du hast vor deinem Soll-Beginn eingestempelt – die Anrechnung beginnt ab dem frühestmöglichen Zeitpunkt."*
+- **Zu spät ausgestempelt:** Bleiben Sie nach Ihrem **Soll-Ende** noch deutlich länger (über den Puffer hinaus), wird die Zeit danach ebenfalls nicht mitgezählt.
+- In der Eintragsliste erkennen Sie das an einer kleinen Zusatzzeile unter der Uhrzeit, z. B. *„gestempelt 07:30 · angerechnet ab 07:45"*.
+
+> **Ihre echte Stempelzeit geht nicht verloren:** Der Zeitpunkt, zu dem Sie tatsächlich gestempelt haben, bleibt immer gespeichert (gesetzlich vorgeschrieben, § 16 ArbZG). Für Ihr Stundenkonto wird nur die **angerechnete** Zeit verwendet.
+
+> **Hinweis:** Diese Begrenzung ist **nur aktiv, wenn Ihre Praxis Soll-Zeiten für Sie hinterlegt hat**. Ist nichts hinterlegt, ändert sich für Sie nichts – dann zählt Ihre gestempelte Zeit ganz normal. Bei Fragen zu Ihren Soll-Zeiten wenden Sie sich an Ihren Administrator.
+
+---
+
+### 3.4 Eintrag bearbeiten oder löschen
 
 In der Spalte **Aktionen** finden Sie Buttons je nach Zustand des Eintrags:
 
@@ -153,12 +207,12 @@ In der Spalte **Aktionen** finden Sie Buttons je nach Zustand des Eintrags:
 | **Löschantrag** | Antrag auf Löschung eines gesperrten Eintrags stellen |
 
 > **Warum können ältere Einträge nicht direkt geändert werden?**
-> Nach einer Sperrfrist gelten Einträge als bestätigt. Korrekturen erfordern dann einen formellen Antrag (→ [Abschnitt 3.3](#33-korrekturantrag-stellen)).
+> Nach einer Sperrfrist gelten Einträge als bestätigt. Korrekturen erfordern dann einen formellen Antrag (→ [Abschnitt 3.5](#35-korrekturantrag-stellen)).
 > Dies dient der Nachvollziehbarkeit gem. [§ 16 ArbZG](https://www.gesetze-im-internet.de/arbzg/__16.html).
 
 ---
 
-### 3.3 Korrekturantrag stellen
+### 3.5 Korrekturantrag stellen
 
 Wenn ein Eintrag gesperrt ist oder Sie nachträglich eine Korrektur beantragen möchten, klicken Sie in der Zeile des betroffenen Eintrags auf den Button **Änderungsantrag**.
 
@@ -170,6 +224,9 @@ Ein Dialog öffnet sich mit dem Vergleich von aktuellem und gewünschtem Eintrag
 
 Für eine vollständige Löschung eines gesperrten Eintrags klicken Sie stattdessen auf **Löschantrag**, geben eine Begründung ein und bestätigen.
 
+> **Pflicht-Pause war nicht möglich? (§ 4 ArbZG):**
+> Wenn Ihre korrigierten Zeiten die Pausenregel nicht erfüllen (mind. 30 Min. bei mehr als 6 h, mind. 45 Min. bei mehr als 9 h), wird Ihr Antrag **nicht einfach abgelehnt**. Stattdessen erscheint ein zusätzliches Feld **„Pflicht-Pause war nicht möglich – Begründung"**. Tragen Sie dort kurz ein, warum keine ausreichende Pause möglich war (z. B. „Notfall, keine Vertretung verfügbar"), und senden Sie den Antrag mit **Mit dokumentierter Ausnahme senden** ab. Die Abweichung wird dokumentiert und dem Administrator zur Genehmigung vorgelegt.
+
 **Was danach passiert:**
 - Der Antrag erscheint beim Administrator zur Prüfung
 - Sie sehen den Status unter **Zeiterfassung → Tab „Anträge"**
@@ -177,7 +234,7 @@ Für eine vollständige Löschung eines gesperrten Eintrags klicken Sie stattdes
 
 ---
 
-### 3.4 Anträge verwalten (Anträge-Tab)
+### 3.6 Anträge verwalten (Anträge-Tab)
 
 Wechseln Sie im Tab-Menü der Zeiterfassung auf **Anträge**.
 
@@ -219,6 +276,10 @@ Die Seite zeigt zwei Tabs:
 | Orange | Fortbildung |
 | Grau | Sonstiges |
 
+> **Sondertage 24./31.12.:** Hat Ihre Praxis Heiligabend oder Silvester als arbeitsfrei oder halben Tag eingestellt, sind diese Tage im Kalender entsprechend markiert (grau „Heiligabend (frei)" bzw. „Silvester (½ Tag)") – ähnlich einem Feiertag.
+
+> **Datenschutz bei Kollegen-Abwesenheiten:** Im Team-Kalender sehen Sie bei **Kolleginnen und Kollegen** nur Urlaub und Fortbildung mit ihrem echten Typ. Krankheit, bezahlte Freistellung, Sonstiges und alle eigenen (individuellen) Abwesenheitsgründe werden bei anderen Personen neutral als **„Abwesend"** angezeigt. Ihre **eigenen** Abwesenheiten sehen Sie natürlich immer mit dem echten Typ, ebenso Administratorinnen und Administratoren.
+
 ---
 
 ### 4.1 Abwesenheit eintragen
@@ -231,9 +292,11 @@ Klicken Sie auf **+ Abwesenheit eintragen**.
 
 1. **Datum** – Beginn der Abwesenheit
 2. **Zeitraum** – Aktivieren Sie diese Option für mehrere Tage; Wochenenden und Feiertage werden automatisch ausgeschlossen
-3. **Typ** – Urlaub / Krank / Fortbildung / Sonstiges
-4. **Notiz** – Optional
-5. **Speichern**
+3. **Halber Tag** – Nur bei einzelnen Tagen wählbar (nicht bei Zeitraum, nicht bei Krank oder Überstundenausgleich); lässt den Tag nur zur Hälfte zählen (**0,5 statt 1,0 Tag**)
+4. **Typ** – Urlaub / Krank / Fortbildung / Überstundenausgleich / Sonstiges
+5. **Stunden** – Bei Urlaub, Krank, Fortbildung und Sonstigem ist das Feld vorausgefüllt und wird ohnehin durch Ihr Tagessoll ersetzt; nur bei **Überstundenausgleich** zählt der hier eingetragene Wert – er wird von Ihrem Überstundenkonto abgezogen
+6. **Notiz** – Optional
+7. **Speichern**
 
 > **Hinweis zu Urlaubstagen:**
 > Das System berechnet automatisch, wie viele Urlaubstage eingetragen werden und zieht diese von Ihrem Budget ab.
@@ -245,7 +308,12 @@ Klicken Sie auf **+ Abwesenheit eintragen**.
 | **Urlaub** | Genehmigter Erholungsurlaub |
 | **Krank** | Krankheitstage – Krankmeldung nach Praxisregelung einreichen |
 | **Fortbildung** | Externe Schulungen, Seminare, Pflichtfortbildungen |
+| **Überstundenausgleich** | Abbau angesammelter Überstunden – Ihr Soll bleibt bestehen, das Überstundenkonto sinkt um die eingetragenen Stunden |
 | **Sonstiges** | Arzttermine, Behördengänge, sonstige Freistellungen |
+
+> **Eigene Gründe:** Hat Ihre Praxis zusätzliche Abwesenheitsgründe eingerichtet (z. B. „Schule"), erscheinen diese bei der Typ-Auswahl unter **„Eigene Gründe"**. Wählen Sie sie wie einen normalen Typ aus.
+
+> **Kind krank (§45 SGB V):** Ist der Grund **„Kind krank"** eingerichtet, wählen Sie ihn wie einen normalen Typ. Der Tag gilt als **entschuldigt**, es entstehen **keine Minusstunden** und es wird **kein Urlaub** verbraucht – er ist aber **unbezahlt** (die Krankenkasse zahlt ggf. Kinderkrankengeld). Ist Ihr Jahresanspruch aufgebraucht, erscheint beim Buchen ein Hinweis – der Tag wird **trotzdem eingetragen**. Die Meldung an die Krankenkasse erfolgt außerhalb von PraxisZeit.
 
 > **Gut zu wissen – Kranktage und Stundensaldo:** Kranktage werden nach § 3 EntgFG als gearbeitete Stunden angerechnet (Soll-Stunden als Ist), sodass keine Minusstunden entstehen.
 
@@ -284,7 +352,91 @@ In der Listenansicht Ihrer Abwesenheiten befindet sich der Button **Löschen**. 
 
 ---
 
-## 5. Profil & Passwort
+### 4.4 So wird Ihr Urlaub berechnet
+
+PraxisZeit führt Urlaub **nach Arbeitstagen** (Tagesprinzip nach § 3 BUrlG) – **nicht** nach Stunden:
+
+- **Ein freier Arbeitstag = genau 1 Urlaubstag**, unabhängig davon, wie viele Stunden Sie an diesem Tag arbeiten würden. Ein 9-Stunden-Tag kostet genauso viel Urlaub wie ein 4-Stunden-Tag: **einen Tag**.
+- **Ein halber Tag zählt 0,5 Urlaubstage.** Aktivieren Sie beim Eintragen (nur bei einzelnen Tagen) die Option **Halber Tag** – siehe [Abschnitt 4.1](#41-abwesenheit-eintragen).
+- Eine **freie Woche** kostet so viele Urlaubstage, wie Sie Arbeitstage in der Woche haben (5-Tage-Woche → 5 Tage, 3-Tage-Woche → 3 Tage).
+- Ihr **Jahresanspruch** richtet sich nach der Zahl Ihrer Arbeitstage pro Woche (z. B. 5 Tage → 30 Tage, 3 Tage → anteilig 18 Tage). Den genauen Wert legt Ihr Administrator fest.
+- Das **Urlaubskonto** auf dem Dashboard zeigt jederzeit Budget, genommene und verbleibende Tage.
+
+> Intern rechnet das System mit Stunden (für die Soll-/Ist-Berechnung), Ihr Urlaubsverbrauch wird Ihnen aber immer in **ganzen Tagen** angezeigt.
+
+### 4.5 Betriebsferien (Praxisschließung)
+
+Wenn Ihre Praxis **Betriebsferien** einträgt (z. B. Weihnachts- oder Sommerschließung), legt PraxisZeit für Ihre Arbeitstage in diesem Zeitraum **automatisch** Abwesenheiten an – Sie müssen dafür nichts selbst eintragen. Wochenenden, Feiertage und Ihre freien Wochentage bleiben dabei außen vor.
+
+Wie sich das auf Ihr Konto auswirkt, legt Ihre Praxisleitung fest:
+
+- **Als bezahlte Freistellung:** Es wird **kein** Urlaubstag abgezogen, Ihr Überstundenkonto bleibt unberührt (wie ein Feiertag).
+- **Als Urlaub:** Jeder Schließtag wird Ihrem **Urlaubskonto** als Urlaubstag abgezogen. Reicht Ihr Resturlaub nicht für die gesamte Schließung, wird – je nach Einstellung Ihrer Praxis – zunächst Ihr Urlaub aufgebraucht und die restlichen Schließtage als **Überstundenabbau** gebucht: Ihr **Überstundenkonto sinkt** (es kann dabei auch ins Minus gehen), aber es entsteht **kein Minus-Urlaub**. Ist diese Einstellung nicht aktiv, können bei längerer Schließung **Minus-Urlaubstage** entstehen.
+
+> Fällt in Ihre Betriebsferien ein als „halber Feiertag" eingestellter Sondertag (z. B. Heiligabend als ½-Tag), wird dafür nur ein **halber** Urlaubs- bzw. Überstundentag verrechnet – passend zum halben Tagessoll dieses Tages.
+
+> Betriebsferien werden bewusst **ohne Budget-Grenze** gebucht: Anders als bei einer selbst eingetragenen Urlaubsbuchung oder einem Urlaubsantrag (die bei zu wenig Resturlaub jeweils abgelehnt werden) kann Ihre Praxisleitung Betriebsferien auch dann anordnen, wenn Ihr Resturlaub dafür nicht reicht.
+
+> Bei Fragen zur konkreten Verrechnung Ihrer Betriebsferien wenden Sie sich an Ihre Praxisleitung.
+
+---
+
+## 5. So berechnet PraxisZeit Ihre Stunden und Ihren Urlaub
+
+Dieser Abschnitt erklärt in einfachen Worten, wie die Werte auf Ihrem Dashboard zustande kommen.
+
+### Ihr Tagessoll
+
+Ihr **Tagessoll** ist die Stundenzahl, die Sie an einem Arbeitstag leisten sollen. Es ergibt sich aus Ihren Wochenstunden geteilt durch Ihre Arbeitstage pro Woche:
+
+> **Tagessoll = Wochenstunden ÷ Arbeitstage pro Woche**
+
+Beispiele: 40 h auf 5 Tage = **8 h/Tag**; 20 h auf 5 Tage = **4 h/Tag**; 24 h auf 3 Tage = **8 h/Tag**. Hat Ihre Praxis für Sie individuelle Tagesstunden hinterlegt (z. B. Mo/Di je 10 h, Mi 4 h), gilt der jeweils eingetragene Wert. An Wochenenden und Feiertagen ist das Tagessoll 0.
+
+### Ihre Ist-Stunden
+
+Ihr **Ist** ist Ihre tatsächlich erfasste Arbeitszeit: **(Ende − Beginn) − Pause** je Eintrag. Zusätzlich werden **Krankheit** und **Fortbildung** so angerechnet, als hätten Sie an diesen Tagen normal gearbeitet – sie zählen also zu Ihrem Ist.
+
+### Saldo und Überstunden
+
+- **Tagessaldo / Monatssaldo:** Ist − Soll. Ein **grüner** Saldo (+) bedeutet Mehrarbeit, ein **roter** (−) Minusstunden.
+- **Überstundenkonto:** der fortlaufend aufsummierte Saldo seit Jahresbeginn – inklusive des Übertrags aus dem Vorjahr.
+
+### Was passiert bei Abwesenheiten?
+
+| Abwesenheit | Wirkung auf Ihre Stunden |
+|---|---|
+| **Urlaub** | Soll des Tages entfällt, 1 Urlaubstag wird abgezogen |
+| **Krank** | Soll bleibt, wird als geleistet gutgeschrieben (kein Minus) |
+| **Fortbildung** | zählt wie Arbeitszeit |
+| **Bezahlte Freistellung / Sonstiges** | Soll des Tages entfällt, **kein** Urlaubsabzug |
+| **Überstundenausgleich** | Soll bleibt, der Tag zählt als 0 Stunden → Ihr Überstundenkonto sinkt |
+
+> **Eigene Abwesenheitsgründe** (z. B. „Kind krank", „Schule") sind nur ein Etikett mit eigenem Namen und eigener Farbe – rechnerisch verhalten sie sich wie eine der obigen Zeilen, je nachdem wie Ihre Praxis den Grund eingerichtet hat. „Kind krank" verhält sich z. B. wie „Sonstiges" (Soll entfällt, kein Urlaubsabzug), ist aber – anders als eine bezahlte Freistellung – **unbezahlt**. Details in [Abschnitt 4.1](#41-abwesenheit-eintragen).
+
+> **Betriebsferien** wirken je nach Einstellung Ihrer Praxis als Urlaub oder als bezahlte Freistellung – Details in [Abschnitt 4.5](#45-betriebsferien-praxisschließung).
+
+### Ihr Urlaub
+
+Urlaub wird **nach Tagen** gezählt: 1 freier Arbeitstag = 1 Urlaubstag – egal, wie lang der Tag ist. Die Details stehen in [Abschnitt 4.4](#44-so-wird-ihr-urlaub-berechnet).
+
+> **Kurzbeispiel (40 h / 5 Tage, Tagessoll 8 h):** In einem Monat mit 22 Werktagen, davon 1 Feiertag und 4 Urlaubstagen, bleiben 17 Soll-Tage → **136 h Soll**. Arbeiten Sie 137,5 h, steht Ihr Monatssaldo bei **+1,5 h**.
+
+---
+
+## 6. Wenn für Sie keine Stunden gezählt werden
+
+Für manche Mitarbeitende führt die Praxis bewusst **keine Stundenzählung**. Das bedeutet:
+
+- Es gibt **kein Soll/Ist** und **keine Überstunden** für Sie. Auf dem Dashboard fehlen die Kacheln **Tagessaldo**, **Monatssaldo** und **Überstundenkonto**, und auch der Stempel-Button (Ein-/Ausstempeln) wird nicht angezeigt.
+- **Urlaub und Krankheit werden trotzdem erfasst** – und zwar **tagebasiert**: 1 freier Arbeitstag = 1 Urlaubstag (ein Halbtag zählt als voller Tag). Ihr **Urlaubskonto** auf dem Dashboard funktioniert wie bei allen anderen.
+- Sie nutzen den Bereich **Abwesenheiten** ganz normal (siehe [Abschnitt 4](#4-abwesenheiten)) – nur die reine Arbeitszeit-Erfassung entfällt.
+
+> **Ist das ein Fehler?** Nein. Wenn bei Ihnen die Stunden- und Überstundenanzeige fehlt, ist das eine bewusste Einstellung Ihrer Praxis für Ihren Account. Bei Fragen wenden Sie sich an Ihren Administrator.
+
+---
+
+## 7. Profil & Passwort
 
 Klicken Sie in der Navigation auf **Profil**.
 
@@ -310,13 +462,29 @@ Klicken Sie in der Karte **Passwort ändern** auf **Ändern**.
 
 > **Sicherheitshinweis:** Nach einer Passwortänderung werden alle anderen aktiven Sitzungen automatisch abgemeldet.
 
+### Zwei-Faktor-Authentifizierung (2FA)
+
+Sie können Ihr Konto zusätzlich mit einem Einmal-Code aus einer **Authenticator-App** (z. B. Google Authenticator, Authy) absichern. Ist 2FA aktiv, benötigen Sie beim Login neben Benutzername und Passwort einen wechselnden 6-stelligen Code.
+
+**2FA aktivieren** (Karte **Zwei-Faktor-Authentifizierung** im Profil):
+
+1. Klicken Sie auf **„2FA aktivieren"**.
+2. **Scannen Sie den angezeigten QR-Code** mit Ihrer Authenticator-App – alternativ tragen Sie den angezeigten Schlüssel manuell ein.
+3. Geben Sie den **6-stelligen Code** aus der App ein und bestätigen Sie mit **„Bestätigen & 2FA aktivieren"**.
+
+**Login mit aktiver 2FA:** Geben Sie wie gewohnt Benutzername und Passwort ein. Anschließend werden Sie nach dem **6-stelligen Code** aus Ihrer Authenticator-App gefragt.
+
+**2FA deaktivieren:** Klicken Sie auf **„2FA deaktivieren"** und bestätigen Sie zur Sicherheit Ihr **aktuelles Passwort**.
+
+> **Tipp:** Bewahren Sie Ihr Smartphone bzw. die Authenticator-App sicher auf. Verlieren Sie den Zugang zur App, wenden Sie sich an Ihren Administrator – er kann Ihr Konto zurücksetzen.
+
 ### Weitere Einstellungen
 
 Unter **Weitere Einstellungen** (aufklappbar) können Sie persönliche Darstellungsoptionen anpassen, z. B. Ihre Kalenderfarbe im Teamkalender.
 
 ---
 
-## 6. Mobil-Nutzung
+## 8. Mobil-Nutzung
 
 PraxisZeit ist vollständig für mobile Geräte optimiert.
 
@@ -341,6 +509,22 @@ Am unteren Rand befindet sich eine **Tab-Leiste** mit Direktzugriffen:
 
 Tippen Sie auf den **+ Button** oben rechts auf der Zeiterfassungsseite, um das Eingabeformular zu öffnen.
 
+### Schnell aufs Smartphone öffnen (QR-Code)
+
+Sie müssen die Server-Adresse nicht abtippen: Auf der **Login-Seite** gibt es den
+Link **„Auf dem Smartphone öffnen (QR-Code)"**. Er zeigt einen QR-Code mit der
+Adresse genau dieser PraxisZeit-Installation.
+
+1. Öffnen Sie PraxisZeit am PC über die richtige Adresse (z. B. `https://192.168.178.50`).
+2. Klicken Sie auf **„Auf dem Smartphone öffnen (QR-Code)"**.
+3. Scannen Sie den QR-Code mit der **Kamera** Ihres Smartphones — der Handy-Browser
+   öffnet dieselbe Login-Seite.
+4. Melden Sie sich dort wie gewohnt mit **Benutzername und Passwort** an.
+
+> Der QR-Code **öffnet nur die Seite** — er meldet Sie nicht automatisch an. Ihr
+> Smartphone muss im selben Netzwerk (Praxis-WLAN) sein wie der Server, und bei
+> einem selbstsignierten Zertifikat bestätigen Sie einmalig die Sicherheitswarnung.
+
 ### Installation als App (PWA)
 
 Auf unterstützten Geräten können Sie PraxisZeit wie eine App installieren:
@@ -349,7 +533,7 @@ Auf unterstützten Geräten können Sie PraxisZeit wie eine App installieren:
 
 ---
 
-## 7. Häufige Fragen (FAQ)
+## 9. Häufige Fragen (FAQ)
 
 **F: Ich sehe meinen Eintrag nicht mehr, obwohl ich ihn gespeichert habe.**
 A: Überprüfen Sie, ob Sie den richtigen Monat anzeigen. Nutzen Sie die Pfeile `<` `>` neben dem Monatsnamen.
@@ -357,17 +541,32 @@ A: Überprüfen Sie, ob Sie den richtigen Monat anzeigen. Nutzen Sie die Pfeile 
 **F: Ich bekomme eine Warnung bei der Eingabe meiner Arbeitszeit.**
 A: PraxisZeit prüft die gesetzlichen Grenzen:
 - Netto > 8h: Hinweis (zulässig mit Ausgleich – § 3 ArbZG)
-- Netto > 10h: Blockiert (Tageshöchstgrenze – § 3 ArbZG)
+- Netto > 10h: bei **manueller Eingabe** blockiert; beim **Live-Ausstempeln** nur Warnung, weil die Zeit bereits geleistet ist (Tageshöchstgrenze – § 3 ArbZG)
 - Zu kurze Pause: Warnung (§ 4 ArbZG – bei >6h mind. 30 Min., bei >9h mind. 45 Min.)
 
+**F: Beim Ausstempeln werde ich nach meiner Pause gefragt – was muss ich eintragen?**
+A: Tragen Sie im Feld **Pause (Min.)** ein, wie viele Minuten Sie heute Pause gemacht haben. Bei mehr als 6 Stunden Arbeit verlangt das Gesetz eine Pause (§ 4 ArbZG). Reicht Ihre Eingabe nicht aus, können Sie entweder die Pausenminuten korrigieren **oder** im erscheinenden Textfeld kurz begründen, warum keine Pause möglich war. Erst danach ist das Ausstempeln abgeschlossen.
+
+**F: Warum steht bei meinem Eintrag „gestempelt 07:30 · angerechnet ab 07:45"?**
+A: Ihre Praxis hat für diesen Wochentag eine Soll-Arbeitszeit hinterlegt. Wenn Sie deutlich vor dem Soll-Beginn ein- oder nach dem Soll-Ende ausstempeln, wird nur bis zu einem kleinen Puffer (Standard 15 Min.) angerechnet. Ihre tatsächliche Stempelzeit bleibt aber gespeichert. Siehe [Abschnitt 3.3](#33-soll-arbeitszeiten-und-anrechnung).
+
 **F: Wie berechnet sich mein Urlaubsanspruch?**
-A: Ihr Urlaubsbudget richtet sich nach Ihrer vertraglichen Wochenstundenzahl. Bei Teilzeit wird es anteilig berechnet.
+A: Ihr Urlaubsbudget richtet sich nach Ihrer vertraglichen Wochenstundenzahl. Bei Teilzeit wird es anteilig berechnet. Verbraucht wird **tagebasiert**: 1 freier Arbeitstag = 1 Urlaubstag, ein halber Tag = 0,5 Urlaubstage (siehe [Abschnitt 4.4](#44-so-wird-ihr-urlaub-berechnet)).
+
+**F: Ich kann beim Eintragen einer Abwesenheit den Typ „Überstundenausgleich" wählen – was passiert dabei?**
+A: Damit bauen Sie angesammelte Überstunden ab. Ihr Soll für den Tag bleibt bestehen, der Tag zählt aber mit 0 Ist-Stunden – die von Ihnen im Feld **Stunden** eingetragene Zahl wird direkt von Ihrem Überstundenkonto abgezogen. Es entsteht **kein** Urlaubsabzug.
+
+**F: Was bewirkt die Option „Halber Tag" beim Eintragen einer Abwesenheit?**
+A: Sie ist nur bei einzelnen Tagen wählbar (nicht bei Zeitraum, Krank oder Überstundenausgleich) und lässt den Tag nur zur Hälfte zählen – bei Urlaub also **0,5** statt 1,0 Tage, z. B. für einen Arzttermin am Vormittag, an dem Sie nachmittags arbeiten.
+
+**F: Bei mir fehlen die Stunden- und Überstundenkacheln. Ist das kaputt?**
+A: Nein. Für manche Mitarbeitende führt die Praxis keine Stundenzählung. Dann entfallen Soll/Ist, Überstunden und der Stempel-Button; Urlaub und Krankheit werden weiter tagebasiert geführt. Mehr dazu in [Abschnitt 6](#6-wenn-für-sie-keine-stunden-gezählt-werden).
 
 **F: Was bedeutet der rote „-" Wert bei Überstunden?**
 A: Ein negativer Wert bedeutet, dass Sie weniger gearbeitet haben als Ihre Sollstunden.
 
 **F: Kann ich eine Abwesenheit für mehrere Tage eintragen?**
-A: Ja. Im Abwesenheitsformular aktivieren Sie die Option **Zeitraum** und geben Start- und Enddatum ein. Das System trägt nur Werktage (Mo–Fr) ein und überspringt Wochenenden und Feiertage.
+A: Ja. Im Abwesenheitsformular aktivieren Sie die Option **Zeitraum** und geben Start- und Enddatum ein. Das System trägt nur Werktage (Mo–Fr) ein und überspringt Wochenenden, Feiertage sowie als arbeitsfrei eingestellte Sondertage (z. B. Heiligabend).
 
 **F: Wie stelle ich einen Korrekturantrag für einen alten Eintrag?**
 A: Navigieren Sie zu **Zeiterfassung → Tab „Einträge"**, suchen Sie den betroffenen Eintrag und klicken Sie auf den **Änderungsantrag**-Button in der Aktionsspalte. Bei entsperrten Einträgen nutzen Sie direkt den **Bearbeiten**-Button.
@@ -395,6 +594,24 @@ PraxisZeit unterstützt die Einhaltung des **Arbeitszeitgesetzes (ArbZG)**:
 
 Vollständiger Gesetzestext: [https://www.gesetze-im-internet.de/arbzg/](https://www.gesetze-im-internet.de/arbzg/BJNR117100994.html)
 
+> **Minijob-Arbeitszeitkonto:** Für Mitarbeitende mit einem Minijob-Arbeitszeitkonto unterstützt PraxisZeit zusätzlich die Vorgaben aus **§ 2 Abs. 2 MiLoG** (Mindestlohngesetz) mit weichen Hinweisen am Überstundenkonto – siehe [Abschnitt 2](#2-dashboard--die-übersicht).
+
 ---
 
-*PraxisZeit – Zeiterfassungssystem | Mitarbeiter-Handbuch v2.1 | April 2026*
+## Schichtplan (falls Ihre Praxis ihn nutzt)
+
+Nutzt Ihre Praxis die **Schichtplanung**, erscheint links der Menüpunkt
+**Schichtplan**. Dort sehen Sie die aktiven Wochenpläne als Übersicht: welcher
+Arbeitsplatz (z. B. Tresen, Labor) wann besetzt ist und wer eingeteilt ist.
+
+Auf dem **Dashboard** zeigt die Karte **„Deine Einteilung heute"** Ihre heutigen
+Einsätze mit Arbeitsplatz und Uhrzeit. Unter **Profil → „Meine Einweisungen"**
+sehen Sie, für welche Arbeitsplätze Sie eingewiesen sind (pflegt Ihr Administrator).
+
+Die Schichtplanung ist ein reines Planungswerkzeug und verändert **nicht** Ihre
+erfassten Arbeitszeiten, Ihren Urlaub oder Ihr Überstundenkonto. Die Einteilung
+legt Ihr Administrator fest.
+
+---
+
+*PraxisZeit – Zeiterfassungssystem | Mitarbeiter-Handbuch v2.5 | Juli 2026 (PraxisZeit 1.15.0)*

--- a/frontend/src/components/DocViewer.tsx
+++ b/frontend/src/components/DocViewer.tsx
@@ -279,7 +279,7 @@ export const handbuchMitarbeiterSections: AccordionItem[] = [
     content: (
       <div className="space-y-2">
         <p>Das Dashboard zeigt Ihren <strong>Tagessaldo</strong> (heute: Ist vs. Tagessoll), den <strong>Monatssaldo</strong> (Ist – Soll in H:MM), den kumulierten Jahressaldo und das Urlaubskonto.</p>
-        <p>Im <strong>laufenden Monat</strong> zählt das Soll nur bis zum <strong>letzten abgeschlossenen Arbeitstag</strong> – Sie starten den Monat also nicht mit einem dicken Minus; der heutige Tag zählt mit, sobald Sie <strong>ausgestempelt</strong> haben. Abgeschlossene Monate entsprechen dem vollen Monat.</p>
+        <p>Im <strong>laufenden Monat</strong> zählt das Soll nur bis zum <strong>letzten abgeschlossenen Arbeitstag</strong> – Sie starten den Monat also nicht mit einem dicken Minus; der heutige Tag zählt mit, sobald Sie <strong>ausgestempelt</strong> haben. Abgeschlossene Monate entsprechen dem vollen Monat. Das <strong>Überstundenkonto</strong> folgt für den laufenden Monat demselben Stichtag – auch hier entsteht am Monatsanfang kein künstliches Minus.</p>
         <p>Grüner Saldo = Überstunden, roter Saldo = Fehlstunden. Auf mobilen Geräten wird die untere Tab-Leiste zur Navigation genutzt.</p>
       </div>
     ),
@@ -332,13 +332,13 @@ export const handbuchMitarbeiterSections: AccordionItem[] = [
     title: '7. Abwesenheiten eintragen',
     content: (
       <div className="space-y-2">
-        <p>Navigieren Sie zu <strong>Abwesenheiten</strong> und klicken Sie auf <strong>+ Abwesenheit eintragen</strong>. Wählen Sie den Typ (Urlaub, Krank, Fortbildung, Sonstiges) und das Datum. Hat Ihre Praxis zusätzliche Gründe eingerichtet (z. B. „Schule"), erscheinen diese in der Typ-Auswahl unter <strong>„Eigene Gründe"</strong>.</p>
+        <p>Navigieren Sie zu <strong>Abwesenheiten</strong> und klicken Sie auf <strong>+ Abwesenheit eintragen</strong>. Wählen Sie den Typ (Urlaub, Krank, Fortbildung, Überstundenausgleich, Sonstiges) und das Datum. Hat Ihre Praxis zusätzliche Gründe eingerichtet (z. B. „Schule"), erscheinen diese in der Typ-Auswahl unter <strong>„Eigene Gründe"</strong>.</p>
         <p className="text-gray-700"><strong>Kind krank (§45 SGB V):</strong> Ist der Grund „Kind krank" eingerichtet, wählen Sie ihn wie einen normalen Typ. Der Tag gilt als <strong>entschuldigt</strong> – keine Minusstunden, <strong>kein</strong> Urlaubsabzug, aber <strong>unbezahlt</strong> (die Krankenkasse zahlt ggf. Kinderkrankengeld). Ist Ihr Jahresanspruch aufgebraucht, erscheint ein Hinweis – der Tag wird <strong>trotzdem eingetragen</strong>.</p>
         <p>Für Zeiträume aktivieren Sie die Checkbox <strong>„Zeitraum"</strong> und geben ein Enddatum an. Wochenenden und Feiertage werden automatisch ausgeschlossen.</p>
         <p>Hat Ihre Praxis <strong>Heiligabend (24.12.)</strong> oder <strong>Silvester (31.12.)</strong> als arbeitsfrei oder halben Tag eingestellt, sind diese Tage im Kalender entsprechend markiert: grau „Heiligabend (frei)" bzw. amber „Silvester (½ Tag)" – ähnlich einem Feiertag.</p>
         <p>Wenn Urlaubsgenehmigungspflicht aktiv ist, wechselt die App nach dem Absenden automatisch zum Tab <strong>„Meine Anträge"</strong>.</p>
         <p className="text-gray-700"><strong>So wird Urlaub berechnet:</strong> nach dem Tagesprinzip (§3 BUrlG) – <strong>ein freier Arbeitstag = genau 1 Urlaubstag</strong>, egal wie viele Stunden Sie an dem Tag arbeiten. Eine freie Woche kostet so viele Tage, wie Sie Arbeitstage haben. Ihr Urlaubskonto zeigt die verbleibenden Tage.</p>
-        <p className="text-gray-700"><strong>Betriebsferien (Praxisschließung):</strong> Bei Betriebsferien trägt die App Ihre Abwesenheiten an Ihren Arbeitstagen <strong>automatisch</strong> ein – Sie müssen nichts selbst buchen. Je nach Einstellung Ihrer Praxis zählen die Tage als <strong>bezahlte Freistellung</strong> (kein Urlaubsabzug) oder als <strong>Urlaub</strong>. Reicht Ihr Urlaub für die Schließung nicht, wird – wenn Ihre Praxis das so eingestellt hat – zuerst Ihr Urlaub verbraucht und der Rest als <strong>Überstundenabbau</strong> gebucht (Ihr Überstundenkonto sinkt und kann ins Minus gehen), sodass kein Minus-Urlaub entsteht. Die genaue Verrechnung legt die Praxisleitung fest.</p>
+        <p className="text-gray-700"><strong>Betriebsferien (Praxisschließung):</strong> Bei Betriebsferien trägt die App Ihre Abwesenheiten an Ihren Arbeitstagen <strong>automatisch</strong> ein – Sie müssen nichts selbst buchen. Je nach Einstellung Ihrer Praxis zählen die Tage als <strong>bezahlte Freistellung</strong> (kein Urlaubsabzug) oder als <strong>Urlaub</strong>. Reicht Ihr Urlaub für die Schließung nicht, wird – wenn Ihre Praxis das so eingestellt hat – zuerst Ihr Urlaub verbraucht und der Rest als <strong>Überstundenabbau</strong> gebucht (Ihr Überstundenkonto sinkt und kann ins Minus gehen), sodass kein Minus-Urlaub entsteht. Die genaue Verrechnung legt die Praxisleitung fest. Fällt ein als „halber Feiertag" eingestellter Sondertag (24./31.12.) in die Schließung, wird dafür nur ein <strong>halber</strong> Urlaubs- bzw. Überstundentag verrechnet. Anders als bei einer selbst eingetragenen Urlaubsbuchung gibt es bei Betriebsferien <strong>keine Budget-Grenze</strong> – Ihre Praxisleitung kann die Schließung auch anordnen, wenn Ihr Resturlaub dafür nicht reicht.</p>
       </div>
     ),
   },
@@ -351,6 +351,7 @@ export const handbuchMitarbeiterSections: AccordionItem[] = [
         <p><strong>Saldo</strong> = Ist − Soll (grün = Mehrarbeit, rot = Minusstunden). Das <strong>Überstundenkonto</strong> summiert die Salden seit Jahresbeginn inkl. Vorjahresübertrag.</p>
         <p><strong>Überstundenausgleich:</strong> Das Soll bleibt, der Tag zählt als 0 Stunden → Ihr Überstundenkonto sinkt.</p>
         <p className="text-gray-700"><strong>Urlaub (Tagesprinzip, §3 BUrlG):</strong> 1 freier Arbeitstag = 1 Urlaubstag, egal wie lang der Tag ist (Halbtag = 0,5).</p>
+        <p className="text-gray-700"><strong>Minijob mit fester Monatsarbeitszeit:</strong> Führt Ihre Praxis Sie mit einer <strong>festen vereinbarten Monatsarbeitszeit</strong> statt des obigen, aus Wochenstunden berechneten Solls, zeigt Ihr Monatssaldo jeden Monat dasselbe feste Soll (anteilig bei unterjährigem Ein-/Austritt). Feiertage sowie Urlaub oder bezahlte Freistellung an einem für Sie geplanten Arbeitstag werden dabei automatisch mit den geplanten Stunden gutgeschrieben; unbezahlt freie Tage mindern stattdessen das Monatssoll. Am Überstundenkonto kann dann ein weicher, nicht blockierender Hinweis erscheinen (§ 2 Abs. 2 MiLoG). Ob dieses Modell für Sie gilt, legt Ihre Praxisleitung fest.</p>
       </div>
     ),
   },
@@ -407,6 +408,7 @@ export const handbuchAdminSections: AccordionItem[] = [
         <p><strong>Erster/Letzter Arbeitstag</strong> begrenzen die Soll-Berechnung: vor dem Eintritt bzw. nach dem Austritt entsteht kein Stundensoll. Die Übersicht zeigt je MA Urlaubskonto <strong>und</strong> Überstundensaldo (Jahr bis heute; „—" ohne Stundenzählung).</p>
         <p className="text-amber-700">⚠️ Bei <strong>unterjährigem Eintritt</strong> (nicht seit 1. Januar im System) den „Ersten Arbeitstag" unbedingt setzen – sonst zählt das Soll auch Tage vor dem Eintritt und es entstehen Phantom-Minusstunden.</p>
         <p><strong>Soll-Arbeitszeiten (Arbeitszeit-Fenster):</strong> Im Benutzerformular können Sie pro MA und Wochentag Soll-Beginn und Soll-Ende hinterlegen. Zeiten außerhalb des Fensters (abzüglich Puffer) werden nicht angerechnet; der gestempelte Rohwert bleibt gespeichert (§16). Der systemweite Puffer (Standard 15 Min.) ist unter <strong>Einstellungen → Arbeitszeit-Fenster Puffer</strong> konfigurierbar. Opt-in: ohne Soll-Zeiten kein Eingriff. MA mit deaktivierter Stundenzählung sind ausgenommen.</p>
+        <p><strong>Minijob / Arbeitszeitkonto (§ 2 Abs. 2 MiLoG):</strong> Für Minijobber:innen auf Arbeitszeitkonto aktivieren Sie im Formular die Checkbox „Arbeitszeitkonto (§ 2 Abs. 2 MiLoG)" und tragen optional die „Vereinbarte Monatsarbeitszeit (h)" ein (leer = automatisch aus Wochenstunden × 13/3). Zusätzlich aktivierbar: „<strong>Feste Monatsarbeitszeit</strong>" – dann ist das Monats-Soll jeden Monat fix die vereinbarte Monatszeit, statt aus Wochenstunden/Arbeitstagen zu schwanken (setzt das Arbeitszeitkonto und eine eingetragene Monatszeit voraus). Details zu den weichen MiLoG-Warnungen und zur festen Monatsarbeitszeit: Abschnitt „Eigene Abwesenheitsgründe, Kind krank &amp; Minijob".</p>
         <p><strong>Kalenderfarbe:</strong> Im Benutzerformular können Sie die Kalenderfarbe aus einer Palette für jede:n Mitarbeiter:in vorgeben (Badge-Ring im Teamkalender); der/die Mitarbeiter:in kann sie auch selbst im Profil ändern.</p>
         <p><strong>Monatsjournal:</strong> Das Buch-Symbol in der Aktionsspalte öffnet das Monatsjournal des/der Mitarbeitenden. Die Überschrift trägt den Namen – <strong>„Monatsjournal: Vorname Nachname"</strong> –, damit beim Wechsel zwischen Personen sofort klar ist, wessen Journal angezeigt wird.</p>
         <p><strong>Login als … (Ansicht als Mitarbeiter:in):</strong> Das Anmelde-Symbol in der Aktionsspalte (nur bei aktiven Mitarbeitenden) öffnet die App aus deren Sicht – nützlich, um das Mitarbeiter-Dashboard zu prüfen oder ein Problem nachzustellen. Die Ansicht ist <strong>ausschließlich lesend</strong>: Stempeln, Anträge und alle Änderungen sind gesperrt. Ein Hinweisbanner oben zeigt dauerhaft „Sie sehen PraxisZeit als … – nur Lesen"; über <strong>„Zurück zu Admin"</strong> kehren Sie zu Ihrem Konto zurück. Jede solche Sitzung wird protokolliert (wer, wen, wann – DSGVO-Rechenschaftspflicht).</p>
@@ -474,7 +476,19 @@ export const handbuchAdminSections: AccordionItem[] = [
     ),
   },
   {
-    title: '8. ArbZG-Berichte & Compliance',
+    title: '8. Eigene Abwesenheitsgründe, Kind krank & Minijob',
+    content: (
+      <div className="space-y-2">
+        <p><strong>Eigene Abwesenheitsgründe (#312):</strong> Unter <strong>Einstellungen → „Eigene Abwesenheitsgründe"</strong> legen Sie zusätzliche, frei benannte Gründe an (z. B. „Schule" für Auszubildende) – mit eigener Farbe und einem fixen <strong>Basis-Verhalten</strong>: <em>„Zählt als gearbeitet"</em> (wie Fortbildung, z. B. Berufsschule), <em>„Bezahlt frei"</em> (Tagessoll → 0, saldoneutral, kein Urlaubsabzug), <em>„Unbezahlt frei"</em> (wie „Bezahlt frei", aber Lohn gekürzt – für Kind krank oder unbezahlten Sonderurlaub) oder <em>„Überstundenabbau"</em> (Überstundenkonto sinkt um das Tagessoll). Das Basis-Verhalten ist nach dem Anlegen fix; Gründe lassen sich umbenennen, umfärben und deaktivieren. Sie erscheinen beim Buchen unter „Eigene Gründe".</p>
+        <p className="text-gray-700"><strong>Datenschutz:</strong> Da ein eigener Grund sensibel sein kann (z. B. „Reha"), zeigt der Team-Kalender Abwesenheiten mit eigenem Grund für andere Mitarbeitende nur als <strong>„abwesend"</strong> – nur Admins sehen die Bezeichnung.</p>
+        <p><strong>Kind krank &amp; Sonderurlaub-Vorlagen (#376):</strong> Unter „Vorlagen (1-Klick aktivieren)" legen Sie gängige Gründe direkt an – Kind krank, Todesfall, Hochzeit, Geburt, Umzug, Arztbesuch, Pflege. <strong>Kind krank</strong> (§45 SGB V) ist „unbezahlt frei" und wird pro Kalenderjahr gezählt: Standardanspruch unter <strong>Einstellungen → „Kind-krank-Standardanspruch"</strong> (Voreinstellung 15 Tage), pro Mitarbeiter:in im Benutzerformular überschreibbar. Bei Überschreitung erscheint beim Buchen ein <strong>Hinweis</strong> – die Abwesenheit wird trotzdem erfasst, nicht blockiert. Verbrauch je Person in der Benutzerübersicht.</p>
+        <p><strong>Minijob / Arbeitszeitkonto (§ 2 Abs. 2 MiLoG, #377):</strong> Für Minijobber:innen auf Arbeitszeitkonto aktivieren Sie im Benutzerformular „Arbeitszeitkonto (§ 2 Abs. 2 MiLoG)". PraxisZeit warnt dann <strong>weich</strong> (nichts wird blockiert): bei <strong>&gt; 50 %</strong> Konto-Plusstunden der vereinbarten Monatsarbeitszeit und bei überfälligem <strong>12-Monats-Ausgleich</strong>. Die vereinbarte Monatsarbeitszeit tragen Sie im Feld „Vereinbarte Monatsarbeitszeit (h)" ein (leer = automatisch Wochenstunden × 13/3); der aktuelle gesetzliche Mindestlohn steht unter <strong>Einstellungen → „Gesetzlicher Mindestlohn"</strong>. Die Grenze bindet nur mindestlohnwirksame Stunden; PraxisZeit speichert keine Lohndaten und prüft daher nicht die 603-€-Grenze.</p>
+        <p className="text-gray-700"><strong>Feste Monatsarbeitszeit (Baustein 2b):</strong> Bei aktivem Arbeitszeitkonto zusätzlich aktivierbar: „Feste Monatsarbeitszeit (Monats-Soll = vereinbarte Monatsarbeitszeit)". Statt der Tagessoll-Summe zählt dann jeden Monat exakt die vereinbarte Monatszeit als Soll (anteilig bei unterjährigem Ein-/Austritt). Feiertag, Urlaub oder bezahlte Freistellung an einem geplanten Tag schreiben die geplanten Stunden dem Ist gut; ein unbezahlt entschuldigter Tag mindert stattdessen das feste Soll. Weiche Warnung, wenn das Monats-Ist die vereinbarte Zeit übersteigt. Bekannte Grenze: Fällt ein <strong>ganzer</strong> Monat durch Urlaub/Krankheit aus und liegen die geplanten Tagesstunden deutlich unter der Monatszeit, deckt die Gutschrift nur den geplanten Anteil ab – der flexible Rest bleibt Konto-Defizit und braucht eine manuelle Korrektur. Details in Abschnitt „Berechnungsgrundlagen".</p>
+      </div>
+    ),
+  },
+  {
+    title: '9. ArbZG-Berichte & Compliance',
     content: (
       <div className="space-y-2">
         <p>Unter <strong>Berichte</strong> (nach unten scrollen) finden Sie: <strong>§5 Ruhezeitverstöße</strong> (&lt;11h zwischen Arbeitstagen), <strong>§6 Nachtarbeit</strong> (≥48 Nachtarbeitstage/Jahr), <strong>§11 Sonntagsarbeit</strong> (max. 37/Jahr) und <strong>§11 Ersatzruhetag</strong> (Fristen überwachen). Erfasste Pflicht-Pause-Ausnahmen samt Begründung sind ebenfalls einsehbar.</p>
@@ -484,7 +498,7 @@ export const handbuchAdminSections: AccordionItem[] = [
     ),
   },
   {
-    title: '9. Audit-Log & Fehler-Monitoring',
+    title: '10. Audit-Log & Fehler-Monitoring',
     content: (
       <div className="space-y-2">
         <p>Das <strong>Änderungsprotokoll</strong> zeichnet alle Aktionen unveränderlich auf (Login, Zeiteinträge, Abwesenheiten, Benutzerverwaltung, Korrekturanträge). Dient als Nachweis gem. §16 ArbZG bei Betriebsprüfungen.</p>
@@ -493,7 +507,7 @@ export const handbuchAdminSections: AccordionItem[] = [
     ),
   },
   {
-    title: '10. Berechnungsgrundlagen (Soll, Ist, Überstunden, Urlaub)',
+    title: '11. Berechnungsgrundlagen (Soll, Ist, Überstunden, Urlaub)',
     content: (
       <div className="space-y-2">
         <p><strong>Tagessoll</strong> = Wochenstunden ÷ Arbeitstage pro Woche – der Divisor ist <strong>nicht</strong> fix 5 (24 h auf 3 Tage = 8 h/Tag). Individuelle Tagesstunden je Wochentag sind möglich; Wochenende/Feiertag/außerhalb des Beschäftigungszeitraums = 0.</p>
@@ -501,13 +515,13 @@ export const handbuchAdminSections: AccordionItem[] = [
         <p><strong>Abwesenheiten:</strong> Urlaub, bezahlte Freistellung &amp; Sonstige senken das Soll; Krank &amp; Fortbildung füllen das Ist auf (saldo-neutral); der Überstundenausgleich lässt das Soll stehen (Ist 0 h) und baut Überstunden ab.</p>
         <p><strong>Überstundenkonto</strong> = fortlaufende Summe der Monatssalden ab dem Jahresübertrag. Die Spalte „Überstunden (JTD)" zeigt 1. Januar bis heute zzgl. Carryover.</p>
         <p><strong>Urlaub (Tagesprinzip §3 BUrlG):</strong> 1 freier Arbeitstag = 1 Tag (Halbtag 0,5), unabhängig von der Stundenzahl. Anspruch <code>30 × Arbeitstage ÷ 5</code>, anteilig bei unterjährigem Eintritt/Austritt, zzgl. Resturlaub-Vortrag (Carryover). Nur Urlaub belastet das Budget; ein als „Frei + zählt als Urlaub" konfigurierter Sondertag (24./31.12.) kostet ebenfalls 1 Tag. Vor Eintritt/nach Austritt: kein Anspruch und kein Verbrauch.</p>
-        <p><strong>Feste Monatsarbeitszeit (Minijob-Modus, #377 Baustein 2b):</strong> Für MA mit diesem Opt-in gilt statt der obigen Tagessoll-Summe ein <strong>festes</strong> Monats-Soll (= vereinbarte Monatsarbeitszeit, kalendertag-pro-rata bei Ein-/Austritt); Feiertag/Urlaub/bezahlte Freistellung an geplanten Tagen schreiben die geplanten Stunden dem Ist gut statt das Soll zu senken, unbezahlte Fehltage (Sonstiges) mindern stattdessen das feste Soll. Details in Abschnitt 13 „Einstellungen".</p>
+        <p><strong>Feste Monatsarbeitszeit (Minijob-Modus, #377 Baustein 2b):</strong> Für MA mit diesem Opt-in gilt statt der obigen Tagessoll-Summe ein <strong>festes</strong> Monats-Soll (= vereinbarte Monatsarbeitszeit, kalendertag-pro-rata bei Ein-/Austritt); Feiertag/Urlaub/bezahlte Freistellung an geplanten Tagen schreiben die geplanten Stunden dem Ist gut statt das Soll zu senken, unbezahlte Fehltage (Sonstiges) mindern stattdessen das feste Soll. Details in Abschnitt 8 „Eigene Abwesenheitsgründe, Kind krank & Minijob".</p>
         <p className="text-gray-500">Vollständige Formeln und durchgerechnete Beispiele: <code>docs/BERECHNUNGEN.md</code> bzw. Admin-Handbuch-Anhang „Berechnungsgrundlagen".</p>
       </div>
     ),
   },
   {
-    title: '11. Datensicherung (Backup & Restore)',
+    title: '12. Datensicherung (Backup & Restore)',
     content: (
       <div className="space-y-2">
         <p>Unter <strong>Datensicherung</strong> erstellen Sie jederzeit eine vollständige, komprimierte Sicherung der Datenbank (<strong>Jetzt sichern</strong>) oder aktivieren eine <strong>tägliche automatische Sicherung</strong> mit Aufbewahrungsdauer und optionalem Speicherort.</p>
@@ -518,7 +532,7 @@ export const handbuchAdminSections: AccordionItem[] = [
     ),
   },
   {
-    title: '12. Schichtplanung (optional)',
+    title: '13. Schichtplanung (optional)',
     content: (
       <div className="space-y-2">
         <p>Die <strong>Schichtplanung</strong> ist <strong>standardmäßig deaktiviert</strong>. Sie aktivieren sie unter <strong>Einstellungen → Schichtplanung</strong>. Erst danach erscheinen die Menüpunkte <strong>Schichtplanung</strong> (Admin) und <strong>Schichtplan</strong> (alle) und das Dashboard-Widget.</p>


### PR DESCRIPTION
## Worum es geht

Nutzer-Doku auf den ausgelieferten **1.15.0**-Rechenstand gebracht (war teils Stand 1.8.2 / 1.11.0). Alle Formeln gegen `calculation_service.py`, `closure_split_service.py`, `milog_service.py`, `minimum_wage.py` verifiziert (Multi-Agent-Review + adversarialer Faktencheck, 0 offene Fehler).

## Änderungen

**docs/BERECHNUNGEN.md** (Hauptarbeit, +480 Z., war Stand 1.8.2)
- §6.1 **Eigene Abwesenheitsgründe** (#312): `base_behavior`→`AbsenceType`-Mapping, `UNPAID_FREE`-Semantik, **Kind-krank**-Limit §45 SGB V (#376), DSGVO-Maskierung
- §7.4 **Saldo-Stichtag „bis heute"** (#313): `get_soll_cutoff_date`, Live-Anzeigen, `soll_basis`-Umschalter; Exporte/Journal/Jahresabschluss bewusst voller Monat
- §9 **Betriebsferien** (neu): Buchung/Ausschlüsse, Verrechnung Urlaub vs. bez. Freistellung, **#394** Halbtags-Sondertag (0,5 via `half_special_day_weight`), **#314** chronologischer VACATION→OVERTIME-Split, kein Budget-Cap
- §10 **Minijob / MiLoG** (neu): Mindestlohn-Stufen, `MILOG_ACCOUNT_50` / `MILOG_SETTLEMENT_DUE` (bewusst Soll-basiert), **fester Monats-Soll-Modus** (`use_fixed_monthly_target`) inkl. Gutschrift/Soll-Minderung + bekannte Grenze
- §15 durchgerechnete Minijob-Fixmodus-Beispiele; §8.4 Budget-Check um `half_special_day_weight` ergänzt; TOC + Renummerierung

**docs/handbuch/*.md** (waren größtenteils aktuell): Version-Stempel 1.15.0 + Präzisierungen (Fixmodus-Voraussetzungen, Journal/Jahresabschluss voller Monat, MA-Minijob-Sicht, Halbtag/Überstundenausgleich-Felder, #394).

**In-App-Hilfe (2 Sync-Flächen, CLAUDE.md-Regel):**
- `frontend/src/components/DocViewer.tsx`: Handbuch-Akkordeons um Minijob/MiLoG ergänzt, neuer Admin-Abschnitt „Eigene Abwesenheitsgründe, Kind krank & Minijob" (Renummerierung 8–13)
- `frontend/public/help/*.md`: downloadbarer Help-Mirror **byte-identisch** zu `docs/handbuch/*.md` re-synct

## Verifikation
- `tsc --noEmit` clean (DocViewer)
- Doku-Accuracy: adversarialer Faktencheck gegen den Calc-Code, 1 Low gefunden + behoben (§8.4-Faktor), sonst 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
