### PR TITLE
feat(#408): Jahresurlaubsanspruch mit Nachkommastelle (dezimal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### ✨ Neu
+- **Jahresurlaubsanspruch mit Nachkommastelle (#408).** `User.vacation_days` ist
+  jetzt dezimal (Migration 066, `Numeric(4,1)`): eine 3-Tage-Teilzeitkraft kann
+  z. B. **16,8** Urlaubstage (28×3/5) exakt eingetragen bekommen, statt auf 17
+  gerundet zu werden (das erzeugte 0,2 Tage Ungerechtigkeit vs. Kolleg:innen mit
+  unterjährigem Eintritt). Eingabefeld akzeptiert 0,1-Schritte. Die Berechnung
+  war bereits dezimalfähig (`Decimal`); nur Speicher/Schema/Eingabe blockierten.
+
 ## [1.15.1] - 2026-07-15
 
 Patch-Release. Behebt einen Weißbild-Absturz (#382) in der Admin-Dashboard-

--- a/backend/alembic/versions/2026_07_18_1200-066_vacation_days_decimal.py
+++ b/backend/alembic/versions/2026_07_18_1200-066_vacation_days_decimal.py
@@ -1,0 +1,37 @@
+"""#408: users.vacation_days Integer → Numeric(4,1)
+
+Kundenreport (philvdb): der Jahresurlaubsanspruch braucht eine Nachkommastelle
+(z. B. 28×3/5 = 16,8 Tage für eine 3-Tage-Teilzeitkraft). Bisher nur ganzzahlig
+→ Rundung auf 17 erzeugte 0,2 Tage Ungerechtigkeit vs. anderen Teilzeitkräften.
+Additiv/verlustfrei im Up (Integer → Numeric); Down rundet zurück auf ganze
+Tage (lossy — Natur einer Präzisionsreduktion, akzeptiert).
+
+Der Calc rechnete bereits mit `Decimal(str(user.vacation_days))`; nur Speicher/
+Schema/Eingabe blockierten die Nachkommastelle.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "066_vacation_days_decimal"
+down_revision = "065_fixed_monthly_target"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "users", "vacation_days",
+        existing_type=sa.Integer(),
+        type_=sa.Numeric(4, 1),
+        existing_nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "users", "vacation_days",
+        existing_type=sa.Numeric(4, 1),
+        type_=sa.Integer(),
+        existing_nullable=False,
+        postgresql_using="round(vacation_days)::integer",
+    )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -26,7 +26,7 @@ class User(Base):
     last_name = Column(String(100), nullable=False)
     role = Column(Enum(UserRole), default=UserRole.EMPLOYEE, nullable=False)
     weekly_hours = Column(Numeric(4, 1), nullable=False)  # e.g., 20.0, 30.0, 38.5
-    vacation_days = Column(Integer, nullable=False, default=30)
+    vacation_days = Column(Numeric(4, 1), nullable=False, default=30)  # #408: Dezimal (z. B. 16,8)
     work_days_per_week = Column(Integer, nullable=False, default=5)
     track_hours = Column(Boolean, default=True, nullable=False)  # Track Soll/Ist hours for this user
     calendar_color = Column(String(7), nullable=False, default='#93C5FD')  # Pastel blue default

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -537,7 +537,7 @@ def export_my_data(
             "email": current_user.email,
             "role": current_user.role.value,
             "weekly_hours": float(current_user.weekly_hours),
-            "vacation_days": current_user.vacation_days,
+            "vacation_days": float(current_user.vacation_days),  # #408: Numeric(4,1)→Decimal; JSONResponse/json.dumps kann Decimal nicht serialisieren
             "is_active": current_user.is_active,
             "created_at": current_user.created_at.isoformat() if current_user.created_at else None,
         },

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -35,7 +35,7 @@ class UserBase(BaseModel):
     first_name: str = Field(..., min_length=1, max_length=100)
     last_name: str = Field(..., min_length=1, max_length=100)
     weekly_hours: float = Field(..., ge=0, le=60)
-    vacation_days: int = Field(..., ge=0, le=50)
+    vacation_days: float = Field(..., ge=0, le=50)  # #408: Dezimal (z. B. 16,8 für 3-Tage-Teilzeit)
     work_days_per_week: int = Field(default=5, ge=1, le=7)
     track_hours: bool = True
     calendar_color: str = Field(default='#93C5FD', pattern=r'^#[0-9A-Fa-f]{6}$')
@@ -103,7 +103,7 @@ class UserUpdate(BaseModel):
     first_name: Optional[str] = Field(None, min_length=1, max_length=100)
     last_name: Optional[str] = Field(None, min_length=1, max_length=100)
     weekly_hours: Optional[float] = Field(None, ge=0, le=60)
-    vacation_days: Optional[int] = Field(None, ge=0, le=50)
+    vacation_days: Optional[float] = Field(None, ge=0, le=50)  # #408: Dezimal
     work_days_per_week: Optional[int] = Field(None, ge=1, le=7)
     track_hours: Optional[bool] = None
     is_active: Optional[bool] = None
@@ -192,7 +192,7 @@ class UserListResponse(BaseModel):
     last_name: str
     email: Optional[str] = None
     weekly_hours: float
-    vacation_days: int
+    vacation_days: float  # #408: Dezimal
     work_days_per_week: int
     track_hours: bool
     is_active: bool

--- a/backend/app/services/lifecycle_service.py
+++ b/backend/app/services/lifecycle_service.py
@@ -312,7 +312,10 @@ def _user_dict(u: User) -> dict[str, Any]:
         "last_name": u.last_name,
         "role": u.role.value if hasattr(u.role, "value") else str(u.role),
         "weekly_hours": float(u.weekly_hours) if u.weekly_hours is not None else None,
-        "vacation_days": u.vacation_days,
+        # #408: vacation_days ist jetzt Numeric(4,1) → Decimal. json.dumps (unten,
+        # export_as_json_bytes) kann Decimal nicht serialisieren → float casten
+        # (wie weekly_hours darüber). Vorher Integer, daher kein Cast nötig.
+        "vacation_days": float(u.vacation_days) if u.vacation_days is not None else None,
         "work_days_per_week": u.work_days_per_week,
         "track_hours": u.track_hours,
         "calendar_color": u.calendar_color,

--- a/backend/tests/test_vacation_days_decimal.py
+++ b/backend/tests/test_vacation_days_decimal.py
@@ -1,0 +1,74 @@
+"""#408: Jahresurlaubsanspruch (User.vacation_days) mit Nachkommastelle.
+
+Kundenreport (philvdb): eine 3-Tage-Teilzeitkraft hat 28×3/5 = 16,8 Urlaubstage.
+Bisher nur ganzzahlig eingebbar → gerundet auf 17 → 0,2 Tage Ungerechtigkeit
+vs. einer Kollegin mit unterjährigem Eintritt. `vacation_days` akzeptiert jetzt
+Dezimalwerte (Numeric(4,1), Schema float, ge=0/le=50). Der Calc rechnete bereits
+mit `Decimal(str(user.vacation_days))` — nur Speicher/Schema/Eingabe blockierten.
+"""
+import uuid
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from app.models import User, UserRole
+from app.schemas.user import UserBase, UserUpdate
+from app.services import calculation_service
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _base_kwargs(**over):
+    kw = dict(
+        username="dec", email="dec@t.l", first_name="De", last_name="Ci",
+        weekly_hours=16.8, work_days_per_week=3, vacation_days=16.8,
+    )
+    kw.update(over)
+    return kw
+
+
+def test_userbase_accepts_decimal_vacation_days():
+    m = UserBase(**_base_kwargs(vacation_days=16.8))
+    assert float(m.vacation_days) == pytest.approx(16.8)
+
+
+def test_userupdate_accepts_decimal_vacation_days():
+    m = UserUpdate(vacation_days=22.4)
+    assert float(m.vacation_days) == pytest.approx(22.4)
+
+
+def test_vacation_days_rejects_over_50():
+    with pytest.raises(ValidationError):
+        UserBase(**_base_kwargs(vacation_days=50.1))
+
+
+def test_vacation_days_rejects_negative():
+    with pytest.raises(ValidationError):
+        UserBase(**_base_kwargs(vacation_days=-0.5))
+
+
+def test_vacation_days_whole_number_still_ok():
+    m = UserBase(**_base_kwargs(vacation_days=30))
+    assert float(m.vacation_days) == pytest.approx(30.0)
+
+
+def _user(db, vacation_days):
+    u = User(
+        id=uuid.uuid4(), username=f"v{uuid.uuid4().hex[:6]}", email=f"{uuid.uuid4().hex[:6]}@t.l",
+        password_hash="x", first_name="V", last_name="D", role=UserRole.EMPLOYEE,
+        weekly_hours=16.8, work_days_per_week=3, vacation_days=vacation_days,
+        track_hours=True, use_daily_schedule=False, is_active=True, tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def test_vacation_account_budget_is_decimal(db):
+    """Ganzjährig beschäftigt, 16,8 Tage Anspruch, keine Abwesenheiten →
+    Budget + Rest = 16,8 (nicht auf 16 oder 17 gerundet)."""
+    u = _user(db, 16.8)
+    acc = calculation_service.get_vacation_account(db, u, 2026)
+    assert acc["budget_days"] == pytest.approx(16.8, abs=0.05)
+    assert acc["remaining_days"] == pytest.approx(16.8, abs=0.05)

--- a/frontend/src/pages/admin/users/UserForm.tsx
+++ b/frontend/src/pages/admin/users/UserForm.tsx
@@ -396,10 +396,11 @@ export default function UserForm({ editUser, onSaved }: UserFormProps) {
               id="f-vacation"
               type="number"
               value={formData.vacation_days}
-              onChange={(e) => setFormData({ ...formData, vacation_days: parseInt(e.target.value) || 0 })}
+              onChange={(e) => setFormData({ ...formData, vacation_days: parseFloat(e.target.value) || 0 })}
               required
               min="0"
               max="50"
+              step="0.1"
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary"
             />
             {suggestedVacation !== null && formData.vacation_days !== suggestedVacation && (


### PR DESCRIPTION
Fixes #408 (Kundenreport @philvdb).

## Problem
Eine 3-Tage-Teilzeitkraft hat 28×3/5 = **16,8** Urlaubstage. Der Jahresanspruch (`User.vacation_days`) war nur **ganzzahlig** eingebbar → Rundung auf 17 → 0,2 Tage Ungerechtigkeit vs. einer Kollegin mit unterjährigem Eintritt.

## Lösung (Ansatz A: Dezimal-Eingabe)
- **Migration 066:** `users.vacation_days` Integer → `Numeric(4,1)`.
- **Schema:** `vacation_days` int → float (`UserBase`/`UserUpdate`/`UserListResponse`, `ge=0`/`le=50`). `suggested_vacation_days` bleibt int (30×Arbeitstage/5 = immer ganzzahlig).
- **Frontend:** UserForm-Eingabe `parseInt` → `parseFloat` + `step="0.1"`.
- Die **Berechnung war bereits dezimalfähig** (`Decimal(str(user.vacation_days))`) — unverändert.

## ⚠️ DSGVO-Export-Fix (Folge der Numeric-Umstellung, vom Review als CRITICAL gefunden)
Zwei rohe `json.dumps`-Export-Pfade schrieben `vacation_days` ungecastet als `Decimal` → `TypeError: Object of type Decimal is not JSON serializable` → **HTTP 500 für JEDEN Nutzer** (auch bei ganzzahligem Wert), sobald der Spaltentyp Decimal liefert:
- `lifecycle_service._user_dict` (Art. 15 Selbstauskunft `/me/data-export` + Admin-Tenant-Export `/tenant/export`)
- `auth.py /me/export` (Art. 20 Datenübertragbarkeit)

Beide casten jetzt `float(...)` — **exakt wie das benachbarte `weekly_hours`** (auch `Numeric`). `vacation_days` war vorher Integer, daher kein Cast nötig. Alle anderen `vacation_days`-Serialisierungen (`calculation_service` → schon `float`; API-Responses → `jsonable_encoder`) sind sauber.

## Verifikation
- **Backend-Voll-Suite:** 1378 passed. Die 6 verbleibenden Fails sind **pre-existing** `shift_planning`-„MyToday"-Tests (date-abhängig, `KeyError:'id'`) — failen **auch auf master** ohne diese Änderung, nicht #408-bezogen.
- **PG18:** Migration 066 up→down→up; `users.vacation_days` = `numeric(4,1)`; 16,8 speichert als 16,8 (SQLite versteckt Numeric-Precision → PG-Round-Trip nötig).
- **Frontend:** tsc clean, UserForm 13/13, build ok.
- **Multi-Agent-Review:** 1 CRITICAL (der Export-Decimal-Crash) gefunden + gefixt, 0 offen.
- Neuer Test `tests/test_vacation_days_decimal.py` (Schema-Dezimal + Bounds + Calc-Budget-Round-Trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
