### PR TITLE
fix(#382): Whitescreen im Admin-Dashboard bei eingestempeltem Mitarbeiter

### DIFF
--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -10,7 +10,7 @@ import ConfirmDialog from '../../components/ConfirmDialog';
 import MonthSelector from '../../components/MonthSelector';
 import WeekSelector, { isoWeekMonday, weekLabel } from '../../components/WeekSelector';
 import { getErrorMessage } from '../../utils/errorMessage';
-import { formatHoursHM, parseHours } from '../../utils/formatters';
+import { formatHoursHM, parseHours, formatClockTime } from '../../utils/formatters';
 import { submitWithBreakWaiver } from '../../utils/breakWaiverRetry';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import UpdateBanner from '../../components/UpdateBanner';
@@ -326,8 +326,8 @@ export default function AdminDashboard() {
     setShowNewEntryForm(false);
     setEntryForm({
       date: entry.date,
-      start_time: entry.start_time.substring(0, 5),
-      end_time: entry.end_time.substring(0, 5),
+      start_time: formatClockTime(entry.start_time, '08:00'),
+      end_time: formatClockTime(entry.end_time, '17:00'),
       break_minutes: entry.break_minutes,
       note: entry.note || '',
       entry_type: 'work',
@@ -1405,8 +1405,8 @@ export default function AdminDashboard() {
                             {employeeTimeEntries.map((entry) => (
                               <tr key={entry.id} className="hover:bg-gray-50">
                                 <td className="px-4 py-2 text-sm">{format(new Date(entry.date), 'dd.MM.yyyy')}</td>
-                                <td className="px-4 py-2 text-sm">{entry.start_time.substring(0, 5)}</td>
-                                <td className="px-4 py-2 text-sm">{entry.end_time.substring(0, 5)}</td>
+                                <td className="px-4 py-2 text-sm">{formatClockTime(entry.start_time)}</td>
+                                <td className="px-4 py-2 text-sm">{formatClockTime(entry.end_time, 'offen')}</td>
                                 <td className="px-4 py-2 text-sm">{entry.break_minutes} min</td>
                                 <td className="px-4 py-2 text-sm text-gray-500">{entry.note || '-'}</td>
                                 <td className="px-4 py-2 text-right text-sm space-x-1">

--- a/frontend/src/utils/formatters.test.ts
+++ b/frontend/src/utils/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatHoursHM, formatHoursHMText, parseHours } from './formatters';
+import { formatHoursHM, formatHoursHMText, parseHours, formatClockTime } from './formatters';
 
 describe('formatHoursHM', () => {
   it('formats whole hours', () => {
@@ -72,5 +72,21 @@ describe('parseHours', () => {
   it('returns 0 for empty/invalid input', () => {
     expect(parseHours('')).toBe(0);
     expect(parseHours('abc')).toBe(0);
+  });
+});
+
+describe('formatClockTime', () => {
+  it('truncates a "HH:MM:SS" backend time to "HH:MM"', () => {
+    expect(formatClockTime('08:30:00')).toBe('08:30');
+    expect(formatClockTime('17:05')).toBe('17:05');
+  });
+
+  it('#382: null/undefined end_time (open, running entry) does NOT throw and uses the fallback', () => {
+    // A clocked-in entry has end_time=null; `null.substring()` used to crash the
+    // Admin-Dashboard detail view (ErrorBoundary "Etwas ist schiefgelaufen").
+    expect(formatClockTime(null)).toBe('–');
+    expect(formatClockTime(undefined)).toBe('–');
+    expect(formatClockTime(null, 'offen')).toBe('offen');
+    expect(formatClockTime(undefined, '17:00')).toBe('17:00');
   });
 });

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -52,3 +52,19 @@ export function parseHours(value: string): number {
   const n = parseFloat(value);
   return Number.isFinite(n) ? n : 0;
 }
+
+/**
+ * #382: Null-safe "HH:MM" from a backend time string ("HH:MM:SS").
+ *
+ * A clocked-in (running) TimeEntry has `end_time === null` (the column is
+ * nullable). Calling `entry.end_time.substring(0, 5)` on such a row threw
+ * `Cannot read properties of null` in the Admin-Dashboard detail view →
+ * ErrorBoundary white-screen ("Etwas ist schiefgelaufen") for any employee
+ * currently clocked in. This returns `fallback` for null/undefined instead.
+ */
+export function formatClockTime(
+  value: string | null | undefined,
+  fallback = '–',
+): string {
+  return value ? value.substring(0, 5) : fallback;
+}


### PR DESCRIPTION
Fixes #382 (die am 2026-07-14 von @philvdb gemeldete Regression).

## Root-Cause
Anders als PR #388 (das nur den *200-mit-HTML-Body*-Fall abfing) ist das ein **reiner Render-Crash auf validen Daten**:

Ein **laufender** (eingestempelter, noch nicht ausgestempelter) `TimeEntry` hat `end_time = null` (Spalte ist `nullable`; `list_time_entries` filtert offene Einträge **nicht** heraus). Die Admin-Dashboard-Detailansicht rief in der Zeiteintrags-Tabelle
```jsx
{entry.end_time.substring(0, 5)}
```
**ungeguardet** auf → `Cannot read properties of null (reading 'substring')` → ErrorBoundary „Etwas ist schiefgelaufen".

Deckt sich exakt mit dem Report:
- „betrifft **die meisten realen Mitarbeiter mit Zeiterfassung**" = die gerade eingestempelt sind
- „**manche nicht**" = nicht eingestempelte
- reproduzierbar **während der Arbeitszeit** im **laufenden Monat** (`month=2026-07`)
- **alle API-Calls liefern 200/JSON** — kein Netzwerk-/HTML-Problem, sondern Rendering

(Der beobachtete Logout danach ist der bekannte, separate 401-Refresh-Effekt bei entwerteter Sitzung — hier nicht betroffen.)

## Fix
- Neuer null-sicherer Helper `formatClockTime(value, fallback)` in `utils/formatters.ts` (+ Unit-Tests, TDD).
- `AdminDashboard`: Zeiteintrags-Tabelle nutzt ihn → offener Eintrag zeigt **„offen"** statt Crash; auch `handleAdminEditEntry` guarded jetzt `end_time`.

Systemischer Scan bestätigt: die übrigen Zeit-Render-Stellen (`TimeTracking`, `MonthlyJournal`, `ChangeRequestForm`, `Dashboard`) sind **bereits** null-geguardet — nur die Admin-Dashboard-Detailansicht war es nicht.

## Verifikation
- `vitest` **213/213** (inkl. 2 neue `formatClockTime`-Tests, reproduzieren den null-Crash) · `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
