### PR TITLE
feat(#402): Voraussichtlicher Überstundensaldo zum Jahresende

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -229,10 +229,20 @@ def get_overtime_account(
         if _exceeded:
             milog_warnings.append(milog_service.monthly_exceeded_warning_text(_exceeded))
 
+    # #402: bereits feststehender künftiger Freizeitausgleich + projizierter
+    # Jahresende-Saldo. projected nur setzen, wenn künftiger Ausgleich existiert
+    # (sonst None → Frontend blendet die Zeile aus).
+    future_comp = calculation_service.future_freizeitausgleich_impact(
+        db, current_user, cutoff_date=cutoff
+    )
+    projected = float(current_balance) - float(future_comp) if future_comp > 0 else None
+
     return OvertimeAccount(
         current_balance=current_balance,
         history=history,
         milog_warnings=milog_warnings,
+        future_comp_hours=float(future_comp),
+        projected_year_end=projected,
     )
 
 

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -14,7 +14,9 @@ from app.models.public_holiday import PublicHoliday
 from app.middleware.auth import require_admin
 from app.schemas.reports import EmployeeMonthlyReport, EmployeeYearlyAbsences
 from app.services import calculation_service, export_service, ods_export_service, rest_time_service
+from app.services.timezone_service import now_local
 from app.services.arbzg_utils import is_night_work
+import calendar
 from app.services.date_filters import date_in_year, date_in_month, date_in_range, parse_year_month
 from app.core.limiter import limiter
 
@@ -86,6 +88,7 @@ def get_monthly_report(
     users = _get_active_visible_users(db, current_user.tenant_id)
 
     reports = []
+    _now = now_local()  # #402: Gate für die Jahresende-Projektion (nur aktueller Monat)
 
     for user in users:
         # #313: per-user cutoff (each user's last finished workday) unless the
@@ -97,6 +100,17 @@ def get_monthly_report(
         # beide pro User redundant neu laden. Identisch zu dessen (actual-target).quantize.
         balance = (actual - target).quantize(Decimal('0.01'))
         overtime = calculation_service.get_overtime_account(db, user, year, month_num, cutoff_date=cutoff)
+
+        # #402: projizierter Jahresende-Saldo — nur im AKTUELLEN Monat sinnvoll
+        # (Projektion „von jetzt bis 31.12."). Boundary = derselbe wie bei overtime:
+        # bis_heute→cutoff, monatsende→Monatsende (verhindert Doppelzählung künftiger
+        # Freizeitausgleich-Tage im laufenden Monat).
+        _future_comp = Decimal('0'); _projected = None
+        if year == _now.year and month_num == _now.month and user.track_hours:
+            _boundary = cutoff if cutoff is not None else date(year, month_num, calendar.monthrange(year, month_num)[1])
+            _future_comp = calculation_service.future_freizeitausgleich_impact(db, user, cutoff_date=_boundary)
+            if _future_comp > 0:
+                _projected = float(overtime) - float(_future_comp)
 
         # Get vacation and sick hours for the month (F-033: sargable)
         vacation_absences = db.query(Absence).filter(
@@ -135,6 +149,8 @@ def get_monthly_report(
             actual_hours=float(actual),
             balance=float(balance),
             overtime_cumulative=float(overtime),
+            future_comp_hours=float(_future_comp),
+            projected_year_end_overtime=_projected,
             vacation_used_hours=vacation_hours,
             vacation_used_days=vacation_days,
             sick_hours=sick_hours if include_health_data else 0.0,
@@ -203,6 +219,7 @@ def get_weekly_report(
     users = _get_active_visible_users(db, current_user.tenant_id)
 
     reports = []
+    _now = now_local()  # #402: Gate für die Jahresende-Projektion (nur aktuelle Woche)
 
     for user in users:
         # #313: per-user cutoff (last finished workday) unless run on the full basis.
@@ -216,6 +233,15 @@ def get_weekly_report(
         overtime = calculation_service.get_overtime_account(
             db, user, wk_end.year, wk_end.month, cutoff_date=ot_cutoff
         )
+
+        # #402: projizierter Jahresende-Saldo — nur in der AKTUELLEN Woche sinnvoll.
+        # Boundary = ot_cutoff (Wochenende bzw. bis_heute-Cutoff), damit künftige
+        # Freizeitausgleich-Tage nicht doppelt zählen.
+        _future_comp = Decimal('0'); _projected = None
+        if wk_end.year == _now.year and wk_start <= _now.date() <= wk_end and user.track_hours:
+            _future_comp = calculation_service.future_freizeitausgleich_impact(db, user, cutoff_date=ot_cutoff)
+            if _future_comp > 0:
+                _projected = float(overtime) - float(_future_comp)
 
         # Urlaub/Krank in der Woche (F-033: sargable range). Bei soll_basis=bis_heute
         # denselben Cutoff wie Soll/Ist anwenden, damit die Tage-Spalten nicht eine
@@ -257,6 +283,8 @@ def get_weekly_report(
             actual_hours=float(actual),
             balance=float(balance),
             overtime_cumulative=float(overtime),
+            future_comp_hours=float(_future_comp),
+            projected_year_end_overtime=_projected,
             vacation_used_hours=vacation_hours,
             vacation_used_days=vacation_days,
             sick_hours=sick_hours if include_health_data else 0.0,

--- a/backend/app/schemas/reports.py
+++ b/backend/app/schemas/reports.py
@@ -28,6 +28,12 @@ class OvertimeAccount(BaseModel):
     current_balance: float
     history: List[OvertimeHistory]
     milog_warnings: List[str] = []  # #377 §2 Abs.2 MiLoG (self-scoped; leer wenn Flag aus)
+    # #402: bereits feststehender künftiger Freizeitausgleich (Σ Tages-Soll der
+    # OVERTIME-Abwesenheiten bis 31.12.) + projizierter Saldo am Jahresende.
+    # projected_year_end ist None, wenn kein künftiger Freizeitausgleich existiert
+    # (Frontend blendet die Zeile dann aus).
+    future_comp_hours: float = 0.0
+    projected_year_end: Optional[float] = None
 
 
 class YtdOvertime(BaseModel):
@@ -80,6 +86,11 @@ class EmployeeMonthlyReport(BaseModel):
     actual_hours: float
     balance: float
     overtime_cumulative: float
+    # #402: projizierter Überstundensaldo am 31.12. = overtime_cumulative − bereits
+    # feststehender künftiger Freizeitausgleich. None, wenn kein künftiger
+    # Freizeitausgleich existiert (Admin-Spalte zeigt dann „—").
+    future_comp_hours: float = 0.0
+    projected_year_end_overtime: Optional[float] = None
     vacation_used_hours: float
     vacation_used_days: float   # Tagesprinzip: Stunden ÷ Tagessoll (für die Anzeige)
     sick_hours: float

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -380,6 +380,75 @@ def get_soll_cutoff_date(db: Session, user: User, today: date = None) -> date:
     return today if has_completed_today else today - timedelta(days=1)
 
 
+def future_freizeitausgleich_impact(
+    db: Session, user: User, *, cutoff_date: date = None, today: date = None
+) -> Decimal:
+    """#402: Σ Tages-Soll der bereits FESTSTEHENDEN künftigen Freizeitausgleich-Tage.
+
+    Summiert das Tages-Soll aller OVERTIME-Abwesenheiten ab dem Tag NACH dem
+    Saldo-Stichtag (#313) bis zum 31.12. des laufenden Jahres — im Beschäftigungs-
+    fenster, ohne Wochenende/Feiertag. Genau um diesen Betrag wird das Über-
+    stundenkonto durch die schon geplanten Freizeitausgleich-Tage noch sinken
+    (bei OVERTIME bleibt das Soll stehen, das Ist ist 0 → Konto −= Tages-Soll).
+
+    Bewusst **Soll-basiert** (dieselbe Quelle `_day_soll_contribution` wie
+    `get_overtime_account`), NICHT das `hours`-Feld — so wird die Projektion im
+    Dezember bitgleich zum dann tatsächlich gebuchten Saldo. `> cutoff_date`
+    verhindert Doppelzählung mit dem aktuellen (bis-heute-)Saldo.
+    """
+    if not user.track_hours:
+        return Decimal('0')
+    if today is None:
+        today = today_local()
+    if cutoff_date is None:
+        cutoff_date = get_soll_cutoff_date(db, user, today)
+    year_end = date(today.year, 12, 31)
+    if cutoff_date >= year_end:
+        return Decimal('0')
+
+    overtime_abs = db.query(Absence).filter(
+        Absence.user_id == user.id,
+        Absence.tenant_id == user.tenant_id,  # F-026 belt-and-suspenders
+        Absence.type == AbsenceType.OVERTIME,
+        Absence.date > cutoff_date,
+        Absence.date <= year_end,
+    ).all()
+    if not overtime_abs:
+        return Decimal('0')
+
+    holiday_dates = {
+        h.date for h in db.query(PublicHoliday).filter(
+            PublicHoliday.tenant_id == user.tenant_id,
+            PublicHoliday.date > cutoff_date,
+            PublicHoliday.date <= year_end,
+        ).all()
+    }
+    wh_changes = db.query(WorkingHoursChange).filter(
+        WorkingHoursChange.user_id == user.id,
+        WorkingHoursChange.tenant_id == user.tenant_id,
+    ).order_by(WorkingHoursChange.effective_from).all()
+    special_cfg = special_days_service.get_special_day_config(db, user.tenant_id, today.year)
+
+    total = Decimal('0')
+    for a in overtime_abs:
+        d = a.date
+        if d.weekday() >= 5:  # Wochenende → 0 Soll
+            continue
+        if not _within_employment_window(user, d):
+            continue
+        # OVERTIME ist NICHT soll-reduzierend → leere half_map → volles Tages-Soll
+        # (× #146-Sondertag-Faktor). Exakt der Betrag, um den dieser Tag später
+        # den Saldo senkt.
+        total += _day_soll_contribution(
+            db, user, d,
+            holiday_dates=holiday_dates,
+            absence_half_map={},
+            wh_changes=wh_changes,
+            special_cfg=special_cfg,
+        )
+    return total.quantize(Decimal('0.01'))
+
+
 def get_range_target(
     db: Session, user: User, start: date, end: date, up_to_date: date = None
 ) -> Decimal:

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -398,6 +398,14 @@ def future_freizeitausgleich_impact(
     """
     if not user.track_hours:
         return Decimal('0')
+    # #377 Baustein 2b: im festen Monats-Soll-Modus bewegt eine OVERTIME-Abwesenheit
+    # das Überstundenkonto NICHT — OVERTIME ist in keinem _FIXED_*_TYPES, hat also
+    # weder Soll- noch Ist-Effekt (get_overtime_account delegiert für diese MA an das
+    # Fix-Modell). Es gibt daher keinen künftigen Freizeitausgleich zu projizieren.
+    # (Fünfter Parallelpfad — Modus-Branch wie in get_range_target/get_overtime_account/
+    # get_ytd_summary/get_overtime_history_detailed, siehe CLAUDE.md #377.)
+    if getattr(user, "use_fixed_monthly_target", False) and getattr(user, "agreed_monthly_hours", None):
+        return Decimal('0')
     if today is None:
         today = today_local()
     if cutoff_date is None:

--- a/backend/tests/test_projected_year_end_overtime.py
+++ b/backend/tests/test_projected_year_end_overtime.py
@@ -1,0 +1,87 @@
+"""#402: Voraussichtlicher Überstundensaldo zum Jahresende.
+
+Kunde (philvdb): unter dem Überstundenkonto soll eine Zeile den projizierten
+Saldo am 31.12. zeigen = aktueller Saldo − bereits feststehender künftiger
+Freizeitausgleich (OVERTIME-Abwesenheiten in der Zukunft, typ. aus Betriebsferien
+via #314). Bewusst Soll-basiert, damit die Projektion im Dezember bitgleich zum
+dann tatsächlichen Saldo wird.
+"""
+import uuid
+from datetime import date
+
+from app.models import User, UserRole, Absence, AbsenceType
+from app.services import calculation_service
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _user(db, track_hours=True):
+    u = User(
+        id=uuid.uuid4(), username=f"o{uuid.uuid4().hex[:6]}", email=f"{uuid.uuid4().hex[:6]}@t.l",
+        password_hash="x", first_name="O", last_name="T", role=UserRole.EMPLOYEE,
+        weekly_hours=40, work_days_per_week=5, vacation_days=30,
+        track_hours=track_hours, use_daily_schedule=False, is_active=True, tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(u); db.commit(); db.refresh(u)
+    return u
+
+
+def _overtime(db, u, d):
+    a = Absence(id=uuid.uuid4(), user_id=u.id, tenant_id=DEFAULT_TENANT_ID,
+                date=d, type=AbsenceType.OVERTIME, hours=8)
+    db.add(a); db.commit()
+    return a
+
+
+TODAY = date(2026, 7, 15)
+CUTOFF = date(2026, 7, 14)
+
+
+def test_future_overtime_day_counts_full_daily_soll(db):
+    u = _user(db)
+    _overtime(db, u, date(2026, 12, 1))  # Dienstag, Werktag, 8h Soll
+    impact = calculation_service.future_freizeitausgleich_impact(db, u, cutoff_date=CUTOFF, today=TODAY)
+    assert float(impact) == 8.0
+
+
+def test_two_future_overtime_days_sum(db):
+    u = _user(db)
+    _overtime(db, u, date(2026, 12, 1))
+    _overtime(db, u, date(2026, 12, 2))
+    impact = calculation_service.future_freizeitausgleich_impact(db, u, cutoff_date=CUTOFF, today=TODAY)
+    assert float(impact) == 16.0
+
+
+def test_past_overtime_not_counted(db):
+    """OVERTIME am/vor dem Stichtag ist schon im aktuellen Saldo → nicht doppelt."""
+    u = _user(db)
+    _overtime(db, u, date(2026, 7, 10))  # vor Cutoff
+    impact = calculation_service.future_freizeitausgleich_impact(db, u, cutoff_date=CUTOFF, today=TODAY)
+    assert float(impact) == 0.0
+
+
+def test_next_year_overtime_excluded(db):
+    """Nur bis 31.12. des laufenden Jahres."""
+    u = _user(db)
+    _overtime(db, u, date(2027, 1, 4))
+    impact = calculation_service.future_freizeitausgleich_impact(db, u, cutoff_date=CUTOFF, today=TODAY)
+    assert float(impact) == 0.0
+
+
+def test_no_future_overtime_zero(db):
+    u = _user(db)
+    impact = calculation_service.future_freizeitausgleich_impact(db, u, cutoff_date=CUTOFF, today=TODAY)
+    assert float(impact) == 0.0
+
+
+def test_untracked_user_zero(db):
+    u = _user(db, track_hours=False)
+    _overtime(db, u, date(2026, 12, 1))
+    impact = calculation_service.future_freizeitausgleich_impact(db, u, cutoff_date=CUTOFF, today=TODAY)
+    assert float(impact) == 0.0
+
+
+def test_weekend_overtime_skipped(db):
+    u = _user(db)
+    _overtime(db, u, date(2026, 12, 5))  # Samstag → 0 Soll
+    impact = calculation_service.future_freizeitausgleich_impact(db, u, cutoff_date=CUTOFF, today=TODAY)
+    assert float(impact) == 0.0

--- a/backend/tests/test_projected_year_end_overtime.py
+++ b/backend/tests/test_projected_year_end_overtime.py
@@ -85,3 +85,17 @@ def test_weekend_overtime_skipped(db):
     _overtime(db, u, date(2026, 12, 5))  # Samstag → 0 Soll
     impact = calculation_service.future_freizeitausgleich_impact(db, u, cutoff_date=CUTOFF, today=TODAY)
     assert float(impact) == 0.0
+
+
+def test_fixed_monthly_target_user_zero(db):
+    """#377 Baustein 2b: im Fix-Soll-Modus bewegt OVERTIME das Konto NICHT
+    (OVERTIME ∉ _FIXED_*_TYPES) → kein künftiger Freizeitausgleich-Impact, sonst
+    wäre die Projektion im Dezember nicht bitgleich zum dann tatsächlichen Saldo."""
+    u = _user(db)
+    u.milog_working_time_account = True
+    u.agreed_monthly_hours = 80
+    u.use_fixed_monthly_target = True
+    db.commit()
+    _overtime(db, u, date(2026, 12, 1))  # würde ohne Modus-Branch 8h liefern
+    impact = calculation_service.future_freizeitausgleich_impact(db, u, cutoff_date=CUTOFF, today=TODAY)
+    assert float(impact) == 0.0

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -49,6 +49,8 @@ interface OvertimeAccount {
   current_balance: number;
   history: OvertimeHistory[];
   milog_warnings?: string[]; // #377 §2 Abs.2 MiLoG (self-scoped)
+  future_comp_hours?: number; // #402: bereits feststehender künftiger Freizeitausgleich
+  projected_year_end?: number | null; // #402: projizierter Saldo am 31.12. (null = kein künftiger Ausgleich)
 }
 
 interface YearlyAbsenceSummary {
@@ -539,6 +541,19 @@ export default function Dashboard() {
               >
                 {overtimeAccount.current_balance >= 0 ? '+' : ''}{formatHoursHM(overtimeAccount.current_balance)} h
               </p>
+              {/* #402: projizierter Saldo zum Jahresende (aktueller Saldo − bereits
+                  feststehender künftiger Freizeitausgleich). Nur wenn künftiger
+                  Ausgleich existiert. Bewusst grau (auch bei Minus, Motivations-
+                  gründe – Kundenwunsch). */}
+              {overtimeAccount.projected_year_end != null && (
+                <div className="mt-3">
+                  <p className="text-xs text-gray-500">Voraussichtl. Überstunden zum Jahresende</p>
+                  <p className="text-lg font-semibold tabular-nums text-gray-500">
+                    {overtimeAccount.projected_year_end >= 0 ? '+' : ''}{formatHoursHM(overtimeAccount.projected_year_end)} h
+                  </p>
+                  <p className="text-[11px] text-gray-400">nach bereits geplantem Freizeitausgleich</p>
+                </div>
+              )}
               {/* #377 §2 Abs.2 MiLoG: weiche Arbeitszeitkonto-Hinweise (Minijob) */}
               {(overtimeAccount.milog_warnings ?? []).length > 0 && (
                 <div className="mt-3 rounded-lg bg-amber-50 border border-amber-200 p-2">

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -24,6 +24,8 @@ interface EmployeeReport {
   actual_hours: number;
   balance: number;
   overtime_cumulative: number;
+  future_comp_hours?: number; // #402
+  projected_year_end_overtime?: number | null; // #402: proj. Saldo 31.12. (null = kein künftiger Ausgleich)
   vacation_used_hours: number;
   vacation_used_days: number;
   sick_hours: number;
@@ -453,6 +455,12 @@ export default function AdminDashboard() {
       return sortDirection === 'asc' ? comparison : -comparison;
     });
 
+  // #402: Spalte „Überstd. Jahresende" nur zeigen, wenn mind. ein MA künftigen
+  // Freizeitausgleich hat (Kundenwunsch: optional, sonst kein zusätzliches Rauschen).
+  const showYearEndCol = filteredAndSortedReport.some(
+    (e) => e.projected_year_end_overtime != null,
+  );
+
   const totalEmployees = report.length;
   // #159: Ø Saldo wahlweise ohne leitende Angestellte (Default) — verhindert
   // dass wenige MA mit vielen Stunden den Schnitt verzerren.
@@ -690,6 +698,15 @@ export default function AdminDashboard() {
                     )}
                   </div>
                 </th>
+                {/* #402: projizierter Saldo zum Jahresende (nur wenn künftiger Freizeitausgleich existiert) */}
+                {showYearEndCol && (
+                  <th
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase"
+                    title="Voraussichtlicher Überstundensaldo am 31.12. = Überstd. kum. abzüglich bereits feststehenden künftigen Freizeitausgleichs"
+                  >
+                    Überstd. Jahresende
+                  </th>
+                )}
                 <th
                   className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase cursor-pointer hover:bg-gray-100 transition"
                   onClick={() => handleSort('vacation_used_days')}
@@ -757,6 +774,19 @@ export default function AdminDashboard() {
                         {formatHoursHM(emp.overtime_cumulative)}
                       </span>
                     </td>
+                    {/* #402: proj. Jahresende-Saldo, grau (auch bei Minus – Kundenwunsch); „—" wenn kein künftiger Ausgleich */}
+                    {showYearEndCol && (
+                      <td className="px-6 py-4 text-sm">
+                        {emp.projected_year_end_overtime != null ? (
+                          <span className="text-gray-500">
+                            {emp.projected_year_end_overtime >= 0 ? '+' : ''}
+                            {formatHoursHM(emp.projected_year_end_overtime)}
+                          </span>
+                        ) : (
+                          <span className="text-gray-300">—</span>
+                        )}
+                      </td>
+                    )}
                     <td className="px-6 py-4 text-sm text-gray-900">{emp.vacation_used_days.toFixed(1)}</td>
                     <td className="px-6 py-4 text-sm text-gray-900">{showHealthData ? emp.sick_days.toFixed(1) : '—'}</td>
                     <td className="px-6 py-4 text-right">


### PR DESCRIPTION
Fixes #402 (Kundenwunsch @philvdb).

## Feature
Zeigt den **projizierten Überstundensaldo am 31.12.** = aktueller Saldo − bereits feststehender künftiger Freizeitausgleich (OVERTIME-Abwesenheiten in der Zukunft, typ. aus Betriebsferien via #314).
- **MA-Dashboard:** neue Zeile unter dem Überstundenkonto: „Voraussichtl. Überstunden zum Jahresende" (grau, auch bei Minus — Kundenwunsch aus Motivationsgründen), **nur wenn** künftiger Freizeitausgleich existiert.
- **Admin-Dashboard:** konditionale Spalte „Überstd. Jahresende" neben „Überstd. kum." (nur wenn mind. ein MA künftigen Ausgleich hat; „—" je Zeile ohne).

## Kern (frozen-calc unberührt, reine Lese-Projektion)
Neuer Helper `future_freizeitausgleich_impact()` = Σ **Tages-Soll** der OVERTIME-Abwesenheiten ab dem Tag **nach** dem Saldo-Stichtag (#313) bis 31.12., im Beschäftigungsfenster, ohne WE/Feiertag. Bewusst **Soll-basiert** über dieselbe Quelle `_day_soll_contribution` wie `get_overtime_account` (NICHT das `hours`-Feld) → die Projektion wird im Dezember **bitgleich** zum dann tatsächlich gebuchten Saldo. `> cutoff` verhindert Doppelzählung mit dem aktuellen (bis-heute-)Saldo. Projektion **nur im aktuellen Zeitfenster** (Monat/Woche); Boundary passt zur `overtime`-Grenze.

## QA
- **7 neue Calc-Tests** (künftig/vergangen/nächstes Jahr/kein/untracked/WE/Summe).
- **Backend-Voll-Suite 1385 passed** (die 6 Rest-Fails = pre-existing `shift_planning`-„MyToday", date-brittle, failen auch auf master).
- **Frontend** tsc + vitest 213/213.
- **Local-Docker E2E auf echtem PG:** tracked User + künftige OVERTIME 01.12./8h → `future_comp_hours=8,0`, `projected_year_end=-8,0` in BEIDEN Endpoints (/dashboard/overtime + /admin/reports/monthly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
