### PR TITLE
Release 1.15.2 — #408 Jahresurlaubsanspruch dezimal + DSGVO-Export-Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.15.2] - 2026-07-18
+
+Patch-Release. Ein neues, klein umrissenes Feature (#408) + der als Folge nötige
+DSGVO-Export-Fix. Eine Migration (066). Kein weiterer Backend-/Berechnungs-Code.
+
 ### ✨ Neu
 - **Jahresurlaubsanspruch mit Nachkommastelle (#408).** `User.vacation_days` ist
   jetzt dezimal (Migration 066, `Numeric(4,1)`): eine 3-Tage-Teilzeitkraft kann
@@ -9,6 +14,13 @@
   gerundet zu werden (das erzeugte 0,2 Tage Ungerechtigkeit vs. Kolleg:innen mit
   unterjährigem Eintritt). Eingabefeld akzeptiert 0,1-Schritte. Die Berechnung
   war bereits dezimalfähig (`Decimal`); nur Speicher/Schema/Eingabe blockierten.
+
+### 🐛 Behoben
+- **DSGVO-Export lief nach der #408-Umstellung in einen 500-Fehler.** Zwei rohe
+  `json.dumps`-Export-Pfade (Art.-15-Selbstauskunft + Admin-Tenant-Export sowie
+  Art.-20-Datenübertragbarkeit `/me/export`) schrieben `vacation_days` als
+  `Decimal` → „Object of type Decimal is not JSON serializable". Beide casten
+  jetzt `float(...)` (wie das benachbarte `weekly_hours`).
 
 ## [1.15.1] - 2026-07-15
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.15.1 (Stand 2026-07-15)
+**Aktuelle Version:** 1.15.2 (Stand 2026-07-18)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -32,7 +32,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.15.1"
+APP_VERSION = "1.15.2"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.15.1",
+      "version": "1.15.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.15.1",
+  "version": "1.15.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.15.1"
+APP_VERSION="1.15.2"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
PATCH. Ein klein umrissenes Feature (#408) + der als Folge nötige DSGVO-Export-Fix. Migration 066. Kein weiterer Backend-/Berechnungs-Code, keine Deps, keine Installer-Änderungen.

## Inhalt
- **Version-Bump** 1.15.1 → 1.15.2 (3 Stellen + Lock).
- **#408** (Kern via #411 gemerged): `User.vacation_days` Integer → `Numeric(4,1)` (Migration 066), Schema int→float, UserForm `step="0.1"` — Jahresurlaub jetzt dezimal (z. B. 16,8 Tage für 3-Tage-Teilzeit). Plus die zwei Decimal-`json.dumps`-Export-Fixes (Art.15/20-DSGVO-Exporte casten `float()`).
- CHANGELOG [1.15.2] + CLAUDE.md.

## QA-Matrix
| Gate | Ergebnis |
|------|----------|
| Delta-Review (multi-agent + verify) | 0 findings (#408 war in der Build-Phase gehärtet, 1 CRITICAL dort gefixt) |
| Backend-Suite | **1378 passed**. Die 6 Rest-Fails = **pre-existing** `shift_planning`-„MyToday" (date-abhängig, `KeyError:'id'`, failen auch auf master, NICHT #408) |
| Migration 066 | up→down→up auf PG18, `users.vacation_days` = `numeric(4,1)` |
| validate-release | **5/5** (PG 18.4) |
| Artefakt-Integrität | 6 Artefakte, SHA ok, kein setup.exe im ZIP, PG-Pin 18.4, Bundle 1.15.2 |
| Local Docker 1.15.2 | Health 200, **echter Login 200**, #408 auf echtem PG (`vacation_days=16.8` persistiert, nicht 17), **DSGVO `/me/export` = 200** (statt 500 = CRITICAL-Fix bestätigt), users-overview 200 |
| .131 (Real-Host) | **unerreichbar** (ping/ssh: No route to host) — dokumentiert |
| Win-Emu / Native-Fresh | übersprungen (0 `installer/`-Änderungen seit v1.13.0) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
