### PR TITLE
fix(#421): Installer fragt beim Update nicht mehr nach Admin-Daten

### DIFF
--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -133,6 +133,66 @@ echo ""
 
 # --- Interactive configuration ---
 
+# #421: Lizenz-Erkennung MUSS vor der Update-Verzweigung stehen. Sie lag frueher
+# im Abfrage-Block und wurde damit im Update-Fall uebersprungen -> LICENSE_FILE
+# ungesetzt -> `set -u` brach den Installer nach der Zusammenfassung ab.
+# Eine license.key neben dem Installer gilt in BEIDEN Faellen.
+_PKG_DIR="$(cd "$(dirname "$0")" && pwd)"
+LICENSE_FILE=""
+if [ -f "${_PKG_DIR}/license.key" ]; then
+    LICENSE_FILE="${_PKG_DIR}/license.key"
+fi
+
+# #421: Das Zielverzeichnis MUSS vor allen anderen Abfragen feststehen, denn es
+# entscheidet, ob dies eine Erstinstallation oder ein Update ist. Frueher wurde
+# es erst nach dem Admin-Passwort erfragt — der Betreiber tippte im Update-Lauf
+# Praxisdaten und ein Admin-Passwort ein, die der Installer anschliessend
+# stillschweigend verwarf (die bestehende praxiszeit.conf bleibt erhalten, siehe
+# unten). Wer sich danach mit dem gerade eingegebenen Passwort anmelden wollte,
+# bekam ein 401 und musste annehmen, das Update habe sein Konto zerstoert.
+read -rp "Installationsverzeichnis [${INSTALL_DIR}]: " CUSTOM_DIR
+INSTALL_DIR=${CUSTOM_DIR:-$INSTALL_DIR}
+
+UPDATE_MODE=0
+if [ -f "${INSTALL_DIR}/config/praxiszeit.conf" ]; then
+    UPDATE_MODE=1
+fi
+
+# Werte aus einer bestehenden praxiszeit.conf lesen (nur fuer Anzeige + die
+# wenigen Stellen, die sie ausserhalb des Config-Schreibens brauchen: PORT fuer
+# CAP_NET_BIND_SERVICE, GEN_SSL fuer die Zertifikatsfrage).
+conf_value() {
+    sed -n "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*//p" "${INSTALL_DIR}/config/praxiszeit.conf" 2>/dev/null \
+        | head -1 | sed 's/^"//; s/"$//'
+}
+
+if [ "$UPDATE_MODE" = "1" ]; then
+    echo ""
+    info "Bestehende Installation in ${INSTALL_DIR} erkannt -> UPDATE."
+    echo ""
+    echo "  Konfiguration und Zugangsdaten bleiben unveraendert:"
+    echo "  Praxisdaten, Admin-Konto und -Passwort, Port, SSL und der"
+    echo "  Sicherheitsschluessel werden NICHT neu abgefragt und NICHT ueberschrieben."
+    echo "  Eingespielt werden ausschliesslich Programmcode und Datenbank-Migrationen."
+    echo ""
+    echo "  Ihr bisheriges Admin-Passwort gilt unveraendert weiter."
+    echo ""
+
+    PRACTICE_NAME=$(conf_value name)
+    HOLIDAY_STATE=$(conf_value holiday_state)
+    ADMIN_USERNAME=$(conf_value username)
+    ADMIN_EMAIL=$(conf_value email)
+    PORT=$(conf_value port)
+    PORT=${PORT:-443}
+    # Zertifikat nur neu erzeugen, wenn die bestehende Installation ueberhaupt
+    # SSL nutzt UND das Zertifikat fehlt (sonst bleibt es unangetastet).
+    if [ -n "$(conf_value ssl_cert)" ] && [ ! -f "${INSTALL_DIR}/config/ssl/cert.pem" ]; then
+        GEN_SSL="J"
+    else
+        GEN_SSL="n"
+    fi
+else
+
 read -rp "Praxis-Name: " PRACTICE_NAME
 if [ -z "$PRACTICE_NAME" ]; then
     error "Praxis-Name darf nicht leer sein."
@@ -196,11 +256,6 @@ done
 # Installer oder aus einer früheren Installation) wird STILL übernommen, damit
 # sie für eine spätere Reaktivierung erhalten bleibt; es wird aber nicht danach
 # gefragt und nichts dazu angezeigt.
-_PKG_DIR="$(cd "$(dirname "$0")" && pwd)"
-LICENSE_FILE=""
-if [ -f "${_PKG_DIR}/license.key" ]; then
-    LICENSE_FILE="${_PKG_DIR}/license.key"
-fi
 
 echo ""
 read -rp "HTTPS-Port [443]: " PORT
@@ -213,9 +268,7 @@ fi
 read -rp "Selbstsigniertes SSL-Zertifikat generieren? [J/n]: " GEN_SSL
 GEN_SSL=${GEN_SSL:-J}
 
-echo ""
-read -rp "Installationsverzeichnis [${INSTALL_DIR}]: " CUSTOM_DIR
-INSTALL_DIR=${CUSTOM_DIR:-$INSTALL_DIR}
+fi   # Ende des Erstinstallations-Zweigs (#421)
 
 # Bestehende Lizenz aus einer früheren Installation übernehmen, wenn keine neue
 # Datei angegeben wurde (Reinstall/Upgrade in dasselbe Verzeichnis) — dann wird
@@ -232,12 +285,20 @@ echo ""
 echo "=============================================="
 echo "  Installationszusammenfassung"
 echo "=============================================="
+if [ "$UPDATE_MODE" = "1" ]; then
+echo "  Modus:       UPDATE (Konfiguration + Zugangsdaten bleiben unveraendert)"
+echo "  Praxis:      ${PRACTICE_NAME:-(aus bestehender Konfiguration)}"
+echo "  Admin:       ${ADMIN_USERNAME:-(unveraendert)} — Passwort unveraendert"
+echo "  Port:        ${PORT}"
+echo "  Verzeichnis: ${INSTALL_DIR}"
+else
 echo "  Praxis:      ${PRACTICE_NAME}"
 echo "  Bundesland:  ${HOLIDAY_STATE}"
 echo "  Admin:       ${ADMIN_USERNAME} <${ADMIN_EMAIL}>"
 echo "  Port:        ${PORT}"
 echo "  SSL:         $([ "${GEN_SSL,,}" = "j" ] && echo 'Ja (selbstsigniert)' || echo 'Nein')"
 echo "  Verzeichnis: ${INSTALL_DIR}"
+fi
 echo "=============================================="
 echo ""
 read -rp "Installation starten? [J/n]: " CONFIRM
@@ -356,11 +417,6 @@ SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(64))" 2>/dev/nu
 # \" / \\ beim Lesen wieder zurueck -> Passwort/Name round-trippen korrekt.
 # Backslash zuerst ersetzen, dann das doppelte Anfuehrungszeichen.
 toml_escape() { local s="$1"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; printf '%s' "$s"; }
-PRACTICE_NAME_ESC=$(toml_escape "$PRACTICE_NAME")
-ADMIN_USERNAME_ESC=$(toml_escape "$ADMIN_USERNAME")
-ADMIN_EMAIL_ESC=$(toml_escape "$ADMIN_EMAIL")
-ADMIN_PASSWORD_ESC=$(toml_escape "$ADMIN_PASSWORD")
-
 if [ -f "${INSTALL_DIR}/config/praxiszeit.conf" ]; then
     # Reinstall/Update: bestehende Konfiguration NICHT ueberschreiben. Ein neu
     # generierter secret_key wuerde sonst alle Sessions ungueltig machen UND alle
@@ -370,6 +426,13 @@ if [ -f "${INSTALL_DIR}/config/praxiszeit.conf" ]; then
     info "Bestehende config/praxiszeit.conf erkannt -> wird beibehalten (Reinstall/Update)."
 else
 info "Schreibe Konfiguration..."
+# #421: Die TOML-Escapes erst HIER — im Update-Fall sind PRACTICE_NAME/ADMIN_*
+# gar nicht abgefragt worden, und `set -u` liess den Installer sonst nach der
+# Zusammenfassung abbrechen (Dienst blieb gestoppt).
+PRACTICE_NAME_ESC=$(toml_escape "$PRACTICE_NAME")
+ADMIN_USERNAME_ESC=$(toml_escape "$ADMIN_USERNAME")
+ADMIN_EMAIL_ESC=$(toml_escape "$ADMIN_EMAIL")
+ADMIN_PASSWORD_ESC=$(toml_escape "$ADMIN_PASSWORD")
 cat > "${INSTALL_DIR}/config/praxiszeit.conf" << TOMLEOF
 [server]
 port = ${PORT}

--- a/installer/macos/install.sh
+++ b/installer/macos/install.sh
@@ -30,6 +30,25 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # --- Konfiguration abfragen ---
 
+# #421: Bei einem Update bleibt die bestehende praxiszeit.conf erhalten (siehe
+# unten) — inklusive Admin-Konto, Passwort und Sicherheitsschluessel. Danach zu
+# fragen ist irrefuehrend: der Betreiber tippt ein Passwort ein, das nirgends
+# ankommt, und kann sich anschliessend nicht damit anmelden. Im Update-Fall
+# also gar nicht erst fragen. Parität zum Linux-Installer.
+UPDATE_MODE=0
+if [ -f "${INSTALL_DIR}/config/praxiszeit.conf" ]; then
+    UPDATE_MODE=1
+fi
+
+if [ "$UPDATE_MODE" = "1" ]; then
+    info "Bestehende Installation in ${INSTALL_DIR} erkannt -> UPDATE."
+    echo "  Konfiguration und Zugangsdaten bleiben unveraendert (Admin-Konto,"
+    echo "  Passwort, Port, Sicherheitsschluessel). Ihr bisheriges Admin-Passwort"
+    echo "  gilt weiter. Eingespielt werden nur Code und Datenbank-Migrationen."
+    PORT=$(sed -n 's/^[[:space:]]*port[[:space:]]*=[[:space:]]*//p' "${INSTALL_DIR}/config/praxiszeit.conf" 2>/dev/null | head -1 | tr -d '"')
+    PORT=${PORT:-8443}
+else
+
 read -rp "Praxis-Name [Testpraxis]: " PRACTICE_NAME
 PRACTICE_NAME=${PRACTICE_NAME:-Testpraxis}
 
@@ -44,6 +63,8 @@ done
 
 read -rp "Port [8443]: " PORT
 PORT=${PORT:-8443}
+
+fi   # Ende des Erstinstallations-Zweigs (#421)
 
 echo ""
 info "Installiere nach ${INSTALL_DIR}..."


### PR DESCRIPTION
Schliesst #421. **Ziel: Folgeversion** — 1.16.0 ist bereits veröffentlicht, dieser Fix landet in der nächsten.

## Problem

Ein Update-Lauf von `install.sh` fragte nach Praxis-Name, Bundesland, Admin-Benutzername, Admin-E-Mail, Admin-Passwort (zweimal), Port und SSL — und verwarf all das anschließend.

Das Verwerfen selbst ist **richtig und bleibt so**: eine bestehende `praxiszeit.conf` muss erhalten bleiben, sonst würde ein neu generierter `secret_key` alle Sessions ungültig machen und die Fernet-verschlüsselten TOTP-Secrets (Migration 050) unentschlüsselbar — jeder 2FA-Nutzer wäre ausgesperrt. Auch das Admin-Passwort des Betreibers darf ein Update nicht überschreiben.

Falsch war nur, **danach zu fragen**. Der Betreiber tippt ein Passwort ein, bestätigt es, sieht am Ende „PraxisZeit erfolgreich installiert!" — und bekommt damit ein 401. Ohne jeden Hinweis, dass die Eingabe ignoriert wurde. Der naheliegende Schluss ist „das Update hat mein Konto zerschossen", nicht „mein altes Passwort gilt weiter". Die Installationszusammenfassung zeigte zusätzlich `Admin: <eingegebener Name> <eingegebene Mail>` — Werte, die nirgends ankamen.

Gefunden beim Release-Test von 1.16.0 auf der Test-Box, wo ich selbst darauf hereingefallen bin.

## Lösung

Das Installationsverzeichnis wird als **erstes** erfragt — es entscheidet, ob dies eine Erstinstallation oder ein Update ist. Findet der Installer dort eine `praxiszeit.conf`, überspringt er den gesamten Abfrage-Block und sagt klar:

```
[INFO] Bestehende Installation in /opt/praxiszeit erkannt -> UPDATE.

  Konfiguration und Zugangsdaten bleiben unveraendert:
  Praxisdaten, Admin-Konto und -Passwort, Port, SSL und der
  Sicherheitsschluessel werden NICHT neu abgefragt und NICHT ueberschrieben.
  Eingespielt werden ausschliesslich Programmcode und Datenbank-Migrationen.

  Ihr bisheriges Admin-Passwort gilt unveraendert weiter.
```

Die Zusammenfassung zeigt im Update-Fall `Modus: UPDATE` und die tatsächlichen Werte aus der vorhandenen Konfiguration statt erfundener Eingaben. Port und SSL-Zustand werden aus der bestehenden `praxiszeit.conf` gelesen, weil beide auch außerhalb des Config-Schreibens gebraucht werden (`CAP_NET_BIND_SERVICE` bei Port < 1024, Zertifikats-Erzeugung).

Ein Update-Lauf braucht damit nur noch zwei Eingaben: Verzeichnis (Enter) und Bestätigung.

## Zwei Folgefehler, die dabei sichtbar wurden

`set -u` löste sie erst im echten Lauf aus — `bash -n` sieht so etwas nicht:

- Die **Lizenz-Erkennung** (`LICENSE_FILE`) lag im Abfrage-Block und wurde im Update-Fall übersprungen → Abbruch nach der Zusammenfassung. Sie gilt jetzt in beiden Fällen; eine `license.key` neben dem Installer wird also weiterhin übernommen.
- Die **TOML-Escapes** (`ADMIN_PASSWORD_ESC` u. a.) liefen unbedingt, obwohl die Variablen im Update-Fall nie gesetzt werden → derselbe Abbruch. Sie stehen jetzt im Erstinstallations-Zweig, wo sie allein gebraucht werden.

Beide ließen den Installer nach der Zusammenfassung abbrechen und den Dienst gestoppt zurück — genau die Art Fehler, die ein Kunde beim Update trifft.

## Verifikation

Auf der Test-Box gegen eine echte native 1.16.0-Installation, als reales Update-Szenario:

| Prüfung | Ergebnis |
|---|---|
| `install.sh exit` | 0 |
| Erstinstallations-Abfragen im Update-Lauf | 0 (vorher 6) |
| `set -u`-Fehler | keine |
| Dienst / Version | `active` / 1.16.0 |
| **Login mit dem bisherigen Passwort** | **HTTP 200** |
| Bestehende `praxiszeit.conf` | unverändert |

## Umfang

- `installer/linux/install.sh`
- `installer/macos/install.sh` (gleiches Muster, analog gelöst)

Der **Erstinstallations-Pfad bleibt unverändert** — alle Abfragen, Validierungen und das Schreiben der Konfiguration laufen dort wie bisher. Der Windows-Wizard ist nicht Teil dieses PRs; ob er dasselbe Muster hat, gehört separat geprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
