### PR TITLE
Release 1.16.0 — Release-Review-Fixes + MINOR-Bump

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.15.2 (Stand 2026-07-18)
+**Aktuelle Version:** 1.16.0 (Stand 2026-07-25)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -32,7 +32,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.15.2"
+APP_VERSION = "1.16.0"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/routers/admin_change_requests.py
+++ b/backend/app/routers/admin_change_requests.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 from typing import List, Optional
 from datetime import datetime, timezone, date, timedelta
 from app.database import get_db
-from app.models import User, TimeEntry, ChangeRequest, ChangeRequestStatus, ChangeRequestType, Absence, AbsenceType, AbsenceReason
+from app.models import User, TimeEntry, ChangeRequest, ChangeRequestStatus, ChangeRequestType, Absence, AbsenceType, AbsenceReason, PublicHoliday
 from app.middleware.auth import require_admin
 from app.schemas.change_request import (
     ChangeRequestResponse,
@@ -511,6 +511,31 @@ def review_change_request(
             # genehmigter Urlaub die 8h und verbrauchte bei Teilzeit (4h/Tag)
             # doppelten Urlaub (8/4 = 2 Tage statt 1).
             cr_user = db.query(User).filter(User.id == cr.user_id, User.tenant_id == cr.tenant_id).first()
+
+            # Release-Review 1.16.0: gesetzliche Feiertage ausschließen. Von den vier
+            # Buchungspfaden war dies der einzige ohne Feiertags-Guard — create_absence
+            # (absences.py), review_vacation_request und _create_closure_absences
+            # nehmen Feiertage über ihre _get_workdays-/holidays-Mengen heraus. Ein
+            # Feiertag hat bereits 0 Soll; eine Absence darauf kostet je nach Typ einen
+            # Urlaubstag für einen ohnehin freien Tag bzw. verfälscht die Abwesenheits-
+            # tage in Reports und §16-Exporten. Wochenenden sind nicht geprüft — die
+            # tragen ebenfalls 0 Soll und werden von den anderen Pfaden über
+            # `weekday() < 5` ausgeschlossen, hier aber bewusst zugelassen (Praxen mit
+            # Samstagsdienst buchen dort reale Abwesenheiten).
+            if cr.proposed_date and cr_user:
+                _is_holiday = db.query(PublicHoliday).filter(
+                    PublicHoliday.date == cr.proposed_date,
+                    PublicHoliday.tenant_id == cr_tenant_id,  # F-026
+                ).first()
+                if _is_holiday:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=(
+                            f"{cr.proposed_date.strftime('%d.%m.%Y')} ist ein Feiertag "
+                            f"({_is_holiday.name}) — dort kann keine Abwesenheit gebucht werden."
+                        ),
+                    )
+
             _is_overtime = cr.proposed_absence_type == AbsenceType.OVERTIME.value
             if cr_user and (not _is_overtime or getattr(cr_user, "use_daily_schedule", False)):
                 weekly = get_weekly_hours_for_date(db, cr_user, cr.proposed_date)
@@ -569,6 +594,15 @@ def review_change_request(
                 date=cr.proposed_date,
                 type=AbsenceType(cr.proposed_absence_type),
                 hours=hours,
+                # Release-Review 1.16.0: half_day MUSS gesetzt werden. Die Spalte ist
+                # nullable ohne Default; NULL bedeutet laut #205 „Legacy-Row vor dem
+                # Feld" und schaltet get_vacation_account/absence_days auf die
+                # stunden-basierte Zählung um — die den #394-Halbtags-Sondertagsfaktor
+                # NICHT anwendet und nach einer rückwirkenden WorkingHoursChange
+                # driftet (8h-Urlaub kostet nach Rückstufung auf 4h/Tag plötzlich 2,0
+                # Tage). Der Änderungsantrag kennt kein Halbtags-Konzept und bucht
+                # immer ganztags → False, analog _create_closure_absences.
+                half_day=False,
                 start_time=cr.proposed_start_time,
                 end_time=cr.proposed_end_time,
                 reason_id=cr.proposed_reason_id,  # #312: carry the custom reason through
@@ -724,7 +758,13 @@ def review_change_request(
             _upd_is_overtime = absence.type == AbsenceType.OVERTIME
             if _upd_user and (not _upd_is_overtime or getattr(_upd_user, "use_daily_schedule", False)):
                 _upd_weekly = get_weekly_hours_for_date(db, _upd_user, _upd_date)
-                absence.hours = float(get_daily_target_for_date(_upd_user, _upd_date, _upd_weekly))
+                _upd_target = float(get_daily_target_for_date(_upd_user, _upd_date, _upd_weekly))
+                # Release-Review 1.16.0: half_day mitziehen. Ohne die Halbierung
+                # bläht ein reiner Zeit-Edit an einer halbtägigen Abwesenheit die
+                # Stunden auf das VOLLE Tagessoll auf — bei SICK/TRAINING wird das
+                # als Ist gutgeschrieben, sodass ein halber Krank-Tag plus halber
+                # Arbeitstag plötzlich 12 statt 8 Ist-Stunden ergibt.
+                absence.hours = round(_upd_target / 2, 2) if absence.half_day else _upd_target
             elif cr.proposed_absence_hours is not None:
                 absence.hours = float(cr.proposed_absence_hours)
             if cr.proposed_date:

--- a/backend/app/routers/admin_time_entries.py
+++ b/backend/app/routers/admin_time_entries.py
@@ -199,6 +199,21 @@ def admin_update_time_entry(
     update_end_time = entry_data.end_time if entry_data.end_time is not None else entry.end_time
     update_break_minutes = entry_data.break_minutes if entry_data.break_minutes is not None else entry.break_minutes
 
+    # Release-Review 1.16.0: die Reihenfolge des GEMERGTEN Paars prüfen.
+    # `TimeEntryUpdate.validate_end_after_start` sieht nur den Payload — ein PUT mit
+    # ausschliesslich `end_time` kommt daran vorbei, und der Router schrieb bisher
+    # end < start durch; `net_hours` fiel dann still über den max(0,…)-Floor auf 0
+    # und der Tag verschwand aus Saldo und §16-Beleg.
+    if (
+        update_start_time is not None
+        and update_end_time is not None
+        and update_end_time <= update_start_time
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Endzeit muss nach Startzeit liegen",
+        )
+
     # #201: Clamp start/end to the affected employee's soll window.
     # Use `affected_user` (the employee whose entry this is), NOT current_user (admin).
     _grace = work_window_service.get_grace_minutes(db, current_user.tenant_id)
@@ -299,12 +314,19 @@ def admin_update_time_entry(
         tenant_id=current_user.tenant_id,
     )
 
-    # Apply only provided updates (always write clamped effective times)
+    # Apply only provided updates (always write clamped effective times).
+    # Release-Review 1.16.0: ein Datumswechsel ändert das Soll-Fenster des Tages und
+    # damit das Kappungsergebnis, auch wenn keine Zeit mitgeschickt wurde. Vorher
+    # wurden Validierung, Duplikatsprüfung und Audit-Log mit den NEU gekappten Zeiten
+    # gefahren, in die DB aber die alten geschrieben — der Audit-Eintrag behauptete
+    # eine Zeit, die nie gespeichert wurde, und das #201-Arbeitszeitfenster liess
+    # sich per reinem Datums-PUT umgehen.
+    _times_affected = entry_data.date is not None
     if entry_data.date is not None:
         entry.date = entry_data.date
-    if entry_data.start_time is not None:
+    if entry_data.start_time is not None or _times_affected:
         entry.start_time = eff_start
-    if entry_data.end_time is not None:
+    if entry_data.end_time is not None or _times_affected:
         entry.end_time = eff_end
     if entry_data.break_minutes is not None:
         entry.break_minutes = entry_data.break_minutes
@@ -315,9 +337,9 @@ def admin_update_time_entry(
         entry.break_waiver_reason = waiver_reason
     # #201: raw_* — reset to None when not capped, set when capped.
     # Only update raw_* when start_time or end_time was explicitly provided in the request.
-    if entry_data.start_time is not None:
+    if entry_data.start_time is not None or _times_affected:
         entry.raw_start_time = raw_start
-    if entry_data.end_time is not None:
+    if entry_data.end_time is not None or _times_affected:
         entry.raw_end_time = raw_end
 
     db.commit()

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import func
 from typing import List
 from datetime import datetime, timezone, timedelta
+from decimal import Decimal
 from app.services.timezone_service import today_local
 from app.database import get_db
 from app.models import User, TimeEntry, Absence, AbsenceReason, WorkingHoursChange, ChangeRequest, TimeEntryAuditLog, UserRole, PublicHoliday
@@ -682,6 +683,33 @@ def update_user(
                 detail="Fester Monats-Soll setzt das MiLoG-Arbeitszeitkonto voraus."
             )
 
+    # Release-Review 1.16.0: Beschäftigungsfenster und Soll-Zeit-Fenster ebenfalls
+    # gegen den EFFEKTIVEN Zustand prüfen, nicht nur gegen den Payload.
+    # `validate_employment_and_window_order` im Schema sieht nur die mitgeschickten
+    # Felder: ein Partial-PUT mit ausschliesslich `last_work_day` kommt an ihm vorbei
+    # (first_work_day ist dort None) und schreibt first > last in die DB. Danach
+    # wirft der `UserResponse`-Validator beim SERIALISIEREN — also erst in der
+    # Antwort und anschliessend bei jedem weiteren Endpoint, der den Nutzer
+    # ausliefert (500, Benutzerliste unbenutzbar). Gleiches Muster wie beim
+    # eff_fixed-Block oben.
+    _eff = lambda name: update_data.get(name, getattr(user, name, None))  # noqa: E731
+    _eff_first, _eff_last = _eff('first_work_day'), _eff('last_work_day')
+    if _eff_first and _eff_last and _eff_first > _eff_last:
+        raise HTTPException(
+            status_code=400,
+            detail="Erster Arbeitstag darf nicht nach dem letzten Arbeitstag liegen.",
+        )
+    for _wd, _label in (
+        ('monday', 'Montag'), ('tuesday', 'Dienstag'), ('wednesday', 'Mittwoch'),
+        ('thursday', 'Donnerstag'), ('friday', 'Freitag'),
+    ):
+        _s, _e = _eff(f'scheduled_start_{_wd}'), _eff(f'scheduled_end_{_wd}')
+        if _s and _e and _s >= _e:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{_label}: Soll-Beginn muss vor dem Soll-Ende liegen.",
+            )
+
     # VULN-010: invalidate existing JWTs when role is changed
     role_changed = 'role' in update_data and update_data['role'] != user.role
     # #290: did this update turn closure participation ON? Then enrol below.
@@ -831,6 +859,44 @@ def create_working_hours_change(
             status_code=400,
             detail=f"Eine Stundenänderung für den {change_data.effective_from.strftime('%d.%m.%Y')} existiert bereits"
         )
+
+    # Release-Review 1.16.0 (#415-Folgefund): Bevor die ERSTE Änderung eines
+    # Mitarbeiters gespeichert wird, den bisherigen Vertragswert als Basis-Zeile
+    # festhalten.
+    #
+    # Hintergrund: `get_weekly_hours_for_date` fällt für jeden Tag VOR der ersten
+    # erfassten Änderung auf `user.weekly_hours` zurück. Genau dieses Feld wird
+    # weiter unten überschrieben, sobald das Wirkungsdatum <= heute liegt — und
+    # das ist der Default des Stundenverlauf-Dialogs. Ohne Basis-Zeile galt der
+    # NEUE Wert damit rückwirkend für die gesamte Vergangenheit: das Per-Tag-Soll
+    # bereits abgeschlossener Monate verschob sich still, und #415 konnte die
+    # Änderung nicht ausweisen (beide Segmente trugen denselben Wert und wurden
+    # verschmolzen). Die Basis-Zeile friert die Vergangenheit auf dem alten Wert
+    # ein und macht die Änderung im Bericht sichtbar.
+    #
+    # Datum: `first_work_day`, sonst ein Tag vor der ersten Änderung — Hauptsache
+    # vor jeder erfassbaren Buchung. Nur wenn sich der Wert tatsächlich ändert
+    # (sonst entstünde eine Pseudo-Änderung, die weekly_hours_segments ohnehin
+    # wieder verschmelzen würde).
+    _has_history = db.query(WorkingHoursChange).filter(
+        WorkingHoursChange.user_id == user_id,
+        WorkingHoursChange.tenant_id == current_user.tenant_id,  # F-026
+    ).first() is not None
+    if (
+        not _has_history
+        and user.weekly_hours is not None
+        and Decimal(str(user.weekly_hours)) != Decimal(str(change_data.weekly_hours))
+    ):
+        _baseline_date = user.first_work_day or (change_data.effective_from - timedelta(days=1))
+        if _baseline_date >= change_data.effective_from:
+            _baseline_date = change_data.effective_from - timedelta(days=1)
+        db.add(WorkingHoursChange(
+            user_id=user_id,
+            tenant_id=current_user.tenant_id,
+            effective_from=_baseline_date,
+            weekly_hours=user.weekly_hours,
+            note="Automatisch erfasster Ausgangswert vor der ersten Stundenänderung",
+        ))
 
     change = WorkingHoursChange(
         user_id=user_id,

--- a/backend/app/routers/company_closures.py
+++ b/backend/app/routers/company_closures.py
@@ -9,13 +9,44 @@ from pydantic import BaseModel, ConfigDict
 
 from app.database import get_db
 from app.middleware.auth import get_current_user, require_admin
-from app.models import User, Absence, AbsenceType, PublicHoliday, CompanyClosure, TimeEntry, WorkingHoursChange
+from app.models import User, Absence, AbsenceType, PublicHoliday, CompanyClosure, TimeEntry, WorkingHoursChange, TimeEntryAuditLog
 from app.services import calculation_service, settings_service, special_days_service
 # Fix #3: the year re-split lives in a service module so the private-vacation
 # write paths can call it without importing this router (circular-import safe).
 # Re-exported as _resplit_year_closures to keep the existing call sites intact.
 from app.services.closure_split_service import resplit_year_closures as _resplit_year_closures
 from app.routers.admin_helpers import _create_audit_log
+
+
+# Release-Review 1.16.0: Betriebsferien löschen Abwesenheiten (beim Umspeichern und
+# beim Entfernen der Schließung) — bisher spurlos, während `absences.delete_absence`
+# vor jeder Löschung einen Audit-Eintrag schreibt. Für DSGVO Art. 5 Abs. 2 und §16
+# ArbZG muss nachvollziehbar bleiben, wer wann wie viele generierte Abwesenheiten
+# entfernt hat. Eine Summenzeile pro Vorgang statt einer pro Abwesenheit: die
+# Zuordnung steckt in `closure_id`/Note, und ein Voll-Jahr-Umspeichern würde die
+# Audit-Tabelle sonst mit hunderten Zeilen fluten.
+# Marker < 40 Zeichen (time_entry_audit_logs.source ist varchar(40)).
+CLOSURE_AUDIT_SOURCE = "company_closure"  # 15 Zeichen
+
+
+def _audit_closure_absence_deletion(db, current_user, closure, count: int, reason: str) -> None:
+    """Summen-Audit für gelöschte Betriebsferien-Abwesenheiten (No-op bei 0)."""
+    if not count:
+        return
+    db.add(TimeEntryAuditLog(
+        time_entry_id=None,
+        user_id=current_user.id,
+        changed_by=current_user.id,
+        action="delete",
+        source=CLOSURE_AUDIT_SOURCE,
+        old_note=(
+            f"Betriebsferien '{closure.name}' "
+            f"({closure.start_date.isoformat()}–{closure.end_date.isoformat()}): "
+            f"{count} generierte Abwesenheit(en) gelöscht — {reason}"
+        ),
+        tenant_id=current_user.tenant_id,
+    ))
+
 
 router = APIRouter(prefix="/api/company-closures", tags=["company-closures"])
 
@@ -518,12 +549,32 @@ def update_closure(
     # most one closure-absence (the create helper skips days with an existing
     # absence), so flipping its type can never collide with the
     # (tenant_id, user_id, date, type) unique constraint.
+    # Release-Review 1.16.0: Wen der Create-Helper unten überhaupt wieder bucht,
+    # muss VOR dem Löschen feststehen. Er bucht nur für aktive Teilnehmer — eine
+    # ausgeschiedene (`is_active=False`) oder abgewählte
+    # (`receives_company_closures=False`) Person bekam ihre Closure-Absencen also
+    # gelöscht und nie zurück. Das traf ausgerechnet den in CLAUDE.md
+    # dokumentierten Migrationsweg „Toggle nachträglich aktivieren → Schließung neu
+    # speichern": ein reines Umbenennen genügte, um bei aktivem #314-Split den
+    # genommenen Urlaub eines Ausgeschiedenen rückwirkend verschwinden zu lassen
+    # (Urlaubskonto, Abgeltungsbasis, §16-Beleg — ohne jede Spur).
+    employees = db.query(User).filter(
+        User.is_active == True,
+        User.receives_company_closures == True,
+        User.tenant_id == current_user.tenant_id,
+    ).all()
+    _rebookable_user_ids = {e.id for e in employees}
+
+    _deleted_out_of_range = 0
+    _deleted_for_resplit = 0
     for absence in linked:
         if absence.date not in workday_set:
             db.delete(absence)
-        elif split_active:
+            _deleted_out_of_range += 1
+        elif split_active and absence.user_id in _rebookable_user_ids:
             # delete → re-created + re-split by the create helper below
             db.delete(absence)
+            _deleted_for_resplit += 1
         else:
             if name_changed:
                 absence.note = f"Betriebsferien: {data.name}"
@@ -532,6 +583,15 @@ def update_closure(
             absence.end_date = None
             if type_changed:
                 absence.type = new_absence_type
+
+    _audit_closure_absence_deletion(
+        db, current_user, closure, _deleted_out_of_range,
+        "Tag nicht mehr vom Zeitraum abgedeckt",
+    )
+    _audit_closure_absence_deletion(
+        db, current_user, closure, _deleted_for_resplit,
+        "Neuaufteilung Urlaub/Überstundenausgleich (#314), werden neu gebucht",
+    )
 
     # L-3: die obigen Deletes/Updates in die DB schreiben, BEVOR der Create-Helper
     # seine existing_keys-Vorabfrage stellt — sonst sähe er die behaltenen Tage
@@ -542,11 +602,7 @@ def update_closure(
     # Add absences for newly covered workdays. Reuse the create-time helper,
     # which already skips days where the employee has ANY existing absence
     # (foreign absences stay untouched, and days we kept above are skipped).
-    employees = db.query(User).filter(
-        User.is_active == True,
-        User.receives_company_closures == True,
-        User.tenant_id == current_user.tenant_id,
-    ).all()
+    # (employees wurde oben geladen — der Löschzweig braucht die Menge bereits.)
     # #290: re-save must NOT delete logged work. delete_time_entries=False →
     # days where a participant already logged real time are left intact (no
     # closure-absence booked over them). New participants still get absences on
@@ -614,6 +670,13 @@ def delete_closure(
 
     # Delete the generated absences via FK (robust against renames / manual
     # note edits) — tenant_id filter kept as belt-and-suspenders (F-026).
+    _to_delete = db.query(Absence).filter(
+        Absence.closure_id == closure.id,
+        Absence.tenant_id == current_user.tenant_id,
+    ).count()
+    _audit_closure_absence_deletion(
+        db, current_user, closure, _to_delete, "Betriebsferien gelöscht",
+    )
     db.query(Absence).filter(
         Absence.closure_id == closure.id,
         Absence.tenant_id == current_user.tenant_id,

--- a/backend/app/routers/time_entries.py
+++ b/backend/app/routers/time_entries.py
@@ -631,22 +631,6 @@ def create_time_entry(
     if current_user.last_work_day and entry_data.date > current_user.last_work_day:
         raise HTTPException(status_code=400, detail="Datum liegt nach dem letzten Arbeitstag")
 
-    # Check for overlapping entries on the same date
-    existing = db.query(TimeEntry).filter(
-        TimeEntry.user_id == current_user.id,
-        TimeEntry.tenant_id == current_user.tenant_id,  # F-026
-        TimeEntry.date == entry_data.date,
-        TimeEntry.start_time == entry_data.start_time
-    ).first()
-
-    if existing:
-        # B-L4: duplicate entry is a conflict, not a bad request — align with
-        # the 409 used by the CR-approval and absence duplicate paths.
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Es existiert bereits ein Eintrag mit dieser Startzeit an diesem Datum"
-        )
-
     exempt = current_user.exempt_from_arbzg
 
     # #201: clamp start/end to [soll − grace, soll + grace] BEFORE all §4/§3
@@ -657,6 +641,27 @@ def create_time_entry(
     eff_start, eff_end, raw_start, raw_end = work_window_service.clamp(
         current_user, entry_data.date, entry_data.start_time, entry_data.end_time, _grace,
     )
+
+    # Duplikatsprüfung NACH dem Kappen (Release-Review 1.16.0). Gespeichert wird
+    # `eff_start`, geprüft wurde vorher die ROHE `entry_data.start_time` — zwei
+    # verschiedene Rohzeiten innerhalb des Puffers werden aber auf dieselbe
+    # Startzeit gekappt. Die Sonde lief dann ins Leere und erst der UNIQUE-Index
+    # `uq_tenant_user_date_start` schlug zu: HTTP 500 statt des gemeinten 409.
+    # `admin_time_entries` prüft bereits gegen die gekappte Zeit.
+    existing = db.query(TimeEntry).filter(
+        TimeEntry.user_id == current_user.id,
+        TimeEntry.tenant_id == current_user.tenant_id,  # F-026
+        TimeEntry.date == entry_data.date,
+        TimeEntry.start_time == eff_start,
+    ).first()
+
+    if existing:
+        # B-L4: duplicate entry is a conflict, not a bad request — align with
+        # the 409 used by the CR-approval and absence duplicate paths.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Es existiert bereits ein Eintrag mit dieser Startzeit an diesem Datum"
+        )
 
     # §3 ArbZG: daily hours hard cap – skipped for exempt users.
     # MUST run BEFORE the §4 break-waiver / approval branch below: a >10h day is
@@ -908,9 +913,23 @@ def update_time_entry(
     # #201: clamp start/end to [soll − grace, soll + grace] BEFORE all §4/§3
     # checks so compliance is assessed on credited time.
     from app.services import work_window_service
+    # Release-Review 1.16.0: gegen den EIGENTÜMER des Eintrags kappen und prüfen,
+    # nicht gegen den Aufrufer. Diese Route lässt Admins fremde Einträge bearbeiten
+    # (Ownership-Check weiter oben) — mit `current_user` las der Code dann das
+    # Arbeitszeitfenster, `exempt_from_arbzg` und `is_night_worker` des ADMINS.
+    # Ein §18-befreiter Praxisinhaber konnte so für eine nicht befreite MFA einen
+    # 12-Stunden-Tag ohne Pause speichern, weil die §3-Hartgrenze übersprungen
+    # wurde. `admin_time_entries.admin_update_time_entry` macht es bereits richtig.
+    _entry_owner = (
+        current_user if entry.user_id == current_user.id
+        else db.query(User).filter(
+            User.id == entry.user_id,
+            User.tenant_id == current_user.tenant_id,  # F-026
+        ).first() or current_user
+    )
     _grace = work_window_service.get_grace_minutes(db, current_user.tenant_id)
     _eff_start, _eff_end, _raw_start, _raw_end = work_window_service.clamp(
-        current_user, entry.date, entry.start_time, entry.end_time, _grace,
+        _entry_owner, entry.date, entry.start_time, entry.end_time, _grace,
     )
     # Fix #2: only overwrite start/end + raw_* when the respective time was
     # actually part of this partial update — mirrors the admin path
@@ -925,7 +944,7 @@ def update_time_entry(
         entry.end_time = _eff_end
         entry.raw_end_time = _raw_end
 
-    exempt = current_user.exempt_from_arbzg
+    exempt = _entry_owner.exempt_from_arbzg
 
     # §3 ArbZG: daily hours hard cap – skipped for exempt users.
     # MUST run BEFORE the §4 break-waiver / approval branch below: a >10h day is
@@ -1083,7 +1102,7 @@ def update_time_entry(
             update_warnings.append("HOLIDAY_WORK")
         if (
             entry.end_time is not None
-            and current_user.is_night_worker
+            and _entry_owner.is_night_worker
             and is_night_work(entry.start_time, entry.end_time)
             and saved_hours > MAX_NIGHT_WORKER_DAILY_WARN
         ):

--- a/backend/app/schemas/vacation_request.py
+++ b/backend/app/schemas/vacation_request.py
@@ -13,7 +13,11 @@ from app.schemas.validators import (
 class VacationRequestCreate(BaseModel):
     date: date
     end_date: Optional[date] = None
-    hours: float
+    # Release-Review 1.16.0: Grenzen wie in VacationRequestUpdate und AbsenceBase.
+    # Ohne sie ergab `hours: 1000` beim COMMIT einen numeric-Overflow der
+    # numeric(5,2)-Spalte → HTTP 500 statt 422, und `hours: -8` legte einen Antrag
+    # an, den die Genehmigung unverändert als negative Absence-Stunden buchte.
+    hours: float = Field(..., ge=0, le=24)
     note: Optional[str] = None
     absence_type: Optional[str] = "vacation"
     half_day: bool = False  # #167: halber Urlaubstag

--- a/backend/app/services/calculation_service.py
+++ b/backend/app/services/calculation_service.py
@@ -458,14 +458,23 @@ def future_freizeitausgleich_impact(
     """
     if not user.track_hours:
         return Decimal('0')
-    # #377 Baustein 2b: im festen Monats-Soll-Modus bewegt eine OVERTIME-Abwesenheit
-    # das Überstundenkonto NICHT — OVERTIME ist in keinem _FIXED_*_TYPES, hat also
-    # weder Soll- noch Ist-Effekt (get_overtime_account delegiert für diese MA an das
-    # Fix-Modell). Es gibt daher keinen künftigen Freizeitausgleich zu projizieren.
-    # (Fünfter Parallelpfad — Modus-Branch wie in get_range_target/get_overtime_account/
-    # get_ytd_summary/get_overtime_history_detailed, siehe CLAUDE.md #377.)
-    if getattr(user, "use_fixed_monthly_target", False) and getattr(user, "agreed_monthly_hours", None):
-        return Decimal('0')
+    # #377 Baustein 2b — Fix-Soll-Modus. Release-Review 1.16.0: die frühere
+    # Begründung („OVERTIME steht in keinem _FIXED_*_TYPES, bewegt das Konto also
+    # nicht") war genau verkehrt herum. Dass OVERTIME weder in
+    # _FIXED_PAID_CREDIT_TYPES noch in _FIXED_UNPAID_TYPES steht, heißt: es gibt
+    # (a) KEINE Ist-Gutschrift über fixed_month_credit und (b) KEINE Soll-Minderung
+    # über fixed_month_unpaid_reduction. Das Soll bleibt das volle flache
+    # agreed_monthly_hours, das Ist zählt für den Ausgleichstag 0 — der Saldo sinkt
+    # also um exakt die GEPLANTEN Stunden des Tages, genau wie im Tages-Modell.
+    # Die Projektion war damit ausgerechnet für die Gruppe dunkel, deren Konto nach
+    # § 2 Abs. 2 MiLoG binnen 12 Monaten ausgeglichen sein muss.
+    #
+    # Im Fix-Modus ist die maßgebliche Größe die geplante Tagesarbeitszeit
+    # (_fixed_planned_hours), nicht das aus den Wochenstunden abgeleitete Tages-Soll.
+    _fixed_mode = bool(
+        getattr(user, "use_fixed_monthly_target", False)
+        and getattr(user, "agreed_monthly_hours", None)
+    )
     if today is None:
         today = today_local()
     if cutoff_date is None:
@@ -503,6 +512,15 @@ def future_freizeitausgleich_impact(
         if d.weekday() >= 5:  # Wochenende → 0 Soll
             continue
         if not _within_employment_window(user, d):
+            continue
+        if _fixed_mode:
+            # Fix-Soll: das Monats-Soll ist flach und wird von einem OVERTIME-Tag
+            # nicht gemindert; das Ist bekommt für ihn nichts gutgeschrieben. Der
+            # Saldo sinkt also um die GEPLANTEN Stunden dieses Tages. An einem
+            # Feiertag ist die geplante Zeit ohnehin nicht zu leisten → 0.
+            if d in holiday_dates:
+                continue
+            total += _fixed_planned_hours(db, user, d, special_cfg)
             continue
         # OVERTIME ist NICHT soll-reduzierend → leere half_map → volles Tages-Soll
         # (× #146-Sondertag-Faktor). Exakt der Betrag, um den dieser Tag später

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timedelta
 from calendar import monthrange
 from decimal import Decimal
 from typing import List
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 from openpyxl import Workbook
 from openpyxl.styles import Font, PatternFill, Alignment, Border, Side
@@ -39,6 +40,88 @@ def neutralize_spreadsheet_formula(value):
     if isinstance(value, str) and value and value[0] in _FORMULA_PREFIXES:
         return "'" + value
     return value
+
+
+def export_users(db, tenant_id, period_start: date, period_end: date) -> List[User]:
+    """Mitarbeiter, die in einen §16-Beleg für ``[period_start, period_end]`` gehören.
+
+    Release-Review 1.16.0: die Exporte filterten hart auf ``is_active == True``.
+    Das Handbuch weist Admins aber ausdrücklich an, ausgeschiedene Mitarbeiter auf
+    „Inaktiv" zu setzen statt zu löschen (§16 ArbZG: 2 Jahre Aufbewahrung) — genau
+    diese Personen fielen danach ersatzlos aus jedem Monats- und Jahresbericht,
+    auch für Zeiträume, in denen sie noch gearbeitet hatten. Bei einer Prüfung
+    fehlten damit die Nachweise, ohne dass irgendwo ein Hinweis erschien.
+
+    Deshalb: aktive Mitarbeiter wie bisher, PLUS inaktive, die im Zeitraum
+    tatsächlich Daten haben (Zeiteintrag oder Abwesenheit). Ausgeblendete
+    (``is_hidden``) bleiben ausgeblendet — das ist eine bewusste Sichtbarkeits-
+    entscheidung des Admins, keine Ausscheidens-Markierung. Ein Zeitraum ohne
+    Daten des Ausgeschiedenen erzeugt weiterhin kein leeres Blatt.
+    """
+    base = db.query(User).filter(User.is_hidden == False)  # noqa: E712
+    if tenant_id is not None:
+        base = base.filter(User.tenant_id == tenant_id)
+
+    te = db.query(TimeEntry.user_id).filter(
+        TimeEntry.date >= period_start, TimeEntry.date <= period_end
+    )
+    ab = db.query(Absence.user_id).filter(
+        Absence.date >= period_start, Absence.date <= period_end
+    )
+    if tenant_id is not None:
+        te = te.filter(TimeEntry.tenant_id == tenant_id)
+        ab = ab.filter(Absence.tenant_id == tenant_id)
+
+    users = base.filter(User.is_active == True).all()  # noqa: E712
+    users += base.filter(
+        User.is_active == False,  # noqa: E712
+        or_(User.id.in_(te.scalar_subquery()), User.id.in_(ab.scalar_subquery())),
+    ).all()
+    return sorted(users, key=lambda u: ((u.last_name or "").lower(), (u.first_name or "").lower()))
+
+
+def absence_day_target(db, user, d, day_absences, holiday_dates, special_cfg, wh_changes=None):
+    """Release-Review 1.16.0: Tages-Soll an einem Tag MIT Abwesenheit.
+
+    Alle Datei-Exporte setzten hier pauschal ``Decimal('0.00')`` — „irgendeine
+    Abwesenheit ⇒ kein Soll". Das ist an drei Stellen falsch und ließ die
+    Summenzeilen desselben §16-Belegs seinem eigenen „Überstunden kumuliert"
+    widersprechen:
+
+    * **Halbtag** (``half_day=True``): nur 0,5 × Tagessoll fällt weg. Ein halber
+      Urlaubstag plus vier gestempelte Stunden ergab im Export Soll 0 / Ist 4 →
+      +4 h Überstunden statt 0.
+    * **SICK/TRAINING**: nicht soll-reduzierend — das Soll bleibt stehen (die
+      Gutschrift läuft über ``credited_absences``).
+    * **OVERTIME**: Soll bleibt, Ist = 0 (docs/BERECHNUNGEN.md §6). Der Export
+      zeigte 0/0 und verschluckte damit den Konto-Abbau.
+
+    Delegiert an ``calculation_service._day_soll_contribution`` — dieselbe Quelle,
+    die ``get_monthly_target`` und ``get_overtime_account`` nutzen. Damit können
+    Bildschirm und Datei nicht mehr auseinanderlaufen. Wochenende, Beschäftigungs-
+    fenster und Stichtag bleiben Sache des Aufrufers (wie beim Helper selbst);
+    Feiertage behandeln die Exporte in einem eigenen Zweig davor.
+    """
+    # ``_soll_reducing_absence_half_map`` filtert NICHT selbst nach Typ — im
+    # calculation_service übernimmt das die Query (``type.notin_([TRAINING, SICK,
+    # OVERTIME])``). Hier kommen die Absencen aus dem Export-Grouping, also muss der
+    # Filter an dieser Stelle stehen: TRAINING/SICK/OVERTIME lassen das Soll stehen.
+    soll_reducing = [
+        a for a in day_absences
+        if a.type not in (
+            calculation_service.AbsenceType.TRAINING,
+            calculation_service.AbsenceType.SICK,
+            calculation_service.AbsenceType.OVERTIME,
+        )
+    ]
+    half_map = calculation_service._soll_reducing_absence_half_map(soll_reducing)
+    return calculation_service._day_soll_contribution(
+        db, user, d,
+        holiday_dates=holiday_dates,
+        absence_half_map=half_map,
+        wh_changes=wh_changes,
+        special_cfg=special_cfg,
+    )
 
 
 def _de_hours(value) -> str:
@@ -106,10 +189,8 @@ def generate_monthly_report(db: Session, year: int, month: int, include_health_d
     wb.remove(wb.active)
 
     # Get all active, non-hidden employees (F-026: explicit tenant filter on top of RLS)
-    q = db.query(User).filter(User.is_active == True, User.is_hidden == False)
-    if tenant_id is not None:
-        q = q.filter(User.tenant_id == tenant_id)
-    users = q.order_by(User.last_name, User.first_name).all()
+    users = export_users(db, tenant_id, date(year, month, 1),
+                         date(year, month, monthrange(year, month)[1]))
 
     for user in users:
         _create_employee_sheet(wb, db, user, year, month, include_health_data)
@@ -345,7 +426,8 @@ def _create_employee_sheet(wb: Workbook, db: Session, user: User, year: int, mon
             for col in range(1, 11):
                 sheet.cell(row=row, column=col).fill = PatternFill(start_color="FFFFCC", end_color="FFFFCC", fill_type="solid")
         elif day_absences:
-            target = Decimal('0.00')
+            # Release-Review 1.16.0: zentrale Soll-Quelle statt pauschal 0.
+            target = absence_day_target(db, user, current_date, day_absences, set(holidays_by_date), special_day_config)
             absence_type_map = {
                 "vacation": "Urlaub",
                 "sick": "Krank",
@@ -494,10 +576,7 @@ def generate_yearly_report(db: Session, year: int, include_health_data: bool = F
     wb.remove(wb.active)
 
     # Get all active, non-hidden employees (F-026: explicit tenant filter on top of RLS)
-    q = db.query(User).filter(User.is_active == True, User.is_hidden == False)
-    if tenant_id is not None:
-        q = q.filter(User.tenant_id == tenant_id)
-    users = q.order_by(User.last_name, User.first_name).all()
+    users = export_users(db, tenant_id, date(year, 1, 1), date(year, 12, 31))
 
     # Create overview sheet
     _create_yearly_overview_sheet(wb, db, users, year, include_health_data)
@@ -892,7 +971,8 @@ def _create_employee_yearly_sheet(wb: Workbook, db: Session, user: User, year: i
             for col in range(1, 11):
                 sheet.cell(row=row, column=col).fill = PatternFill(start_color="FFFFCC", end_color="FFFFCC", fill_type="solid")
         elif day_absences:
-            target = Decimal('0.00')
+            # Release-Review 1.16.0: zentrale Soll-Quelle statt pauschal 0.
+            target = absence_day_target(db, user, current_date, day_absences, set(holidays_by_date), special_day_config)
             absence_type_map = {
                 "vacation": "Urlaub",
                 "sick": "Krank",
@@ -1043,10 +1123,7 @@ def generate_yearly_report_classic(db: Session, year: int, include_health_data: 
     wb.remove(wb.active)
 
     # Get all active, non-hidden employees (F-026: explicit tenant filter on top of RLS)
-    q = db.query(User).filter(User.is_active == True, User.is_hidden == False)
-    if tenant_id is not None:
-        q = q.filter(User.tenant_id == tenant_id)
-    users = q.order_by(User.last_name, User.first_name).all()
+    users = export_users(db, tenant_id, date(year, 1, 1), date(year, 12, 31))
 
     for user in users:
         _create_employee_classic_sheet(wb, db, user, year, include_health_data)
@@ -1363,10 +1440,8 @@ def generate_monthly_report_pdf(db: Session, year: int, month: int, include_heal
                    'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember']
 
     # F-026: explicit tenant filter (belt-and-suspenders on top of RLS)
-    _q = db.query(User).filter(User.is_active == True, User.is_hidden == False)
-    if tenant_id is not None:
-        _q = _q.filter(User.tenant_id == tenant_id)
-    users = _q.order_by(User.last_name, User.first_name).all()
+    users = export_users(db, tenant_id, date(year, month, 1),
+                         date(year, month, monthrange(year, month)[1]))
 
     # Landscape A4: 297mm − 30mm margins = 267mm usable
     col_widths = [22*mm, 10*mm, 13*mm, 13*mm, 15*mm, 16*mm, 14*mm, 16*mm, 74*mm, 74*mm]
@@ -1511,7 +1586,8 @@ def generate_monthly_report_pdf(db: Session, year: int, month: int, include_heal
                     abw += ' | Nachtarbeit'
                 bg = colors.HexColor('#FFFFCC')
             elif day_absences:
-                target = Decimal('0.00')
+                # Release-Review 1.16.0: zentrale Soll-Quelle statt pauschal 0.
+                target = absence_day_target(db, user, cur, day_absences, set(holidays_by_date), special_day_config)
                 # I-1: ALLE Absences des Tages zeigen; DSGVO F-003: Krank ohne
                 # Health-Flag maskieren (Label 'Abwesenheit', Notiz unterdrückt).
                 abw_parts = []
@@ -1577,7 +1653,18 @@ def generate_monthly_report_pdf(db: Session, year: int, month: int, include_heal
 
         # ── Summary ──
         story.append(Spacer(1, 4 * mm))
-        monthly_balance = total_net - total_target
+        # Release-Review 1.16.0: #377 Baustein 2b — der Fixmodus-Branch fehlte hier
+        # als einziger der drei Monats-Exportflächen (XLSX Z.439, ODS-Monat), sodass
+        # dieselbe §16-Auskunft je Dateiformat unterschiedliche Soll-Zahlen trug und
+        # das PDF sich gegen sein eigenes „Überstunden kumuliert" (bereits
+        # modus-bewusst) stellte. Nicht-Modus-MA bleiben auf der Per-Tag-Summe.
+        if getattr(user, "use_fixed_monthly_target", False) and getattr(user, "agreed_monthly_hours", None):
+            summary_target = calculation_service.get_monthly_target(db, user, year, month)
+            summary_actual = calculation_service.get_monthly_actual(db, user, year, month)
+        else:
+            summary_target = total_target
+            summary_actual = total_net
+        monthly_balance = summary_actual - summary_target
         overtime_account = calculation_service.get_overtime_account(db, user, year, month)
         vacation_account = calculation_service.get_vacation_account(db, user, year)
 
@@ -1586,8 +1673,8 @@ def generate_monthly_report_pdf(db: Session, year: int, month: int, include_heal
 
         summary_rows = [
             [Paragraph('Zusammenfassung', ParagraphStyle('st', fontName='Helvetica-Bold', fontSize=8, leading=10)), ''],
-            [Paragraph('Soll-Stunden:', s_sum_lbl), Paragraph(f"{float(total_target):.2f} h", s_sum_val)],
-            [Paragraph('Ist-Stunden:', s_sum_lbl), Paragraph(f"{float(total_net):.2f} h", s_sum_val)],
+            [Paragraph('Soll-Stunden:', s_sum_lbl), Paragraph(f"{float(summary_target):.2f} h", s_sum_val)],
+            [Paragraph('Ist-Stunden:', s_sum_lbl), Paragraph(f"{float(summary_actual):.2f} h", s_sum_val)],
             [Paragraph('Saldo Monat:', s_sum_lbl),
              Paragraph(f"{float(monthly_balance):+.2f} h",
                        ParagraphStyle('sb', fontName='Helvetica-Bold', fontSize=7.5,

--- a/backend/app/services/ods_export_service.py
+++ b/backend/app/services/ods_export_service.py
@@ -20,6 +20,8 @@ from app.services import calculation_service, special_days_service
 from app.services.arbzg_utils import is_night_work
 from app.services.date_filters import date_in_month, date_in_year
 from app.services.export_service import (
+    absence_day_target,  # Release-Review 1.16.0
+    export_users,  # Release-Review 1.16.0
     neutralize_spreadsheet_formula, _load_reason_names, _absence_export_label, _group_by_date,
     format_weekly_hours_history,  # #415
 )
@@ -110,9 +112,16 @@ def _save(doc: OpenDocumentSpreadsheet) -> BytesIO:
     return buf
 
 
-def _get_active_users(db: Session, tenant_id=None) -> List[User]:
-    """Return active, non-hidden users. F-026: apply explicit tenant filter
-    (belt-and-suspenders on top of RLS) when tenant_id is provided."""
+def _get_active_users(db: Session, tenant_id=None, period=None) -> List[User]:
+    """Mitarbeiter für den Export. F-026: expliziter Tenant-Filter zusätzlich zu RLS.
+
+    Release-Review 1.16.0: mit ``period`` (start, end) delegiert die Auswahl an
+    ``export_service.export_users`` — aktive plus ausgeschiedene MA, die im Zeitraum
+    Daten haben. Ohne ``period`` bleibt das alte Verhalten (nur aktive), damit
+    Aufrufer ohne Zeitraumbezug unverändert funktionieren.
+    """
+    if period is not None:
+        return export_users(db, tenant_id, period[0], period[1])
     q = db.query(User).filter(User.is_active == True, User.is_hidden == False)
     if tenant_id is not None:
         q = q.filter(User.tenant_id == tenant_id)
@@ -129,7 +138,8 @@ def generate_monthly_report(db: Session, year: int, month: int, include_health_d
     F-026: pass tenant_id for belt-and-suspenders explicit filter."""
     doc, bold, normal = _doc_with_styles()
 
-    users = _get_active_users(db, tenant_id)
+    users = _get_active_users(db, tenant_id, period=(
+        date(year, month, 1), date(year, month, monthrange(year, month)[1])))
     for user in users:
         _monthly_sheet(doc, db, user, year, month, bold, normal, include_health_data)
 
@@ -299,13 +309,16 @@ def _monthly_sheet(doc, db, user, year, month, bold, normal, include_health_data
                     bem_parts.append(e.note)
             tr.addElement(_str_cell(" | ".join(bem_parts) if bem_parts else ""))
         elif day_absences:
-            target = Decimal("0.00")
+            # Release-Review 1.16.0: zentrale Soll-Quelle statt pauschal 0
+            # (Halbtag/SICK/TRAINING/OVERTIME behalten Soll) — Parität zu XLSX.
+            target = absence_day_target(db, user, current_date, day_absences, set(holidays_by_date), special_day_config)
             # DSGVO F-003 / #312: sick + custom-reason absences maskiert (Label +
             # Note) außer bei explizit angeforderten Gesundheitsdaten. ALLE
             # Abwesenheiten des Tages (Misch-Tag) werden gerendert.
             label, note_str = _absence_cell_parts(day_absences, reason_names, include_health_data)
-            tr.addElement(_float_cell(0.0))
-            tr.addElement(_float_cell(0.0))
+            tr.addElement(_float_cell(float(target)))
+            # net ist hier Decimal (vgl. else-Zweig) — beide Seiten Decimal halten.
+            tr.addElement(_float_cell(float(net - target)))
             tr.addElement(_str_cell(label))
             tr.addElement(_str_cell(note_str))
         else:
@@ -373,7 +386,7 @@ def generate_yearly_report(db: Session, year: int, include_health_data: bool = F
     F-026: pass tenant_id for belt-and-suspenders explicit filter."""
     doc, bold, normal = _doc_with_styles()
 
-    users = _get_active_users(db, tenant_id)
+    users = _get_active_users(db, tenant_id, period=(date(year, 1, 1), date(year, 12, 31)))
     _yearly_overview_sheet(doc, db, users, year, bold, include_health_data)
     _absences_overview_sheet(doc, db, users, year, bold, include_health_data)
     for user in users:
@@ -638,8 +651,10 @@ def _yearly_employee_sheet(doc, db, user, year, bold, include_health_data: bool 
             # DSGVO F-003/Art. 9 / #312: sick + custom-reason maskiert außer bei
             # angeforderten Gesundheitsdaten; ALLE Abwesenheiten des Tages (Misch-Tag).
             label, note_str = _absence_cell_parts(day_absences, reason_names, include_health_data)
-            tr.addElement(_float_cell(0.0))
-            tr.addElement(_float_cell(0.0))
+            # Release-Review 1.16.0: zentrale Soll-Quelle statt pauschal 0.
+            target = float(absence_day_target(db, user, current_date, day_absences, set(holidays_by_date), special_day_config))
+            tr.addElement(_float_cell(target))
+            tr.addElement(_float_cell(net - target))
             tr.addElement(_str_cell(label))
             tr.addElement(_str_cell(note_str))
         else:
@@ -665,7 +680,7 @@ def generate_yearly_report_classic(db: Session, year: int, include_health_data: 
     F-026: pass tenant_id for belt-and-suspenders explicit filter."""
     doc, bold, normal = _doc_with_styles()
 
-    users = _get_active_users(db, tenant_id)
+    users = _get_active_users(db, tenant_id, period=(date(year, 1, 1), date(year, 12, 31)))
     for user in users:
         _classic_sheet(doc, db, user, year, bold, include_health_data)
 

--- a/backend/tests/test_fix2_whchange_daily_schedule.py
+++ b/backend/tests/test_fix2_whchange_daily_schedule.py
@@ -68,8 +68,21 @@ def test_whchange_ok_for_normal_user(db, default_tenant):
         db=db, current_user=admin,
     )
     assert float(result.weekly_hours) == 20.0
-    n = db.query(WorkingHoursChange).filter(WorkingHoursChange.user_id == emp.id).count()
-    assert n == 1
+    # Release-Review 1.16.0: die ERSTE Änderung legt zusätzlich eine Basis-Zeile mit
+    # dem bisherigen Vertragswert an. Ohne sie fiele `get_weekly_hours_for_date` für
+    # die gesamte Vergangenheit auf `user.weekly_hours` zurück — das gerade auf den
+    # NEUEN Wert gesetzt wird —, wodurch sich das Soll bereits abgeschlossener
+    # Monate rückwirkend verschoben hätte.
+    rows = (
+        db.query(WorkingHoursChange)
+        .filter(WorkingHoursChange.user_id == emp.id)
+        .order_by(WorkingHoursChange.effective_from)
+        .all()
+    )
+    assert len(rows) == 2
+    assert float(rows[0].weekly_hours) == 40.0, "Ausgangswert eingefroren"
+    assert rows[0].effective_from < date(2026, 1, 1)
+    assert float(rows[1].weekly_hours) == 20.0
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_projected_year_end_overtime.py
+++ b/backend/tests/test_projected_year_end_overtime.py
@@ -87,15 +87,47 @@ def test_weekend_overtime_skipped(db):
     assert float(impact) == 0.0
 
 
-def test_fixed_monthly_target_user_zero(db):
-    """#377 Baustein 2b: im Fix-Soll-Modus bewegt OVERTIME das Konto NICHT
-    (OVERTIME ∉ _FIXED_*_TYPES) → kein künftiger Freizeitausgleich-Impact, sonst
-    wäre die Projektion im Dezember nicht bitgleich zum dann tatsächlichen Saldo."""
+def test_fixed_monthly_target_user_counts_planned_hours(db):
+    """#377 Baustein 2b — Release-Review 1.16.0: korrigiert die frühere Annahme.
+
+    Dass OVERTIME in KEINEM der _FIXED_*_TYPES steht, bedeutet gerade nicht, dass
+    das Konto unbewegt bliebe: es gibt weder eine Ist-Gutschrift (fixed_month_credit)
+    noch eine Soll-Minderung (fixed_month_unpaid_reduction). Das Soll bleibt also das
+    volle flache agreed_monthly_hours, das Ist zählt für den Ausgleichstag 0 — der
+    Saldo sinkt um die GEPLANTEN Stunden des Tages. Die Projektion muss das zeigen,
+    sonst ist sie ausgerechnet für die MiLoG-Konto-Gruppe dunkel (§ 2 Abs. 2 MiLoG:
+    Ausgleich binnen 12 Monaten).
+    """
     u = _user(db)
     u.milog_working_time_account = True
     u.agreed_monthly_hours = 80
     u.use_fixed_monthly_target = True
+    u.use_daily_schedule = True
+    u.hours_monday = 4
+    u.hours_tuesday = 0
+    u.hours_wednesday = 0
+    u.hours_thursday = 0
+    u.hours_friday = 0
     db.commit()
-    _overtime(db, u, date(2026, 12, 1))  # würde ohne Modus-Branch 8h liefern
+    _overtime(db, u, date(2026, 12, 7))  # ein Montag → 4 geplante Stunden
+    impact = calculation_service.future_freizeitausgleich_impact(db, u, cutoff_date=CUTOFF, today=TODAY)
+    assert float(impact) == 4.0
+
+
+def test_fixed_monthly_target_unplanned_day_is_zero(db):
+    """Ein Ausgleichstag an einem ungeplanten Wochentag senkt im Fix-Modus nichts —
+    dort war ohnehin keine Arbeitszeit vorgesehen."""
+    u = _user(db)
+    u.milog_working_time_account = True
+    u.agreed_monthly_hours = 80
+    u.use_fixed_monthly_target = True
+    u.use_daily_schedule = True
+    u.hours_monday = 4
+    u.hours_tuesday = 0
+    u.hours_wednesday = 0
+    u.hours_thursday = 0
+    u.hours_friday = 0
+    db.commit()
+    _overtime(db, u, date(2026, 12, 8))  # Dienstag → nicht geplant
     impact = calculation_service.future_freizeitausgleich_impact(db, u, cutoff_date=CUTOFF, today=TODAY)
     assert float(impact) == 0.0

--- a/backend/tests/test_release_review_116_exports.py
+++ b/backend/tests/test_release_review_116_exports.py
@@ -1,0 +1,184 @@
+"""Release-Review 1.16.0 — die §16-Datei-Exporte dürfen sich nicht mehr selbst
+widersprechen.
+
+Alle Per-Tag-Schleifen der Exporte setzten das Tages-Soll auf 0, sobald der Tag
+IRGENDEINE Abwesenheit trug. Das ist an drei Stellen falsch:
+
+* **Halbtag**: nur 0,5 × Tagessoll fällt weg — ein halber Urlaubstag plus vier
+  gestempelte Stunden ergab Soll 0 / Ist 4 und damit +4 h Überstunden statt 0.
+* **SICK/TRAINING**: nicht soll-reduzierend, das Soll bleibt stehen.
+* **OVERTIME**: Soll bleibt, Ist = 0 (docs/BERECHNUNGEN.md §6) — der Export zeigte
+  0/0 und verschluckte den Konto-Abbau.
+
+Die Summenzeilen desselben Dokuments widersprachen damit ihrem eigenen
+„Überstunden kumuliert" (das aus dem modus-bewussten ``get_overtime_account``
+kommt). Diese Tests binden die Export-Summen an ``get_monthly_target`` /
+``get_monthly_actual`` — die Quelle, die Bildschirm und Berechnung nutzen.
+"""
+from datetime import date, time
+from decimal import Decimal
+from io import BytesIO
+
+import pytest
+from openpyxl import load_workbook
+
+from app.models import Absence, AbsenceType, TimeEntry
+from app.services import calculation_service
+from app.services.export_service import generate_monthly_report, generate_monthly_report_pdf
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+YEAR, MONTH = 2026, 3
+
+
+def _entry(db, user, d, start_h, end_h, break_min=0):
+    e = TimeEntry(
+        user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+        start_time=time(start_h, 0), end_time=time(end_h, 0), break_minutes=break_min,
+    )
+    db.add(e); db.commit()
+    return e
+
+
+def _absence(db, user, d, typ, hours, half_day=False):
+    a = Absence(
+        user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=d,
+        type=typ, hours=hours, half_day=half_day,
+    )
+    db.add(a); db.commit()
+    return a
+
+
+def _sheet(db, user):
+    bio = generate_monthly_report(db, YEAR, MONTH)
+    bio.seek(0)
+    wb = load_workbook(BytesIO(bio.read()))
+    return wb[f"{user.last_name} {user.first_name}"[:31]]
+
+
+def _summary(sheet):
+    """Summenblock: (Soll, Ist) aus den beschrifteten Zeilen lesen."""
+    out = {}
+    for row in range(1, sheet.max_row + 1):
+        label = sheet.cell(row=row, column=1).value
+        if isinstance(label, str) and label.startswith(("Soll-Stunden", "Ist-Stunden")):
+            out[label.split()[0]] = float(sheet.cell(row=row, column=2).value or 0)
+    return out
+
+
+def _day_row(sheet, d):
+    """Die Tageszeile zu einem Datum: (Netto, Soll, Differenz)."""
+    stamp = d.strftime("%d.%m.%Y")
+    for row in range(1, sheet.max_row + 1):
+        v = sheet.cell(row=row, column=1).value
+        if (v.strftime("%d.%m.%Y") if hasattr(v, "strftime") else str(v)) == stamp:
+            return (
+                sheet.cell(row=row, column=6).value,
+                sheet.cell(row=row, column=7).value,
+                sheet.cell(row=row, column=8).value,
+            )
+    raise AssertionError(f"keine Tageszeile für {stamp}")
+
+
+class TestHalfDayAbsence:
+    """Halber Urlaubstag + halber Arbeitstag = ausgeglichen, nicht +4 h."""
+
+    def test_day_row_keeps_half_the_target(self, db, test_user):
+        d = date(YEAR, MONTH, 9)  # Montag
+        _absence(db, test_user, d, AbsenceType.VACATION, 4, half_day=True)
+        _entry(db, test_user, d, 8, 12)
+
+        _net, target, diff = _day_row(_sheet(db, test_user), d)
+        assert float(target) == 4.0, "halber Urlaubstag darf nur das halbe Soll entfernen"
+        assert float(diff) == 0.0, "vier gearbeitete Stunden gegen vier Soll-Stunden = ausgeglichen"
+
+    def test_summary_matches_the_calculation(self, db, test_user):
+        d = date(YEAR, MONTH, 9)
+        _absence(db, test_user, d, AbsenceType.VACATION, 4, half_day=True)
+        _entry(db, test_user, d, 8, 12)
+
+        summary = _summary(_sheet(db, test_user))
+        expected = float(calculation_service.get_monthly_target(db, test_user, YEAR, MONTH))
+        assert summary["Soll-Stunden"] == pytest.approx(expected, abs=0.01)
+
+
+class TestOvertimeCompensationDay:
+    """Freizeitausgleich: Soll bleibt stehen, Ist ist 0 → der Tag zieht das Konto."""
+
+    def test_day_row_keeps_the_full_target(self, db, test_user):
+        d = date(YEAR, MONTH, 10)  # Dienstag
+        _absence(db, test_user, d, AbsenceType.OVERTIME, 8)
+
+        _net, target, _diff = _day_row(_sheet(db, test_user), d)
+        assert float(target) == 8.0, "OVERTIME ist nicht soll-reduzierend (BERECHNUNGEN.md §6)"
+
+    def test_summary_matches_the_calculation(self, db, test_user):
+        _absence(db, test_user, date(YEAR, MONTH, 10), AbsenceType.OVERTIME, 8)
+        summary = _summary(_sheet(db, test_user))
+        expected = float(calculation_service.get_monthly_target(db, test_user, YEAR, MONTH))
+        assert summary["Soll-Stunden"] == pytest.approx(expected, abs=0.01)
+
+
+class TestSickDayKeepsTarget:
+    """Krank ist nicht soll-reduzierend — die Gutschrift läuft über das Ist."""
+
+    def test_day_row_keeps_the_full_target(self, db, test_user):
+        d = date(YEAR, MONTH, 11)  # Mittwoch
+        _absence(db, test_user, d, AbsenceType.SICK, 8)
+
+        _net, target, _diff = _day_row(_sheet(db, test_user), d)
+        assert float(target) == 8.0
+
+
+class TestFullDayVacationStillRemovesTarget:
+    """Kontrollfall: der häufigste Fall bleibt unverändert bei 0."""
+
+    def test_day_row_target_is_zero(self, db, test_user):
+        d = date(YEAR, MONTH, 12)  # Donnerstag
+        _absence(db, test_user, d, AbsenceType.VACATION, 8, half_day=False)
+
+        _net, target, _diff = _day_row(_sheet(db, test_user), d)
+        assert float(target) == 0.0
+
+    def test_clean_month_summary_is_unchanged(self, db, test_user):
+        """Ein Monat ohne Abwesenheiten muss byte-identisch zur alten Ausgabe
+        bleiben — der Fix darf nur Abwesenheitstage betreffen."""
+        _entry(db, test_user, date(YEAR, MONTH, 2), 8, 16)
+        summary = _summary(_sheet(db, test_user))
+        expected = float(calculation_service.get_monthly_target(db, test_user, YEAR, MONTH))
+        assert summary["Soll-Stunden"] == pytest.approx(expected, abs=0.01)
+
+
+class TestPdfFixedModeSummary:
+    """#377 Baustein 2b: das PDF war die einzige Monats-Exportfläche ohne
+    Fixmodus-Branch — drei Dateiformate desselben Monats trugen verschiedene
+    Soll-Zahlen."""
+
+    def _minijob(self, db, user):
+        user.milog_working_time_account = True
+        user.use_fixed_monthly_target = True
+        user.agreed_monthly_hours = Decimal("40.0")
+        user.use_daily_schedule = True
+        user.hours_monday = 3
+        user.hours_tuesday = 0
+        user.hours_wednesday = 3
+        user.hours_thursday = 0
+        user.hours_friday = 0
+        db.commit()
+        return user
+
+    def test_pdf_builds_for_a_fixed_mode_user(self, db, test_user):
+        self._minijob(db, test_user)
+        out = generate_monthly_report_pdf(db, YEAR, MONTH)
+        out.seek(0)
+        assert out.read()[:5] == b"%PDF-"
+
+    def test_xlsx_summary_uses_the_flat_agreed_target(self, db, test_user):
+        """Der XLSX-Zweig war schon korrekt — er dient hier als Referenzwert,
+        an den das PDF gebunden ist."""
+        user = self._minijob(db, test_user)
+        summary = _summary(_sheet(db, user))
+        assert summary["Soll-Stunden"] == pytest.approx(40.0, abs=0.01)
+        assert summary["Soll-Stunden"] == pytest.approx(
+            float(calculation_service.get_monthly_target(db, user, YEAR, MONTH)), abs=0.01
+        )

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -94,7 +94,7 @@ docker compose exec -T db pg_dump -U praxiszeit --clean --if-exists praxiszeit \
 täglich 02:00 + 30-Tage-Rotation:
 
 ```cron
-0 2 * * * cd /pfad/zu/praxiszeit && docker compose exec -T db pg_dump -U praxiszeit praxiszeit | gzip > ~/praxiszeit-backups/pz_$(date +\%F).sql.gz && find ~/praxiszeit-backups -name 'pz_*.sql.gz' -mtime +30 -delete
+0 2 * * * cd /pfad/zu/praxiszeit && docker compose exec -T db pg_dump --clean --if-exists -U praxiszeit praxiszeit | gzip > ~/praxiszeit-backups/pz_$(date +\%F).sql.gz && find ~/praxiszeit-backups -name 'pz_*.sql.gz' -mtime +30 -delete
 ```
 
 (Backup-Verzeichnis vorher anlegen: `mkdir -p ~/praxiszeit-backups`.)
@@ -146,7 +146,7 @@ Restore idempotent (vorhandene Objekte werden gedroppt und neu angelegt) — ein
 manuelles Leeren der DB ist **nicht** nötig:
 
 ```bash
-gunzip -c backup.sql.gz | docker compose exec -T db psql -U "$POSTGRES_USER" "$POSTGRES_DB"
+gunzip -c backup.sql.gz | docker compose exec -T db psql -v ON_ERROR_STOP=1 -U praxiszeit -d praxiszeit
 ```
 
 ---

--- a/docs/INSTALL-NATIVE.md
+++ b/docs/INSTALL-NATIVE.md
@@ -204,6 +204,10 @@ check_enabled = true
 server_url = "https://updates.mr-development.de"
 
 [backup]
+# Hinweis: `enabled` und `schedule` werden derzeit NICHT ausgewertet.
+# Der Zeitplan steckt im systemd-Timer (Linux, 02:00), im launchd-Job (macOS)
+# bzw. in der Aufgabenplanung (Windows) — dort aendern. Ausgewertet wird nur
+# `retention_days`.
 enabled = true
 schedule = "02:00"
 retention_days = 31

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -259,7 +259,7 @@ docker compose exec -T db pg_dump -U praxiszeit --clean --if-exists praxiszeit |
 crontab -e
 
 # Diese Zeile hinzufuegen (Backup taeglich um 2:00 Uhr):
-0 2 * * * cd ~/praxiszeit && docker compose exec -T db pg_dump -U praxiszeit praxiszeit | gzip > ~/backups/praxiszeit_$(date +\%Y\%m\%d).sql.gz && find ~/backups -name "praxiszeit_*.sql.gz" -mtime +30 -delete
+0 2 * * * cd ~/praxiszeit && docker compose exec -T db pg_dump --clean --if-exists -U praxiszeit praxiszeit | gzip > ~/backups/praxiszeit_$(date +\%Y\%m\%d).sql.gz && find ~/backups -name "praxiszeit_*.sql.gz" -mtime +30 -delete
 ```
 
 Backup-Ordner vorher anlegen:

--- a/docs/handbuch/CHEATSHEET-MITARBEITER.md
+++ b/docs/handbuch/CHEATSHEET-MITARBEITER.md
@@ -159,7 +159,7 @@ Für manche Mitarbeitende führt die Praxis **keine Stundenzählung**:
 
 Zusätzlicher Schutz per Einmal-Code aus einer Authenticator-App (z. B. Google Authenticator, Authy).
 
-**Aktivieren:** Profil → Karte „Zwei-Faktor-Authentifizierung" → **2FA aktivieren** → QR-Code scannen (oder Schlüssel manuell eintragen) → 6-stelligen Code eingeben → **Bestätigen**
+**Aktivieren:** Profil → Karte „Zwei-Faktor-Authentifizierung" → **2FA aktivieren** → aktuelles **Passwort** bestätigen → QR-Code scannen (oder Schlüssel manuell eintragen) → 6-stelligen Code eingeben → **Bestätigen**
 **Login:** Benutzername + Passwort → danach **6-stelligen Code** aus der App
 **Deaktivieren:** **2FA deaktivieren** → aktuelles **Passwort** bestätigen
 > App/Handy verloren? → Administrator kontaktieren

--- a/docs/handbuch/HANDBUCH-MITARBEITER.md
+++ b/docs/handbuch/HANDBUCH-MITARBEITER.md
@@ -469,8 +469,9 @@ Sie können Ihr Konto zusätzlich mit einem Einmal-Code aus einer **Authenticato
 **2FA aktivieren** (Karte **Zwei-Faktor-Authentifizierung** im Profil):
 
 1. Klicken Sie auf **„2FA aktivieren"**.
-2. **Scannen Sie den angezeigten QR-Code** mit Ihrer Authenticator-App – alternativ tragen Sie den angezeigten Schlüssel manuell ein.
-3. Geben Sie den **6-stelligen Code** aus der App ein und bestätigen Sie mit **„Bestätigen & 2FA aktivieren"**.
+2. **Bestätigen Sie Ihr aktuelles Passwort** – zur Sicherheit, damit niemand mit einer offenen Sitzung Ihren zweiten Faktor austauschen kann.
+3. **Scannen Sie den angezeigten QR-Code** mit Ihrer Authenticator-App – alternativ tragen Sie den angezeigten Schlüssel manuell ein.
+4. Geben Sie den **6-stelligen Code** aus der App ein und bestätigen Sie mit **„Bestätigen & 2FA aktivieren"**.
 
 **Login mit aktiver 2FA:** Geben Sie wie gewohnt Benutzername und Passwort ein. Anschließend werden Sie nach dem **6-stelligen Code** aus Ihrer Authenticator-App gefragt.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.15.2",
+      "version": "1.16.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -4720,16 +4720,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.15.2",
+  "version": "1.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -29,7 +29,7 @@
   "overrides": {
     "minimatch": ">=10.2.3",
     "serialize-javascript": ">=7.0.5",
-    "brace-expansion": ">=5.0.6",
+    "brace-expansion": ">=5.0.7",
     "lodash": ">=4.18.0",
     "follow-redirects": ">=1.16.0",
     "undici": ">=7.28.0"

--- a/frontend/public/help/CHEATSHEET-MITARBEITER.md
+++ b/frontend/public/help/CHEATSHEET-MITARBEITER.md
@@ -159,7 +159,7 @@ Für manche Mitarbeitende führt die Praxis **keine Stundenzählung**:
 
 Zusätzlicher Schutz per Einmal-Code aus einer Authenticator-App (z. B. Google Authenticator, Authy).
 
-**Aktivieren:** Profil → Karte „Zwei-Faktor-Authentifizierung" → **2FA aktivieren** → QR-Code scannen (oder Schlüssel manuell eintragen) → 6-stelligen Code eingeben → **Bestätigen**
+**Aktivieren:** Profil → Karte „Zwei-Faktor-Authentifizierung" → **2FA aktivieren** → aktuelles **Passwort** bestätigen → QR-Code scannen (oder Schlüssel manuell eintragen) → 6-stelligen Code eingeben → **Bestätigen**
 **Login:** Benutzername + Passwort → danach **6-stelligen Code** aus der App
 **Deaktivieren:** **2FA deaktivieren** → aktuelles **Passwort** bestätigen
 > App/Handy verloren? → Administrator kontaktieren

--- a/frontend/public/help/HANDBUCH-MITARBEITER.md
+++ b/frontend/public/help/HANDBUCH-MITARBEITER.md
@@ -469,8 +469,9 @@ Sie können Ihr Konto zusätzlich mit einem Einmal-Code aus einer **Authenticato
 **2FA aktivieren** (Karte **Zwei-Faktor-Authentifizierung** im Profil):
 
 1. Klicken Sie auf **„2FA aktivieren"**.
-2. **Scannen Sie den angezeigten QR-Code** mit Ihrer Authenticator-App – alternativ tragen Sie den angezeigten Schlüssel manuell ein.
-3. Geben Sie den **6-stelligen Code** aus der App ein und bestätigen Sie mit **„Bestätigen & 2FA aktivieren"**.
+2. **Bestätigen Sie Ihr aktuelles Passwort** – zur Sicherheit, damit niemand mit einer offenen Sitzung Ihren zweiten Faktor austauschen kann.
+3. **Scannen Sie den angezeigten QR-Code** mit Ihrer Authenticator-App – alternativ tragen Sie den angezeigten Schlüssel manuell ein.
+4. Geben Sie den **6-stelligen Code** aus der App ein und bestätigen Sie mit **„Bestätigen & 2FA aktivieren"**.
 
 **Login mit aktiver 2FA:** Geben Sie wie gewohnt Benutzername und Passwort ein. Anschließend werden Sie nach dem **6-stelligen Code** aus Ihrer Authenticator-App gefragt.
 

--- a/frontend/src/components/DocViewer.tsx
+++ b/frontend/src/components/DocViewer.tsx
@@ -234,7 +234,7 @@ export function CheatsheetAdmin() {
       <section>
         <h3 className="text-base font-semibold text-gray-800 border-b border-gray-200 pb-2 mb-3">📅 Betriebsferien</h3>
         <p className="text-sm text-gray-600">Abwesenheiten → Neue Betriebsferien → Bezeichnung + Von–Bis → Speichern</p>
-        <p className="text-sm text-gray-500 mt-1">Alle MA mit „Nimmt an Betriebsferien teil" (Standard) erhalten automatisch Einträge – rollenunabhängig, keine Urlaubstage. Nachträglich Berechtigte: Option setzen – Einträge werden automatisch für laufende und künftige Betriebsferien nachgetragen.</p>
+        <p className="text-sm text-gray-500 mt-1">Alle MA mit „Nimmt an Betriebsferien teil" (Standard) erhalten automatisch Einträge – rollenunabhängig. Die <strong>Verrechnung</strong> wählen Sie beim Anlegen: „Als Urlaub werten" (Standard – 1 Urlaubstag je Schließ-Arbeitstag) oder „Bezahlte Freistellung" (saldoneutral, kostet keinen Urlaub). Nachträglich Berechtigte: Option setzen – Einträge werden automatisch für laufende und künftige Betriebsferien nachgetragen.</p>
         <p className="text-sm text-gray-500 mt-1">Sind die (urlaubszählenden) Betriebsferien länger als das Resturlaub-Budget, lässt sich unter <strong>Einstellungen → „Betriebsferien &amp; Urlaub"</strong> die Option „Überzählige Betriebsferien als Überstundenabbau" aktivieren: erst Urlaub, dann Überstunden (Konto darf ins Minus) – statt Minus-Urlaub. Global, Standard aus.</p>
       </section>
 
@@ -370,7 +370,7 @@ export const handbuchMitarbeiterSections: AccordionItem[] = [
     content: (
       <div className="space-y-2">
         <p>Unter <strong>Profil</strong> sehen Sie Ihre persönlichen Daten. Über <strong>Passwort ändern → Ändern</strong> setzen Sie ein neues Passwort (mind. 10 Zeichen, Groß-/Kleinbuchstabe, Ziffer).</p>
-        <p><strong>Zwei-Faktor-Authentifizierung (2FA):</strong> Schützen Sie Ihr Konto zusätzlich mit einem Einmal-Code aus einer Authenticator-App (z. B. Google Authenticator, Authy). <strong>Aktivieren:</strong> Karte „Zwei-Faktor-Authentifizierung" → „2FA aktivieren" → QR-Code scannen (oder Schlüssel manuell eintragen) → 6-stelligen Code bestätigen. <strong>Login:</strong> nach Benutzername + Passwort wird der 6-stellige Code abgefragt. <strong>Deaktivieren:</strong> „2FA deaktivieren" → aktuelles Passwort bestätigen. Bei verlorenem Zugang zur App hilft Ihr Administrator.</p>
+        <p><strong>Zwei-Faktor-Authentifizierung (2FA):</strong> Schützen Sie Ihr Konto zusätzlich mit einem Einmal-Code aus einer Authenticator-App (z. B. Google Authenticator, Authy). <strong>Aktivieren:</strong> Karte „Zwei-Faktor-Authentifizierung" → „2FA aktivieren" → aktuelles Passwort bestätigen → QR-Code scannen (oder Schlüssel manuell eintragen) → 6-stelligen Code bestätigen. <strong>Login:</strong> nach Benutzername + Passwort wird der 6-stellige Code abgefragt. <strong>Deaktivieren:</strong> „2FA deaktivieren" → aktuelles Passwort bestätigen. Bei verlorenem Zugang zur App hilft Ihr Administrator.</p>
         <p>Persönliche Daten wie Name und Wochenstunden können nur vom Administrator geändert werden. Unter <strong>Weitere Einstellungen</strong> finden Sie optionale Darstellungsoptionen.</p>
       </div>
     ),

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.15.2"
+APP_VERSION="1.16.0"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes

--- a/tools/docker/generate-secrets.sh
+++ b/tools/docker/generate-secrets.sh
@@ -10,6 +10,14 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
+# Release-Review 1.16.0: Im Docker-Bundle liegt das Skript neben der .env.example,
+# im Quellcode-Repo aber unter tools/docker/ — die .env.example nur im Root. Der
+# in INSTALL-DOCKER.md und INSTALLATION.md dokumentierte Aufruf
+# `bash tools/docker/generate-secrets.sh` brach dadurch IMMER mit
+# "FEHLER: .env.example nicht gefunden" ab. Gleicher Fallback wie in
+# backup.sh/restore.sh, damit die .env im Root landet (dort sucht compose sie).
+if [ ! -f .env.example ] && [ -f ../../.env.example ]; then cd ../../; fi
+
 if [ ! -f .env.example ]; then
     echo "FEHLER: .env.example nicht gefunden. Dieses Skript aus dem Verzeichnis mit" >&2
     echo "        der docker-compose.yml / .env.example heraus aufrufen." >&2


### PR DESCRIPTION
MINOR-Bump: seit 1.15.2 sind zwei nutzersichtbare Features gelandet — #402 (projizierter Jahresende-Überstundensaldo) und #415 (Stundenänderungen in Berichten) — plus zwei Security-Fixes (#416, #418).

## Release-Review

5 Lanes (Korrektheit, Services/DB, API-Verträge, Doku/Handbücher, Delta seit v1.15.2), jeder Fund von einem Skeptiker gegengeprüft, der ihn zu widerlegen versuchte: **21 bestätigt, 5 verworfen**. Alle 21 behoben.

### Korrektheit / Buchungspfade

**Stiller Datenverlust in `update_closure` (HIGH).** Bei aktivem #314-Split löschte ein *reines Umbenennen* einer Betriebsferien-Schließung alle verlinkten Abwesenheiten und verließ sich darauf, dass der Re-Create-Helper sie neu bucht — der filtert aber auf `is_active`/`receives_company_closures`. Abwesenheiten ausgeschiedener oder abgewählter Mitarbeiter verschwanden damit rückwirkend samt genommenem Urlaub, ohne Audit-Spur. Betroffen war ausgerechnet der in CLAUDE.md dokumentierte Migrationsweg „Toggle nachträglich aktivieren → Schließung neu speichern". Die Löschung ist jetzt auf tatsächlich wieder-buchbare Personen begrenzt; beide Löschpfade schreiben einen Audit-Eintrag (DSGVO Art. 5 Abs. 2), als Summenzeile pro Vorgang statt pro Abwesenheit.

**CR-Genehmigung setzte `half_day` nicht (HIGH).** Die Spalte ist nullable ohne Default; NULL bedeutet laut #205 „Legacy-Row" und schaltet die Urlaubszählung auf den stunden-basierten Pfad um. Ein per Änderungsantrag gebuchter halber Sondertag kostete dadurch 1,0 statt 0,5 Urlaubstage — obwohl der Pre-Check unmittelbar davor 0,5 reserviert hatte. Zusätzlich: der UPDATE-Zweig überschrieb `hours` mit dem vollen Tagessoll ohne `half_day` zu berücksichtigen (verdoppelte Ist-Gutschrift), und die CR-Genehmigung war der einzige der vier Buchungspfade ohne Feiertags-Guard.

### §16-Datei-Exporte

**Tages-Soll pauschal 0 bei jeder Abwesenheit (HIGH).** Alle fünf Per-Tag-Schleifen setzten das Soll auf 0, sobald der Tag irgendeine Abwesenheit trug. Falsch bei Halbtagen (nur 0,5 fällt weg), bei SICK/TRAINING (nicht soll-reduzierend) und beim Überstundenausgleich (Soll bleibt, Ist 0). Ein halber Urlaubstag plus vier gestempelte Stunden ergab „Soll 0 / Ist 4" und damit +4 h Überstunden statt 0 — während zwei Zeilen darunter „Überstunden kumuliert" unverändert stand. Das Soll kommt jetzt aus `_day_soll_contribution`, derselben Quelle wie `get_monthly_target`.

**PDF fehlte der #377-Fixmodus-Branch (HIGH)** — als einziger der drei Monats-Exportflächen. Drei Dateiformate desselben Monats trugen für Minijobber verschiedene Soll-Zahlen.

**Exporte filterten hart auf `is_active` (MEDIUM).** Das Handbuch weist Admins an, Ausgeschiedene auf inaktiv zu setzen statt zu löschen (§16: 2 Jahre Aufbewahrung) — genau diese Personen fielen aus jedem Beleg, auch für Zeiträume, in denen sie gearbeitet hatten. Jetzt: aktive plus ausgeschiedene mit Daten im Zeitraum.

### Delta seit 1.15.2

**#415 war im Normalfall wirkungslos — und verschob still das Soll (HIGH).** `create_working_hours_change` überschreibt `user.weekly_hours`, sobald das Wirkungsdatum ≤ heute liegt, und das ist der Default des Dialogs. Da `get_weekly_hours_for_date` für alle Tage *vor* der ersten erfassten Änderung auf eben dieses Feld zurückfällt, galt der neue Wert rückwirkend für die gesamte Vergangenheit: das Soll bereits abgeschlossener Monate verschob sich, und die Änderung war im Bericht unsichtbar (beide Segmente trugen denselben Wert). Die erste Änderung legt jetzt eine Basis-Zeile mit dem bisherigen Vertragswert an.

**#402 war für MiLoG-Fix-Soll-Mitarbeiter dunkel (MEDIUM).** Die Projektion gab hart 0 zurück, mit einer Begründung im Code, die sich als genau verkehrt herum erwies: dass OVERTIME in keinem der `_FIXED_*_TYPES` steht, heißt gerade *keine* Ist-Gutschrift und *keine* Soll-Minderung — der Saldo sinkt also um die geplanten Stunden. Betroffen war die Gruppe, deren Konto nach § 2 Abs. 2 MiLoG binnen 12 Monaten ausgeglichen sein muss. Beide Prämissen wurden vor der Änderung im Code nachgeprüft; der Test, der die falsche Annahme zementierte, ist korrigiert.

### API / Validierung

`admin_update_time_entry` prüfte die Reihenfolge des *gemergten* start/end-Paars nicht (der Schema-Validator sieht nur den Payload) und schrieb bei reiner Datumsänderung die alten Zeiten, während Audit und Duplikatsprüfung mit den neu gekappten liefen. `update_time_entry` nutzte `current_user` statt des Eintrags-Eigentümers für Kappung und ArbZG-Prüfungen — ein §18-befreiter Admin konnte für eine nicht befreite Mitarbeiterin einen 12-Stunden-Tag speichern. `create_time_entry` prüfte Duplikate gegen die rohe Startzeit, gespeichert wird die gekappte (500 statt 409). `update_user` prüft Beschäftigungs- und Soll-Zeit-Fenster jetzt gegen den Effektivzustand. `VacationRequestCreate.hours` bekommt die Grenzen des Update-Schemas.

### Doku

`tools/docker/generate-secrets.sh` brach beim dokumentierten Aufruf **immer** ab (suchte `.env.example` im eigenen Verzeichnis) — Fallback wie in `backup.sh`, verifiziert. Cron-Dump ohne `--clean --if-exists` ließ sich mit dem dokumentierten Restore nicht einspielen; der Restore-Befehl nutzte Host-Variablen, die dort nie gesetzt sind. `[backup] enabled`/`schedule` sind als wirkungslos gekennzeichnet. Die In-App-Kurzanleitung behauptete, Betriebsferien kosteten keine Urlaubstage — der Default ist das Gegenteil. Der 2FA-Passwortschritt aus #416 ist in allen fünf Nutzer-Doku-Flächen nachgezogen, Mirrors `diff`-geprüft.

## Verifikation

- Backend **1458 passed**; die 6 verbleibenden sind die bekannten date-brittlen `shift_planning`-MyToday-Tests (Samstag, Pläne Mo–Fr), unabhängig von diesem Branch.
- Frontend 217 Vitest + `tsc --noEmit` + `vite build` grün.
- **6/6 Artefakte** gebaut; Windows-Integrität: kein `setup.exe` im ZIP-Baum (478 MB statt der ~1 GB des bekannten Verdopplungs-Bugs), PG-Installer-SHA exakt auf dem 18.4-Pin, gebündelte `updater.py` auf 1.16.0, SHA256SUMS 6/6 OK.
- **validate-release: 5/5 Distros.**
- **Lokales Docker-Upgrade:** `/api/health` 200, **echter Login 200** (Token + CSRF-Cookie), vier authentifizierte Endpunkte 200, alembic auf `066` (keine neue Migration in diesem Release), DB-Fingerprints vor/nach dem Upgrade **bit-identisch**, alle 7 Export-Endpunkte liefern gültige Dateien. Live gegengeprüft: `/totp/setup` → 422 ohne / 400 mit falschem Passwort, `/api/settings` ohne `license`-Block.

**Nicht getestet:** die Test-Box `.131` ist nicht erreichbar (`No route to host`, drittes Release in Folge) — der native Linux-Installer läuft in diesem Release daher auf keinem echten Host.

Dependency: `brace-expansion`-Override auf `>=5.0.7` (einziger offener Dependabot-Alert, dev-only via eslint). Produktions-Abhängigkeitsbaum: 0 HIGH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
