### PR TITLE
Add settings for year-end overtime projection, see #402

### DIFF
--- a/backend/app/routers/admin_settings.py
+++ b/backend/app/routers/admin_settings.py
@@ -9,6 +9,10 @@ from app.middleware.auth import require_admin
 from app.routers.admin_helpers import SettingUpdate
 from app.services import special_days_service, type_colors_service
 from typing import Dict
+from app.services.settings_service import (
+    SHOW_YEAR_END_OVERTIME_ADMIN_DASHBOARD,
+    SHOW_YEAR_END_OVERTIME_EMPLOYEE_DASHBOARD,
+)
 
 router = APIRouter(prefix="/api/admin", tags=["admin"], dependencies=[Depends(require_admin)])
 
@@ -27,10 +31,12 @@ _ALLOWED_SETTINGS = {
     "shift_planning_weekdays",  # #371 konfigurierbare Wochentage (CSV 0=Mo…6=So, Default Mo–Fr)
     "closure_overtime_after_vacation",  # #314 Betriebsferien > Urlaub → Überstundenabbau (Default aus)
     "child_sick_days_default",  # #376 Kind-krank-Default-Anspruch/Jahr (int, Default 15)
+    SHOW_YEAR_END_OVERTIME_EMPLOYEE_DASHBOARD,
+    SHOW_YEAR_END_OVERTIME_ADMIN_DASHBOARD,
 } | special_days_service.SETTING_KEYS
 
 # Settings whose value must be a boolean ("true"/"false").
-_BOOL_SETTINGS = {"vacation_approval_required", "break_exception_requires_approval", "onboarding_enabled", "shift_planning_enabled", "closure_overtime_after_vacation"}
+_BOOL_SETTINGS = {"vacation_approval_required", "break_exception_requires_approval", "onboarding_enabled", "shift_planning_enabled", "closure_overtime_after_vacation", SHOW_YEAR_END_OVERTIME_EMPLOYEE_DASHBOARD, SHOW_YEAR_END_OVERTIME_ADMIN_DASHBOARD, }
 
 
 @router.get("/settings")

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -238,8 +238,8 @@ def get_overtime_account(
     # für das Mitarbeiter-Dashboard deaktivieren.
     show_year_end_projection = get_bool_setting(
         db,
-        current_user.tenant_id,
         SHOW_YEAR_END_OVERTIME_EMPLOYEE_DASHBOARD,
+        tenant_id=current_user.tenant_id,
         default=True,
     )
 

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -13,6 +13,7 @@ from app.services.calculation_service import get_weekly_hours_for_date, get_dail
 from app.services.holiday_service import is_holiday
 from app.services.timezone_service import today_local, now_local
 from sqlalchemy import extract, and_
+from app.services.settings_service import SHOW_YEAR_END_OVERTIME_EMPLOYEE_DASHBOARD, get_bool_setting
 
 router = APIRouter(prefix="/api/dashboard", tags=["dashboard"])
 
@@ -232,10 +233,28 @@ def get_overtime_account(
     # #402: bereits feststehender künftiger Freizeitausgleich + projizierter
     # Jahresende-Saldo. projected nur setzen, wenn künftiger Ausgleich existiert
     # (sonst None → Frontend blendet die Zeile aus).
-    future_comp = calculation_service.future_freizeitausgleich_impact(
-        db, current_user, cutoff_date=cutoff
+    
+    # Die Berechnung und Anzeige der Jahresende-Projektion kann der Tenant
+    # für das Mitarbeiter-Dashboard deaktivieren.
+    show_year_end_projection = get_bool_setting(
+        db,
+        current_user.tenant_id,
+        SHOW_YEAR_END_OVERTIME_EMPLOYEE_DASHBOARD,
+        default=True,
     )
-    projected = float(current_balance) - float(future_comp) if future_comp > 0 else None
+
+    future_comp = Decimal("0")
+    projected = None
+
+    if show_year_end_projection:
+        future_comp = calculation_service.future_freizeitausgleich_impact(
+            db,
+            current_user,
+            cutoff_date=cutoff,
+        )
+
+        if future_comp > 0:
+            projected = float(current_balance) - float(future_comp)
 
     return OvertimeAccount(
         current_balance=current_balance,

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -19,6 +19,7 @@ from app.services.arbzg_utils import is_night_work
 import calendar
 from app.services.date_filters import date_in_year, date_in_month, date_in_range, parse_year_month
 from app.core.limiter import limiter
+from app.services.settings_service import SHOW_YEAR_END_OVERTIME_ADMIN_DASHBOARD, get_bool_setting
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,8 @@ def get_monthly_report(
 
     users = _get_active_visible_users(db, current_user.tenant_id)
 
+    show_year_end_projection = get_bool_setting(db, current_user.tenant_id, SHOW_YEAR_END_OVERTIME_ADMIN_DASHBOARD, default=True)
+
     reports = []
     _now = now_local()  # #402: Gate für die Jahresende-Projektion (nur aktueller Monat)
 
@@ -106,7 +109,7 @@ def get_monthly_report(
         # bis_heute→cutoff, monatsende→Monatsende (verhindert Doppelzählung künftiger
         # Freizeitausgleich-Tage im laufenden Monat).
         _future_comp = Decimal('0'); _projected = None
-        if year == _now.year and month_num == _now.month and user.track_hours:
+        if show_year_end_projection and year == _now.year and month_num == _now.month and user.track_hours:
             _boundary = cutoff if cutoff is not None else date(year, month_num, calendar.monthrange(year, month_num)[1])
             _future_comp = calculation_service.future_freizeitausgleich_impact(db, user, cutoff_date=_boundary)
             if _future_comp > 0:
@@ -218,6 +221,8 @@ def get_weekly_report(
 
     users = _get_active_visible_users(db, current_user.tenant_id)
 
+    show_year_end_projection = get_bool_setting(db, current_user.tenant_id, SHOW_YEAR_END_OVERTIME_ADMIN_DASHBOARD, default=True, )
+
     reports = []
     _now = now_local()  # #402: Gate für die Jahresende-Projektion (nur aktuelle Woche)
 
@@ -238,7 +243,7 @@ def get_weekly_report(
         # Boundary = ot_cutoff (Wochenende bzw. bis_heute-Cutoff), damit künftige
         # Freizeitausgleich-Tage nicht doppelt zählen.
         _future_comp = Decimal('0'); _projected = None
-        if wk_end.year == _now.year and wk_start <= _now.date() <= wk_end and user.track_hours:
+        if show_year_end_projection and wk_end.year == _now.year and wk_start <= _now.date() <= wk_end and user.track_hours:
             _future_comp = calculation_service.future_freizeitausgleich_impact(db, user, cutoff_date=ot_cutoff)
             if _future_comp > 0:
                 _projected = float(overtime) - float(_future_comp)

--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -88,7 +88,7 @@ def get_monthly_report(
 
     users = _get_active_visible_users(db, current_user.tenant_id)
 
-    show_year_end_projection = get_bool_setting(db, current_user.tenant_id, SHOW_YEAR_END_OVERTIME_ADMIN_DASHBOARD, default=True)
+    show_year_end_projection = get_bool_setting(db, SHOW_YEAR_END_OVERTIME_ADMIN_DASHBOARD, tenant_id=current_user.tenant_id, default=True, )
 
     reports = []
     _now = now_local()  # #402: Gate für die Jahresende-Projektion (nur aktueller Monat)
@@ -221,7 +221,7 @@ def get_weekly_report(
 
     users = _get_active_visible_users(db, current_user.tenant_id)
 
-    show_year_end_projection = get_bool_setting(db, current_user.tenant_id, SHOW_YEAR_END_OVERTIME_ADMIN_DASHBOARD, default=True, )
+    show_year_end_projection = get_bool_setting(db, SHOW_YEAR_END_OVERTIME_ADMIN_DASHBOARD, tenant_id=current_user.tenant_id, default=True, )
 
     reports = []
     _now = now_local()  # #402: Gate für die Jahresende-Projektion (nur aktuelle Woche)

--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -54,37 +54,3 @@ SHOW_YEAR_END_OVERTIME_ADMIN_DASHBOARD = (
     "show_year_end_overtime_admin_dashboard"
 )
 
-
-def get_bool_setting(
-    db: Session,
-    tenant_id,
-    key: str,
-    *,
-    default: bool = False,
-) -> bool:
-    """Liest eine boolesche Tenant-Einstellung.
-
-    Fehlende oder ungültige Werte fallen auf ``default`` zurück.
-    """
-
-    value = (
-        db.query(SystemSetting.value)
-        .filter(
-            SystemSetting.key == key,
-            SystemSetting.tenant_id == tenant_id,
-        )
-        .scalar()
-    )
-
-    if value is None:
-        return default
-
-    normalized = str(value).strip().lower()
-
-    if normalized == "true":
-        return True
-
-    if normalized == "false":
-        return False
-
-    return default

--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -44,3 +44,47 @@ def get_int_setting(db: Session, key: str, tenant_id=None, default: int = 0) -> 
         return int(raw)
     except (TypeError, ValueError):
         return default
+
+
+SHOW_YEAR_END_OVERTIME_EMPLOYEE_DASHBOARD = (
+    "show_year_end_overtime_employee_dashboard"
+)
+
+SHOW_YEAR_END_OVERTIME_ADMIN_DASHBOARD = (
+    "show_year_end_overtime_admin_dashboard"
+)
+
+
+def get_bool_setting(
+    db: Session,
+    tenant_id,
+    key: str,
+    *,
+    default: bool = False,
+) -> bool:
+    """Liest eine boolesche Tenant-Einstellung.
+
+    Fehlende oder ungültige Werte fallen auf ``default`` zurück.
+    """
+
+    value = (
+        db.query(SystemSetting.value)
+        .filter(
+            SystemSetting.key == key,
+            SystemSetting.tenant_id == tenant_id,
+        )
+        .scalar()
+    )
+
+    if value is None:
+        return default
+
+    normalized = str(value).strip().lower()
+
+    if normalized == "true":
+        return True
+
+    if normalized == "false":
+        return False
+
+    return default

--- a/frontend/src/pages/admin/Settings.tsx
+++ b/frontend/src/pages/admin/Settings.tsx
@@ -145,6 +145,27 @@ export default function Settings() {
   const [newDate, setNewDate] = useState('');
   const [creating, setCreating] = useState(false);
 
+  // Jahresende-Projektion der Überstunden.
+  // Default an: Nur ein explizites "false" deaktiviert die Anzeige.
+  const [showEmployeeYearEndProjection, setShowEmployeeYearEndProjection] =
+    useState(true);
+
+  const [
+    originalShowEmployeeYearEndProjection,
+    setOriginalShowEmployeeYearEndProjection,
+  ] = useState(true);
+
+  const [showAdminYearEndProjection, setShowAdminYearEndProjection] =
+    useState(true);
+
+  const [
+    originalShowAdminYearEndProjection,
+    setOriginalShowAdminYearEndProjection,
+  ] = useState(true);
+
+  const [savingYearEndProjection, setSavingYearEndProjection] =
+    useState(false);
+
   // Inline edit state
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState('');
@@ -235,6 +256,26 @@ export default function Settings() {
       const childSickVal = childSickSetting?.value ?? '15';
       setChildSickDefault(childSickVal);
       setOriginalChildSickDefault(childSickVal);
+      
+      const employeeYearEndSetting = settingsRes.data.find(
+	  (s) => s.key === 'show_year_end_overtime_employee_dashboard',
+      );
+
+      const employeeYearEndValue =
+        employeeYearEndSetting?.value?.toLowerCase() !== 'false';
+
+      setShowEmployeeYearEndProjection(employeeYearEndValue);
+      setOriginalShowEmployeeYearEndProjection(employeeYearEndValue);
+
+      const adminYearEndSetting = settingsRes.data.find(
+        (s) => s.key === 'show_year_end_overtime_admin_dashboard',
+      );
+
+      const adminYearEndValue =
+        adminYearEndSetting?.value?.toLowerCase() !== 'false';
+
+      setShowAdminYearEndProjection(adminYearEndValue);
+      setOriginalShowAdminYearEndProjection(adminYearEndValue); 
     } catch (err) {
       toast.error(getErrorMessage(err));
     } finally {
@@ -452,6 +493,44 @@ export default function Settings() {
       setSavingChildSick(false);
     }
   };
+
+const saveYearEndProjection = async () => {
+  setSavingYearEndProjection(true);
+
+  try {
+    await Promise.all([
+      apiClient.put(
+        '/admin/settings/show_year_end_overtime_employee_dashboard',
+        {
+          value: String(showEmployeeYearEndProjection),
+        },
+      ),
+      apiClient.put(
+        '/admin/settings/show_year_end_overtime_admin_dashboard',
+        {
+          value: String(showAdminYearEndProjection),
+        },
+      ),
+    ]);
+
+    setOriginalShowEmployeeYearEndProjection(
+      showEmployeeYearEndProjection,
+    );
+    setOriginalShowAdminYearEndProjection(
+      showAdminYearEndProjection,
+    );
+
+    toast.success('Überstunden-Projektion gespeichert.');
+  } catch (err) {
+    toast.error(getErrorMessage(err));
+
+    // Die beiden PUTs sind nicht atomar. Bei einem Teilfehler deshalb
+    // den tatsächlich gespeicherten Stand erneut laden.
+    void loadSettings();
+  } finally {
+    setSavingYearEndProjection(false);
+  }
+};
 
   const createHoliday = async () => {
     if (!newName.trim() || !newDate) {
@@ -1119,6 +1198,127 @@ export default function Settings() {
           </button>
         </div>
       </div>
+
+      {/* Voraussichtlicher Überstundensaldo zum Jahresende */}
+<div className="bg-white rounded-xl shadow-sm p-6">
+  <h2 className="text-lg font-semibold text-gray-900 mb-4">
+    Überstunden-Projektion zum Jahresende
+  </h2>
+
+  <p className="text-sm text-gray-500 mb-5">
+    PraxisZeit kann den aktuellen Überstundensaldo um bereits
+    eingetragenen künftigen Freizeitausgleich vermindern und daraus
+    einen voraussichtlichen Saldo zum 31.12. anzeigen. Die Anzeige
+    lässt sich für Mitarbeitende und Administratoren getrennt
+    aktivieren.
+  </p>
+
+  <div className="space-y-5 max-w-xl">
+    <div className="flex items-center justify-between gap-6">
+      <div>
+        <label
+          htmlFor="employee-year-end-projection-toggle"
+          className="text-sm font-medium text-gray-700"
+        >
+          Im Mitarbeiter-Dashboard anzeigen
+        </label>
+
+        <p className="text-xs text-gray-500 mt-1">
+          Mitarbeitende sehen den voraussichtlichen Jahressaldo in
+          ihrem eigenen Überstundenkonto.
+        </p>
+      </div>
+
+      <button
+        id="employee-year-end-projection-toggle"
+        type="button"
+        role="switch"
+        aria-checked={showEmployeeYearEndProjection}
+        onClick={() =>
+          setShowEmployeeYearEndProjection(
+            !showEmployeeYearEndProjection,
+          )
+        }
+        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${
+          showEmployeeYearEndProjection
+            ? 'bg-primary'
+            : 'bg-gray-300'
+        }`}
+      >
+        <span
+          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+            showEmployeeYearEndProjection
+              ? 'translate-x-6'
+              : 'translate-x-1'
+          }`}
+        />
+      </button>
+    </div>
+
+    <div className="flex items-center justify-between gap-6 pt-5 border-t border-gray-100">
+      <div>
+        <label
+          htmlFor="admin-year-end-projection-toggle"
+          className="text-sm font-medium text-gray-700"
+        >
+          Im Admin-Dashboard anzeigen
+        </label>
+
+        <p className="text-xs text-gray-500 mt-1">
+          Im Monats- und Wochenbericht erscheint die zusätzliche
+          Spalte „Überstd. Jahresende“.
+        </p>
+      </div>
+
+      <button
+        id="admin-year-end-projection-toggle"
+        type="button"
+        role="switch"
+        aria-checked={showAdminYearEndProjection}
+        onClick={() =>
+          setShowAdminYearEndProjection(
+            !showAdminYearEndProjection,
+          )
+        }
+        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${
+          showAdminYearEndProjection
+            ? 'bg-primary'
+            : 'bg-gray-300'
+        }`}
+      >
+        <span
+          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+            showAdminYearEndProjection
+              ? 'translate-x-6'
+              : 'translate-x-1'
+          }`}
+        />
+      </button>
+    </div>
+  </div>
+
+  <div className="mt-5">
+    <button
+      onClick={saveYearEndProjection}
+      disabled={
+        savingYearEndProjection ||
+        (
+          showEmployeeYearEndProjection ===
+            originalShowEmployeeYearEndProjection &&
+          showAdminYearEndProjection ===
+            originalShowAdminYearEndProjection
+        )
+      }
+      className="flex items-center gap-2 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+    >
+      <Save size={16} />
+      Speichern
+    </button>
+  </div>
+</div>
+
+
+
 
       {/* Soll-Fenster-Puffer (#201) */}
       <div className="bg-white rounded-xl shadow-sm p-6">


### PR DESCRIPTION
Es gab leider einen mittelgroßen Aufruhr hier, sodass ich zumindest zunächst mal diese Zeiten wieder verstecken wollte. Da es mir peinlich war das erst zu fordern dann Rolle rückwärts zu machen habe ich jetzt mal meine nicht vorhandenen Python-Kenntnisse durch KI geboostert und Schalter in der live-VM "hineingehacked", diese nun kurzerhand zu einem PR wieder auf Github gemacht. Da das wirklich schnell per VIM im Terminal passiert ist, passen an einigen Stellen die Leerzeichen nicht und auch sonst werden denke ich ein paar Coding-Konventionen (Klammern statt CSV bei imports z. B.) nicht eingehalten - vermute aber das kriegt Claude bzw. ein Coding Standards Fixer schnell hin. Danke!