### PR TITLE
Release 1.15.1 — #382 Whitescreen-Fix + Doku auf 1.15.0-Stand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## [Unreleased]
 
+## [1.15.1] - 2026-07-15
+
+Patch-Release. Behebt einen Weißbild-Absturz (#382) in der Admin-Dashboard-
+Detailansicht und liefert die auf 1.15.0-Stand gebrachte Nutzer-Doku samt
+In-App-Hilfe aus. Kein Backend-/Berechnungs-Code geändert, keine Migration,
+keine neuen Abhängigkeiten, keine Installer-Änderungen.
+
+### 🐛 Behoben
+- **Weißbild „Etwas ist schiefgelaufen" beim Klick auf einen eingestempelten
+  Mitarbeiter (#382).** Ein laufender (eingestempelter, noch nicht
+  ausgestempelter) Zeiteintrag hat `end_time = null`. Die Zeiteintrags-Tabelle
+  der Admin-Dashboard-Detailansicht rief `end_time.substring(…)` ungeguardet
+  auf → Render-Absturz (ErrorBoundary) für jeden Mitarbeiter, der gerade
+  eingestempelt ist. Neuer null-sicherer Helper `formatClockTime` (offener
+  Eintrag → „offen"); der lokale `TimeEntry`-Typ deklariert `end_time` jetzt
+  korrekt als nullbar (Compile-Time-Schutznetz gegen erneutes Auftreten).
+  Anders als der Teil-Fix in 1.14.1 (#388, der nur den 200-mit-HTML-Body-Fall
+  abfing) ist dies ein Render-Crash auf validen Daten.
+
+### 📖 Dokumentation
+- **Berechnungsdoku, Handbücher, Cheat-Sheets & In-App-Hilfe auf 1.15.0-Stand.**
+  `docs/BERECHNUNGEN.md` deutlich erweitert (Betriebsferien inkl. #314/#394,
+  Minijob/MiLoG inkl. festem Monats-Soll, Saldo-Stichtag #313, eigene
+  Abwesenheitsgründe/Kind krank, tagebasierte Zählung); Admin-/Mitarbeiter-
+  Handbücher + Cheat-Sheets, In-App-Hilfe (`DocViewer` + downloadbarer
+  `/help/*.md`-Mirror) synchron nachgezogen. Faktengeprüft gegen den
+  Berechnungs-Code.
+
 ## [1.15.0] - 2026-07-14
 
 Minor-Release. Neues Minijob-Feature (#377 Baustein 2b) + projektweiter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.15.0 (Stand 2026-07-14)
+**Aktuelle Version:** 1.15.1 (Stand 2026-07-15)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -32,7 +32,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.15.0"
+APP_VERSION = "1.15.1"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/docs/BERECHNUNGEN.md
+++ b/docs/BERECHNUNGEN.md
@@ -228,7 +228,7 @@ einem `unpaid_free`-`OTHER`-Tag.
 Für „Kind krank" gilt zusätzlich ein weiches **§45-SGB-V-Limit**: `child_sick_cap()` liefert
 den Jahresanspruch in Tagen (`User.child_sick_days_per_year`, sonst Tenant-Setting
 `child_sick_days_default`, Default 15); `child_sick_days_used()` zählt **tagebasiert** (wie
-§6.2/§8.2) die Absenzen eines als `tracks_child_sick_limit` markierten Grundes. Wird das
+§8.2) die Absenzen eines als `tracks_child_sick_limit` markierten Grundes. Wird das
 Limit überschritten, erscheint die weiche Warnung `CHILD_SICK_LIMIT` — sie blockiert die
 Buchung **nie**.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.15.0",
+  "version": "1.15.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -36,7 +36,7 @@ interface TimeEntry {
   id: string;
   date: string;
   start_time: string;
-  end_time: string;
+  end_time: string | null; // #382: null bei offenem (eingestempeltem) Eintrag — Deref nur über formatClockTime
   break_minutes: number;
   note?: string;
 }

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.15.0"
+APP_VERSION="1.15.1"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
PATCH-Release. Kein Backend-/Berechnungs-Code, keine Migration, keine Deps, keine Installer-Änderungen.

## Inhalt
- **Version-Bump** 1.15.0 → 1.15.1 (3 Stellen + Lock).
- **#382** (Kern-Fix bereits via #409 gemerged): Weißbild „Etwas ist schiefgelaufen" beim Klick auf einen **eingestempelten** Mitarbeiter — offener `TimeEntry` hat `end_time=null`, ungeguardetes `.substring` crashte die Admin-Dashboard-Detailansicht. Neuer Helper `formatClockTime`; hier zusätzlich der lokale `TimeEntry`-Typ auf `end_time: string | null` gehärtet (Compile-Time-Schutznetz, Release-Review-Fund).
- **Doku 1.15.0-Stand** (bereits via #407): BERECHNUNGEN + Handbücher + Cheat-Sheets + In-App-Hilfe (`DocViewer` + `/help/*.md`-Mirror). Hier: toter Verweis §6.2 → §8.2 (Release-Review-Fund).
- CHANGELOG [1.15.1] + CLAUDE.md.

## QA-Matrix
| Gate | Ergebnis |
|------|----------|
| Delta-Review (2 Lanes, adversarial verify) | 0 serious, 2 Low gefixt |
| Backend-Suite (SQLite) | **1378 passed** / 49 skipped (Backend byte-identisch zu 1.15.0) |
| Frontend | vitest **213/213**, tsc clean |
| validate-release (Ubuntu 22/24, Debian 12, Rocky 9, Arch) | **5/5** (PG 18.4) |
| Artefakt-Integrität | 6 Artefakte, SHA ok, kein setup.exe im ZIP, PG-Pin 18.4, Bundle 1.15.1 |
| Local Docker | Health 200, **echter Login 200**, #382-Trigger-Shape (offener Eintrag `end_time=null` → Frontend „offen") |
| .131 (Real-Host) | **unerreichbar** (ping/ssh timeout) — dokumentiert |
| Win-Emulator / Native-Fresh | übersprungen (0 `installer/`-Änderungen seit v1.13.0) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
