### PR TITLE
fix: Kalenderfarben-Kacheln überdecken Text nicht mehr + Viertelstunden beim Anlegen

### DIFF
--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -739,7 +739,10 @@ export default function Profile() {
               </div>
 
               {/* Color Palette */}
-              <div className="grid grid-cols-6 gap-3">
+              {/* Bug-Tracker #3: gleiche feste Kachelgröße wie im Admin-Formular —
+                  `w-full aspect-square` skalierte mit der Spaltenbreite und
+                  überdeckte bei breitem Container/Zoom die Texte darum herum. */}
+              <div className="flex flex-wrap gap-3 py-2">
                 {PASTEL_COLORS.map((color) => (
                   <button
                     key={color.hex}
@@ -747,7 +750,7 @@ export default function Profile() {
                     onClick={() => handleColorChange(color.hex)}
                     aria-label={`Farbe ${color.name}`}
                     aria-pressed={selectedColor === color.hex}
-                    className={`relative w-full aspect-square rounded-lg transition-all hover:scale-110 ${
+                    className={`relative h-10 w-10 shrink-0 rounded-lg transition-all hover:scale-110 ${
                       selectedColor === color.hex
                         ? 'ring-4 ring-primary ring-offset-2 scale-110'
                         : 'hover:ring-2 hover:ring-gray-300'

--- a/frontend/src/pages/admin/users/UserForm.test.tsx
+++ b/frontend/src/pages/admin/users/UserForm.test.tsx
@@ -471,3 +471,35 @@ describe('Task 6+11: Wochenstunden/Tagesplan nur Anzeige beim Bearbeiten (#431)'
     expect(screen.getByLabelText('Wochenstunden')).toBeEnabled();
   });
 });
+
+describe('Bug-Tracker #4: Schrittweite der geplanten Arbeitszeit', () => {
+  it('nimmt Viertelstunden beim Anlegen an — wie der Bearbeiten-Dialog (Fund C, #431)', () => {
+    // step="0.5" wies 20,25 h beim ANLEGEN als Schrittfehler ab, während
+    // dieselbe Zahl über "Wochenstunden anpassen…" längst gespeichert werden
+    // konnte. Zwei Wege zum selben Feld dürfen nicht verschieden streng sein.
+    renderForm({ editUser: null });
+    expect(document.getElementById('f-weekly-hours')).toHaveAttribute('step', '0.25');
+  });
+
+  it('erlaubt bei der Monatsarbeitszeit eine Nachkommastelle (= Genauigkeit der Spalte)', () => {
+    // Der eigene Vorschlagswert (Wochenstunden × 13/3 ≈ 86,7) fiel bei step="0.5"
+    // durch die native Schrittprüfung.
+    renderForm({ editUser: null });
+    fireEvent.click(screen.getByLabelText(/Arbeitszeitkonto/i));
+    expect(document.getElementById('f-agreed-monthly')).toHaveAttribute('step', '0.1');
+  });
+});
+
+describe('Bug-Tracker #3: Kalenderfarben-Kacheln überdecken den Text nicht', () => {
+  it('hält eine feste Kachelgröße statt einer an der Spaltenbreite hängenden', () => {
+    // `w-full aspect-square` im Raster machte die Kacheln so hoch wie die
+    // Spalte breit war — im breiten Formular (bzw. bei Browser-Zoom, wo die
+    // sm:-Stufe wegfällt) wuchsen sie über Label und Hilfetext.
+    renderForm({ editUser: null });
+    const swatch = screen.getByLabelText('Farbe Blau');
+    expect(swatch.className).toContain('h-10');
+    expect(swatch.className).toContain('w-10');
+    expect(swatch.className).not.toContain('aspect-square');
+    expect(swatch.className).not.toContain('w-full');
+  });
+});

--- a/frontend/src/pages/admin/users/UserForm.tsx
+++ b/frontend/src/pages/admin/users/UserForm.tsx
@@ -477,7 +477,11 @@ export default function UserForm({
               <input
                 id="f-weekly-hours"
                 type="number"
-                step="0.5"
+                // Bug-Tracker #4 (Nachzug zu #431-Fund C): derselbe Viertelstunden-
+                // Schritt wie im WorkingHoursModal und bei den Tagesfeldern —
+                // sonst nimmt das Anlegen 20,25 h nicht an, das spätere Ändern
+                // derselben Zahl aber schon.
+                step="0.25"
                 value={formData.weekly_hours}
                 onChange={(e) => setFormData({ ...formData, weekly_hours: parseHours(e.target.value) })}
                 required
@@ -692,7 +696,11 @@ export default function UserForm({
                 <input
                   id="f-agreed-monthly"
                   type="number"
-                  step="0.5"
+                  // Bug-Tracker #4: `0.5` wies u. a. den eigenen Vorschlagswert
+                  // (Wochenstunden × 13/3, eine Nachkommastelle) als Schrittfehler
+                  // ab. `0.1` = Genauigkeit der Spalte `Numeric(5, 1)`; feiner
+                  // einzugeben hieße, dass die DB still rundet.
+                  step="0.1"
                   min="0"
                   max="400"
                   placeholder={
@@ -777,7 +785,13 @@ export default function UserForm({
                 style={{ backgroundColor: formData.calendar_color }}
               />
             </label>
-            <div className="grid grid-cols-6 sm:grid-cols-12 gap-2">
+            {/* Bug-Tracker #3: feste Kachelgröße statt `w-full aspect-square` im
+                Raster. Die Kachelhöhe hing vorher an der Spaltenbreite — in einem
+                breiten Formular (oder bei Browser-Zoom, wo `sm:` nicht mehr greift)
+                wurden die Felder mehrere hundert Pixel hoch und überdeckten Label
+                und Hilfetext. `py-2` hält zusätzlich Platz für Ring + `scale-110`
+                der ausgewählten Kachel, die sonst über die Zeile hinauswächst. */}
+            <div className="flex flex-wrap gap-3 py-2">
               {PASTEL_COLORS.map((color) => (
                 <button
                   key={color.hex}
@@ -786,7 +800,7 @@ export default function UserForm({
                   aria-label={`Farbe ${color.name}`}
                   aria-pressed={formData.calendar_color === color.hex}
                   title={color.name}
-                  className={`relative w-full aspect-square rounded-lg transition-all hover:scale-110 ${
+                  className={`relative h-10 w-10 shrink-0 rounded-lg transition-all hover:scale-110 ${
                     formData.calendar_color === color.hex
                       ? 'ring-4 ring-primary ring-offset-2 scale-110'
                       : 'hover:ring-2 hover:ring-gray-300'


### PR DESCRIPTION
Zwei Meldungen aus dem pzweb-Bug-Tracker (beide von philipp@praxis-braumann.de, seit 10./16.07. offen).

## Bug #3 — „Text überdeckt" (Kalenderfarbe)

Die Farbkacheln lagen in einem Raster mit `w-full aspect-square`, ihre Höhe hing also an der Spaltenbreite. Im breiten Formular — und bei Browser-Zoom, wo die `sm:grid-cols-12`-Stufe wegfällt — wuchsen sie mehrere hundert Pixel hoch und überdeckten Label und Hilfetext (siehe Screenshot der Meldung). Die ausgewählte Kachel trägt zusätzlich `scale-110` + `ring-4 ring-offset-2` und ragte auch ohne das aus ihrer Zeile.

Jetzt feste 40×40-Kacheln in `flex flex-wrap` mit `py-2` Luft für den Ring — in **beiden** Pickern: Admin-Benutzerformular (#297) und Selbstauswahl im Profil (#157), die sich dieselbe Palette und dasselbe Markup teilen.

## Bug #4 — „Eingabe nur in halben Stunden möglich"

Der Kern war mit #431 (1.18.0, Fund C) im `WorkingHoursModal` behoben. Zwei Felder blieben zurück:

- `f-weekly-hours` im **Anlege**-Zweig stand weiter auf `step="0.5"` → 20,25 h ließ sich beim Anlegen nicht speichern, über „Wochenstunden anpassen…" danach schon. Zwei Wege zum selben Feld dürfen nicht unterschiedlich streng sein → `0.25`.
- `f-agreed-monthly` (vereinbarte Monatsarbeitszeit) stand auf `0.5` und wies damit sogar den eigenen Vorschlagswert ab (Wochenstunden × 13/3 ≈ 86,7) → `0.1`, die Genauigkeit der Spalte `Numeric(5, 1)`. Feiner wäre gelogen, die DB rundet dann still.

## Prüfung

- Regressionstests in `UserForm.test.tsx` (Schrittweiten + Kachelgröße)
- Frontend-Suite: 323 grün, `tsc --noEmit` sauber
- Beide Ansichten im laufenden Docker-Stack nachgesehen (Admin-Formular + Profil): Kacheln einreihig, Label und Hilfetext frei, Auswahlring innerhalb der Zeile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
