### PR TITLE
Release 1.18.2 — Review-Funde, Security-Bumps, Version-Bump

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.18.1 (Stand 2026-08-03)
+**Aktuelle Version:** 1.18.2 (Stand 2026-08-13)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---
@@ -171,6 +171,9 @@ Nach nginx.conf / Frontend-Änderungen: `docker compose build frontend && docker
 - Mitarbeiter: `manuel@example.de`
 
 ### Claude-Code-Bash-Gotchas
+- **Einen `docker compose exec`-Aufruf abzubrechen beendet NUR den Client — der Prozess im Container läuft weiter** (1.18.2). Zwei so entstandene pytest-Läufe teilen sich dann `/app/test.db` und erzeugen eine Fehlerkaskade (`no such table: signup_tokens` beim `DROP TABLE`), die wie ein echter Regressionsschaden aussieht. Container-Prozesse sind vom Host aus in `ps` sichtbar (eigener PID-Namensraum, gleiche Liste) → vor einem Neustart der Suite `pgrep -af pytest` prüfen und die Reste killen, dann `rm -f /app/test.db`. Lange Läufe besser mit `setsid nohup … &` und Ausgabe in eine Datei starten — dann überlebt der Lauf einen Abbruch des aufrufenden Tools, und die Ausgabe geht nicht verloren, wenn die Pipe stirbt.
+- **`grep`-Muster, die mit `=` beginnen, frisst ugrep als Option** (1.18.2): `grep -q "===== DONE ====="` trifft nie, ein Monitor darauf bleibt stumm bis zum Timeout, obwohl die Zeile in der Datei steht. `grep -qF -e "===== DONE ====="` nutzen.
+- **`$` in Passwort-Hashes niemals durch die Shell schicken** (1.18.2): ein bcrypt-Hash (`$bcrypt-sha256$v=2,t=2b,…`) wird in doppelten Anführungszeichen bzw. in einem unquotierten Heredoc zu `-sha256=2,t=2b,…` zerlegt — die DB nimmt den Torso an, der Login bleibt 401 und der Fehler sieht aus wie ein Auth-Bug. Hash in eine Datei schreiben und serverseitig lesen (`psql … pg_read_file('/pfad')`), im Container `$$…$$`-Dollar-Quoting nutzen.
 - Das `cd` in einem Bash-Aufruf **persistiert** zwischen Tool-Calls. Nach `cd .claude/worktrees/...` ist `git status` ohne erneutes `cd` immer noch im Worktree. Bei git-Operationen lieber `git -C <pfad>` nutzen oder cwd explizit zurücksetzen.
 - `docker compose cp <host-file> <svc>:<container-path>` resolved den Host-Pfad **relativ zum cwd**, nicht zum Repo-Root. Aus fremdem cwd → `docker cp` mit absoluten Pfaden + Container-Name (`praxiszeit-backend-1`).
 - `docker compose cp` braucht den **Service-Namen** (`backend:`), NICHT den Container-Namen (`praxiszeit-backend-1:` → schlägt still fehl, kopiert nichts). Ganzes Verzeichnis geht: `docker compose cp backend/app backend:/app/` (→ `/app/app`).

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -32,7 +32,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.18.1"
+APP_VERSION = "1.18.2"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/routers/admin_time_entries.py
+++ b/backend/app/routers/admin_time_entries.py
@@ -225,10 +225,27 @@ def admin_update_time_entry(
         User.tenant_id == current_user.tenant_id,
     ).first()
 
-    # Use provided values or fall back to existing
+    # Use provided values or fall back to existing.
+    # Release-Review 1.18.2: der Rückfallwert ist der ROHSTEMPEL, nicht die
+    # gespeicherte (bereits gekappte) Zeit. ``entry.start_time`` als Kappungs-
+    # Eingabe hieß: eine reine Datumsänderung kappte das Ergebnis der letzten
+    # Kappung ein zweites Mal und schrieb es anschließend als neuen „Rohwert"
+    # fest (``_times_affected`` gilt auch bei einem Datums-only-PUT). Der echte
+    # Stempel war damit unwiederbringlich weg — das Audit-Log führt nur
+    # date/start/end/break, keine raw_*-Felder. Er ist aber der §16-Nachweis der
+    # tatsächlichen Anwesenheit und laut CLAUDE.md die Grundlage der
+    # §5-Ruhezeitprüfung; danach rechnete § 5 gegen die geschönte Zeit und ein
+    # echter Verstoß blieb unentdeckt. ``clamp`` leitet aus dem Rohwert für den
+    # neuen Wochentag wieder korrekt eff_* UND raw_* ab.
     update_date = entry_data.date if entry_data.date is not None else entry.date
-    update_start_time = entry_data.start_time if entry_data.start_time is not None else entry.start_time
-    update_end_time = entry_data.end_time if entry_data.end_time is not None else entry.end_time
+    update_start_time = (
+        entry_data.start_time if entry_data.start_time is not None
+        else (entry.raw_start_time or entry.start_time)
+    )
+    update_end_time = (
+        entry_data.end_time if entry_data.end_time is not None
+        else (entry.raw_end_time or entry.end_time)
+    )
     update_break_minutes = entry_data.break_minutes if entry_data.break_minutes is not None else entry.break_minutes
 
     # Release-Review 1.16.0: die Reihenfolge des GEMERGTEN Paars prüfen.

--- a/backend/app/routers/company_closures.py
+++ b/backend/app/routers/company_closures.py
@@ -453,6 +453,14 @@ def create_closure(
     """
     if data.end_date < data.start_date:
         raise HTTPException(status_code=400, detail="Enddatum darf nicht vor dem Startdatum liegen")
+    # Release-Review 1.18.2: dieselbe Klemme wie im Urlaubsantrag
+    # (``vacation_requests``, POST und PATCH). Betriebsferien sind der
+    # destruktivere Pfad — sie loeschen beim Anlegen die Zeiteintraege ALLER
+    # Teilnehmenden pro Werktag —, standen aber als einziger Spannen-Pfad ohne
+    # Obergrenze da: ein Zahlendreher im Jahr (2036 statt 2026) haette in einem
+    # Request die komplette rueckwirkende Zeiterfassung der Praxis geloescht.
+    if (data.end_date - data.start_date).days > 366:
+        raise HTTPException(status_code=400, detail="Der Zeitraum darf maximal ein Jahr umfassen")
 
     # Get all workdays in range
     holidays = _get_holidays_for_range(
@@ -560,6 +568,14 @@ def update_closure(
     """
     if data.end_date < data.start_date:
         raise HTTPException(status_code=400, detail="Enddatum darf nicht vor dem Startdatum liegen")
+    # Release-Review 1.18.2: dieselbe Klemme wie im Urlaubsantrag
+    # (``vacation_requests``, POST und PATCH). Betriebsferien sind der
+    # destruktivere Pfad — sie loeschen beim Anlegen die Zeiteintraege ALLER
+    # Teilnehmenden pro Werktag —, standen aber als einziger Spannen-Pfad ohne
+    # Obergrenze da: ein Zahlendreher im Jahr (2036 statt 2026) haette in einem
+    # Request die komplette rueckwirkende Zeiterfassung der Praxis geloescht.
+    if (data.end_date - data.start_date).days > 366:
+        raise HTTPException(status_code=400, detail="Der Zeitraum darf maximal ein Jahr umfassen")
 
     # F-026: tenant-scoped lookup.
     closure = db.query(CompanyClosure).filter(
@@ -660,13 +676,35 @@ def update_closure(
         _rebookable_user_ids | {a.user_id for a in linked} | {current_user.id},
     )
 
+    # Release-Review 1.18.2: Wen der Create-Helper wieder bucht, war oben geklärt
+    # (Teilnehmermenge) — WELCHE TAGE er überspringt, nicht. Er lässt jeden Tag
+    # aus, an dem bereits Arbeitszeit gebucht ist (#290, „Arbeit gewinnt", er läuft
+    # hier mit delete_time_entries=False). Eine Abwesenheit auf so einem Tag wurde
+    # also gelöscht und nie zurückgebucht, während die Audit-Zeile „werden neu
+    # gebucht" behauptete: ein reines Umbenennen ließ bei aktivem #314-Split den
+    # Urlaubstag ersatzlos verschwinden (Urlaubskonto zu hoch, Soll lebt wieder auf,
+    # §16-Beleg lückenhaft). Solche Zeilen bleiben stehen und werden nur in-place
+    # synchronisiert — wie die der Ausgeschiedenen/Abgewählten.
+    _worked_keys = set()
+    _linked_user_ids = {a.user_id for a in linked}
+    if _linked_user_ids:
+        _worked_keys = {
+            (uid, d) for uid, d in db.query(TimeEntry.user_id, TimeEntry.date).filter(
+                TimeEntry.tenant_id == current_user.tenant_id,  # F-026
+                TimeEntry.user_id.in_(_linked_user_ids),
+                TimeEntry.date >= data.start_date,
+                TimeEntry.date <= data.end_date,
+            ).all()
+        }
+
     _deleted_out_of_range = 0
     _deleted_for_resplit = 0
     for absence in linked:
         if absence.date not in workday_set:
             db.delete(absence)
             _deleted_out_of_range += 1
-        elif split_active and absence.user_id in _rebookable_user_ids:
+        elif (split_active and absence.user_id in _rebookable_user_ids
+                and (absence.user_id, absence.date) not in _worked_keys):
             # delete → re-created + re-split by the create helper below
             db.delete(absence)
             _deleted_for_resplit += 1

--- a/backend/app/routers/vacation_requests.py
+++ b/backend/app/routers/vacation_requests.py
@@ -81,6 +81,11 @@ def apply_vacation_request_patch(
     else:
         new_note = vr.note
     new_absence_type = data.absence_type if "absence_type" in fields_set and data.absence_type is not None else vr.absence_type
+    # Release-Review 1.18.2: half_day ist im Edit jetzt führbar (vorher gar nicht
+    # im Schema) — der Merge folgt dem Muster der übrigen Felder.
+    new_half_day = bool(
+        data.half_day if "half_day" in fields_set and data.half_day is not None else vr.half_day
+    )
 
     no_change = (
         new_date == vr.date
@@ -88,6 +93,7 @@ def apply_vacation_request_patch(
         and new_hours == round(float(vr.hours), 2)
         and (new_note or None) == (vr.note or None)
         and new_absence_type == vr.absence_type
+        and new_half_day == bool(vr.half_day)
     )
     if no_change:
         return _enrich(vr, db)
@@ -99,6 +105,16 @@ def apply_vacation_request_patch(
     # per workday — a PATCH must not be able to silently extend to an unbounded span.
     if (effective_end - new_date).days > 366:
         raise HTTPException(status_code=400, detail="Der Zeitraum darf maximal ein Jahr umfassen")
+    # Release-Review 1.18.2: dieselbe Einzeltag-Regel wie im Create-Schema
+    # (``validate_half_day_single_day``), hier gegen den EFFEKTIVEN Zustand.
+    # Ohne sie kam ein halber Tag über den Bearbeiten-Dialog zu einem Zeitraum,
+    # und die Genehmigung buchte JEDEN Werktag als halben Tag: 5 freie Tage für
+    # 2,5 Urlaubstage, an jedem Tag ein halbes Tagessoll unabgedeckt.
+    if new_half_day and effective_end != new_date:
+        raise HTTPException(
+            status_code=400,
+            detail="Halbe Tage sind nur für Einzeltage möglich",
+        )
     if target_user.first_work_day and new_date < target_user.first_work_day:
         raise HTTPException(status_code=400, detail="Datum liegt vor dem ersten Arbeitstag")
     if target_user.last_work_day and effective_end > target_user.last_work_day:
@@ -153,12 +169,12 @@ def apply_vacation_request_patch(
         # #196: tagebasiert prüfen (konsistent mit POST-Pfad / create_absence /
         # review_vacation_request). Der frühere remaining_hours-Check lief für
         # track_hours=False ins Leere (remaining_hours == 0 UND year_hours_needed
-        # == 0 → nie blockiert). half_day ist im Edit nicht änderbar → vr.half_day.
+        # == 0 → nie blockiert). half_day ist seit 1.18.2 im Edit änderbar → new_half_day.
         # R1-3: skip days with 0h target (e.g. Mo/Mi/Fr user — mirrors the
         # creation/approval loop which skips hours_for_day == 0). #431: der Modus
         # wird PRO TAG aufgeloest, nicht am Live-Flag gelesen (siehe
         # ``is_vacation_billable_day``, dort auch die track_hours=False-Ausnahme).
-        day_factor = 0.5 if vr.half_day else 1.0
+        day_factor = 0.5 if new_half_day else 1.0
         # Fix-Welle 4 #3: EINMAL je Anfrage laden statt je Tag eine Query in
         # ``is_vacation_billable_day`` (F-026: tenant-gefiltert).
         wh_changes = db.query(WorkingHoursChange).filter(
@@ -187,6 +203,7 @@ def apply_vacation_request_patch(
 
     vr.date = new_date
     vr.end_date = new_end_date
+    vr.half_day = new_half_day
     vr.hours = new_hours
     vr.note = new_note
     vr.absence_type = new_absence_type

--- a/backend/app/schemas/vacation_request.py
+++ b/backend/app/schemas/vacation_request.py
@@ -59,6 +59,12 @@ class VacationRequestUpdate(BaseModel):
     hours: Optional[float] = Field(None, ge=0, le=24)
     note: Optional[str] = None
     absence_type: Optional[str] = None
+    # Release-Review 1.18.2: half_day war hier bisher nicht führbar (extra="forbid"
+    # → 422). Die Flagge blieb beim Umbau auf einen Zeitraum still gesetzt, und die
+    # Genehmigung halbierte danach JEDEN Werktag der Spanne. Der Router prüft die
+    # Einzeltag-Invariante gegen den EFFEKTIVEN Wert (gemergt aus Payload + DB) —
+    # damit ist der Umbau auf einen Zeitraum möglich, aber nur mit half_day=False.
+    half_day: Optional[bool] = None
 
     @field_validator('absence_type')
     @classmethod

--- a/backend/app/services/ods_export_service.py
+++ b/backend/app/services/ods_export_service.py
@@ -329,7 +329,7 @@ def _monthly_sheet(doc, db, user, year, month, bold, normal, include_health_data
             for e in day_entries:
                 if e.sunday_exception_reason:
                     bem_parts.append(f"§10-Ausnahmegrund: {e.sunday_exception_reason}")
-                elif e.note:
+                if e.note:  # Release-Review 1.18.2: kein elif — sonst verschluckt der §10-Grund die Notiz (XLSX/PDF zeigen beides)
                     bem_parts.append(e.note)
             tr.addElement(_str_cell(" | ".join(bem_parts) if bem_parts else ""))
         elif is_holiday:
@@ -681,7 +681,7 @@ def _yearly_employee_sheet(doc, db, user, year, bold, include_health_data: bool 
             for e in day_entries:
                 if e.sunday_exception_reason:
                     bem_parts.append(f"§10-Ausnahmegrund: {e.sunday_exception_reason}")
-                elif e.note:
+                if e.note:  # Release-Review 1.18.2: kein elif — sonst verschluckt der §10-Grund die Notiz (XLSX/PDF zeigen beides)
                     bem_parts.append(e.note)
             tr.addElement(_str_cell(" | ".join(bem_parts) if bem_parts else ""))
         elif is_holiday:

--- a/backend/tests/test_admin_entry_date_change_keeps_raw.py
+++ b/backend/tests/test_admin_entry_date_change_keeps_raw.py
@@ -1,0 +1,142 @@
+"""Release-Review 1.18.2: eine reine DATUMS-Änderung durch den Admin darf den
+Rohstempel weder überschreiben noch die bereits gekappte Zeit ein zweites Mal
+kappen.
+
+``admin_update_time_entry`` fütterte ``work_window_service.clamp`` mit dem
+GESPEICHERTEN (also bereits gekappten) ``entry.start_time``. Bei einem PUT, das nur
+``date`` schickt, gilt der Eintrag trotzdem als zeitbetroffen (``_times_affected``)
+und die raw-Felder werden neu geschrieben — der echte Stempel wanderte damit auf
+den gekappten Wert und die angerechnete Zeit rutschte pro Datumsänderung weiter
+ins Soll-Fenster hinein.
+
+Warum das mehr als Kosmetik ist: ``raw_start_time``/``raw_end_time`` sind der
+§16-Nachweis der tatsächlichen Anwesenheit UND laut CLAUDE.md die Grundlage der
+§5-Ruhezeitprüfung (``rest_time_service`` liest ``raw_end_time or end_time``).
+Nach einer Datumskorrektur rechnete § 5 also gegen die geschönte Zeit.
+"""
+from datetime import date, time, timedelta
+
+import pytest
+
+from app.models import User, UserRole, TimeEntry
+from app.routers.admin_time_entries import admin_update_time_entry
+from app.schemas.time_entry import TimeEntryUpdate
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _next_weekday(target_weekday: int) -> date:
+    """Ein Datum in der Zukunft mit dem gewünschten Wochentag (0 = Montag)."""
+    d = date.today() + timedelta(days=7)
+    while d.weekday() != target_weekday:
+        d += timedelta(days=1)
+    return d
+
+
+@pytest.fixture
+def admin(db, default_tenant):
+    u = User(
+        username="adm_raw", email="adm_raw@t.de", password_hash="h",
+        first_name="A", last_name="D", role=UserRole.ADMIN, weekly_hours=40.0,
+        vacation_days=30, work_days_per_week=5, is_active=True,
+        tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture
+def employee(db, default_tenant):
+    # Soll-Fenster: Montag 08:00–16:00, Dienstag 10:00–18:00.
+    u = User(
+        username="emp_raw", email="emp_raw@t.de", password_hash="h",
+        first_name="E", last_name="M", role=UserRole.EMPLOYEE, weekly_hours=40.0,
+        vacation_days=30, work_days_per_week=5, is_active=True,
+        tenant_id=DEFAULT_TENANT_ID,
+        scheduled_start_monday=time(8, 0), scheduled_end_monday=time(16, 0),
+        scheduled_start_tuesday=time(10, 0), scheduled_end_tuesday=time(18, 0),
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def test_date_only_change_keeps_the_raw_stamp(db, default_tenant, admin, employee):
+    monday, tuesday = _next_weekday(0), _next_weekday(1)
+    # Mitarbeiter war ab 06:00 da; das Montags-Fenster (08:00, Puffer 15 min)
+    # kappte die Anrechnung auf 07:45, der Rohstempel hielt die 06:00 fest.
+    entry = TimeEntry(
+        user_id=employee.id, tenant_id=DEFAULT_TENANT_ID, date=monday,
+        start_time=time(7, 45), end_time=time(16, 15),
+        raw_start_time=time(6, 0), raw_end_time=time(18, 30),
+        break_minutes=30,
+    )
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+
+    # Der Admin korrigiert NUR das Datum (Eintrag gehörte auf den Dienstag).
+    admin_update_time_entry(
+        str(entry.id), TimeEntryUpdate(date=tuesday), db=db, current_user=admin,
+    )
+    db.refresh(entry)
+
+    assert entry.date == tuesday
+    # Der echte Stempel bleibt der echte Stempel.
+    assert entry.raw_start_time == time(6, 0)
+    assert entry.raw_end_time == time(18, 30)
+    # Angerechnet wird nach dem Fenster des NEUEN Tages (Di 10:00–18:00, 15 min
+    # Puffer) — gekappt aus dem Rohstempel, nicht aus der schon gekappten Zeit.
+    assert entry.start_time == time(9, 45)
+    assert entry.end_time == time(18, 15)
+
+
+def test_repeated_date_changes_do_not_walk_the_time_inward(db, default_tenant, admin, employee):
+    # Doppelkappung war kumulativ: jede weitere Datumsänderung schob die
+    # angerechnete Zeit ein Stück weiter ins Fenster und fror sie als „Rohwert" ein.
+    monday, tuesday = _next_weekday(0), _next_weekday(1)
+    entry = TimeEntry(
+        user_id=employee.id, tenant_id=DEFAULT_TENANT_ID, date=monday,
+        start_time=time(7, 45), end_time=time(16, 15),
+        raw_start_time=time(6, 0), raw_end_time=time(18, 30),
+        break_minutes=30,
+    )
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+
+    for target in (tuesday, monday, tuesday):
+        admin_update_time_entry(
+            str(entry.id), TimeEntryUpdate(date=target), db=db, current_user=admin,
+        )
+        db.refresh(entry)
+
+    assert entry.raw_start_time == time(6, 0)
+    assert entry.raw_end_time == time(18, 30)
+    assert entry.start_time == time(9, 45)
+    assert entry.end_time == time(18, 15)
+
+
+def test_explicit_time_change_still_sets_the_new_raw_stamp(db, default_tenant, admin, employee):
+    # Gegenprobe: schickt der Admin eine neue Zeit mit, ist SIE der neue
+    # Rohstempel — der alte darf nicht konserviert werden.
+    monday = _next_weekday(0)
+    entry = TimeEntry(
+        user_id=employee.id, tenant_id=DEFAULT_TENANT_ID, date=monday,
+        start_time=time(7, 45), end_time=time(16, 15),
+        raw_start_time=time(6, 0), raw_end_time=time(18, 30),
+        break_minutes=30,
+    )
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+
+    admin_update_time_entry(
+        str(entry.id), TimeEntryUpdate(start_time=time(6, 30)), db=db, current_user=admin,
+    )
+    db.refresh(entry)
+
+    assert entry.raw_start_time == time(6, 30)
+    assert entry.start_time == time(7, 45)

--- a/backend/tests/test_closure_overtime_split.py
+++ b/backend/tests/test_closure_overtime_split.py
@@ -240,6 +240,39 @@ class TestClosureOvertimeSplitUpdate:
             AbsenceType.VACATION, AbsenceType.VACATION, AbsenceType.OVERTIME, AbsenceType.OVERTIME,
         ]
 
+    def test_resave_keeps_absence_on_a_day_the_employee_worked(self, db, default_tenant, admin_client):
+        # Release-Review 1.18.2: der Re-Split-Löschzweig prüfte nur, WEN der
+        # Create-Helper wieder bucht (die Teilnehmermenge), nicht WELCHE TAGE er
+        # überspringt. Der Helfer lässt einen Tag mit gebuchter Arbeitszeit
+        # bewusst aus (#290: Arbeit gewinnt) — die Abwesenheit dort wurde also
+        # gelöscht und nie zurückgebucht, obwohl das Protokoll „werden neu
+        # gebucht" behauptet. Ausgelöst durch ein reines Umbenennen.
+        from datetime import time as _time
+
+        from app.models import TimeEntry
+
+        emp = _make_user(db, "e_worked", vacation_days=30)
+        _set_toggle(db, True)
+        c = _create_closure(admin_client)
+        # Nachträglich wird für einen Schließtag doch Arbeitszeit erfasst
+        # (Admin-Nachtrag, XLS-Import — kein Pfad verbietet das).
+        db.add(TimeEntry(user_id=emp.id, tenant_id=DEFAULT_TENANT_ID, date=TUE,
+                         start_time=_time(9, 0), end_time=_time(17, 0), break_minutes=30))
+        db.commit()
+
+        _update(admin_client, c["id"], counts_as_vacation=True, name="BF-umbenannt")
+
+        dates = [a.date for a in db.query(Absence).filter(
+            Absence.user_id == emp.id, Absence.closure_id == uuid.UUID(c["id"]),
+        ).order_by(Absence.date).all()]
+        # Alle vier Schließtage behalten ihre Abwesenheit — der Tag mit
+        # Arbeitszeit darf nicht gelöscht werden, denn der Create-Helper
+        # überspringt ihn und würde ihn nie zurückbuchen.
+        assert dates == [MON, TUE, WED, THU]
+        assert db.query(TimeEntry).filter(
+            TimeEntry.user_id == emp.id, TimeEntry.date == TUE,
+        ).count() == 1
+
     def test_untracked_employee_keeps_vacation_not_overtime(self, db, default_tenant, admin_client):
         # Review finding: an untracked MA (track_hours=False) has no overtime
         # account → the split must NOT apply (legacy VACATION), otherwise the
@@ -622,3 +655,34 @@ class TestClosureSpecialDays:
         assert r2.status_code == 200, r2.text
         absences = db.query(Absence).filter(Absence.user_id == emp.id).all()
         assert absences and all(a.end_date is None for a in absences)
+
+
+class TestClosureRangeBound:
+    """Release-Review 1.18.2: Spannen-Deckel wie im Urlaubsantrag."""
+
+    def test_create_rejects_span_over_one_year(self, db, default_tenant, admin_client):
+        # Betriebsferien loeschen beim Anlegen die Zeiteintraege ALLER
+        # Teilnehmenden pro Werktag — ein Tippfehler im Jahr darf nicht die
+        # gesamte rueckwirkende Zeiterfassung ausloeschen.
+        r = admin_client.post("/api/company-closures/", json={
+            "name": "Tippfehler", "start_date": "2026-12-24", "end_date": "2036-01-02",
+            "counts_as_vacation": True,
+        })
+        assert r.status_code == 400, r.text
+        assert "maximal ein Jahr" in r.json()["detail"]
+
+    def test_create_accepts_exactly_one_year(self, db, default_tenant, admin_client):
+        r = admin_client.post("/api/company-closures/", json={
+            "name": "Langes Jahr", "start_date": "2026-01-01", "end_date": "2027-01-01",
+            "counts_as_vacation": True,
+        })
+        assert r.status_code == 201, r.text
+
+    def test_update_rejects_span_over_one_year(self, db, default_tenant, admin_client):
+        c = _create_closure(admin_client)
+        r = admin_client.put(f"/api/company-closures/{c['id']}", json={
+            "name": "BF", "start_date": MON.isoformat(), "end_date": "2036-01-02",
+            "counts_as_vacation": True,
+        })
+        assert r.status_code == 400, r.text
+        assert "maximal ein Jahr" in r.json()["detail"]

--- a/backend/tests/test_half_day_validation.py
+++ b/backend/tests/test_half_day_validation.py
@@ -65,3 +65,98 @@ def test_vacation_request_half_day_rejects_multiday():
 def test_vacation_request_half_day_accepts_single_day():
     vr = VacationRequestCreate(date=date(2026, 3, 2), hours=8, half_day=True)
     assert vr.half_day is True
+
+
+# --- Release-Review 1.18.2: dieselbe Regel im PATCH-Pfad -----------------------
+#
+# Die Einzeltag-Regel lebte nur in den Create-Schemas. `VacationRequestUpdate`
+# kannte `half_day` gar nicht, also blieb die Flagge beim Umbau eines
+# Halbtags-Antrags in einen Zeitraum still gesetzt — und die Genehmigung
+# halbierte anschließend JEDEN Werktag des Zeitraums: 5 freie Tage kosteten
+# 2,5 Urlaubstage, und an jedem Tag blieb ein halbes Tagessoll unabgedeckt
+# stehen (dauerhaftes Minus im Überstundenkonto, widersprüchlicher §16-Beleg).
+# Erreichbar ohne Admin: Antrag mit „halber Tag" anlegen, dann im
+# Bearbeiten-Dialog „Zeitraum (mehrere Tage)" setzen.
+
+from datetime import date as _d, timedelta as _td
+
+import pytest
+from fastapi import HTTPException
+
+from app.models import User, UserRole, VacationRequest
+from app.models.vacation_request import VacationRequestStatus
+from app.routers.vacation_requests import apply_vacation_request_patch
+from app.schemas.vacation_request import VacationRequestUpdate
+from tests.conftest import DEFAULT_TENANT_ID
+
+
+def _emp(db):
+    u = User(
+        username="hd_emp", email="hd_emp@t.de", password_hash="h",
+        first_name="H", last_name="D", role=UserRole.EMPLOYEE, weekly_hours=40.0,
+        vacation_days=30, work_days_per_week=5, is_active=True,
+        tenant_id=DEFAULT_TENANT_ID,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _half_day_request(db, user):
+    monday = _d(2026, 9, 14)
+    vr = VacationRequest(
+        user_id=user.id, tenant_id=DEFAULT_TENANT_ID, date=monday, end_date=None,
+        hours=4.0, half_day=True, status=VacationRequestStatus.PENDING.value,
+        absence_type="VACATION",
+    )
+    db.add(vr)
+    db.commit()
+    db.refresh(vr)
+    return vr
+
+
+def test_patch_cannot_turn_a_half_day_request_into_a_range(db, default_tenant):
+    user = _emp(db)
+    vr = _half_day_request(db, user)
+
+    with pytest.raises(HTTPException) as exc:
+        apply_vacation_request_patch(
+            db, vr,
+            VacationRequestUpdate(end_date=vr.date + _td(days=4)),
+            target_user=user, acting_user=user,
+        )
+    assert exc.value.status_code == 400
+    assert "Einzeltag" in exc.value.detail
+    db.refresh(vr)
+    assert vr.end_date is None
+    assert vr.half_day is True
+
+
+def test_patch_may_clear_half_day_together_with_the_range(db, default_tenant):
+    # Der ehrliche Weg zum Zeitraum: die Halbtags-Flagge im selben PATCH löschen.
+    user = _emp(db)
+    vr = _half_day_request(db, user)
+
+    apply_vacation_request_patch(
+        db, vr,
+        VacationRequestUpdate(end_date=vr.date + _td(days=4), half_day=False, hours=8.0),
+        target_user=user, acting_user=user,
+    )
+    db.refresh(vr)
+    assert vr.half_day is False
+    assert vr.end_date == _d(2026, 9, 18)
+
+
+def test_patch_keeps_half_day_on_a_single_day_edit(db, default_tenant):
+    user = _emp(db)
+    vr = _half_day_request(db, user)
+
+    apply_vacation_request_patch(
+        db, vr,
+        VacationRequestUpdate(date=vr.date + _td(days=1)),
+        target_user=user, acting_user=user,
+    )
+    db.refresh(vr)
+    assert vr.half_day is True
+    assert vr.date == _d(2026, 9, 15)

--- a/docs/BUILD-RELEASE.md
+++ b/docs/BUILD-RELEASE.md
@@ -18,6 +18,14 @@ bash tools/validate-release.sh                 # Linux-Tarball: Docker-Smoke geg
 
 **Build-Release-Frontend + Host-Node:** `build-release.sh` ruft intern `npm run build` (Schritt 3) — bricht mit Host-Node ≥26. Frontend vorher mit `docker run --rm -v $(pwd)/frontend:/app -w /app node:20-alpine sh -c "npm run build"` bauen und dann mit `--skip-frontend` releasen (`dist/` muss existieren).
 
+**Abgebrochener Download → mit `--skip-download` weitermachen, nicht ohne** (1.18.2): `download()` greift auf `build/cache/` nur zu, wenn `SKIP_DOWNLOAD=true` gesetzt ist. Reißt ein Download ab (real passiert: `curl: (56) Connection died` beim Windows-Python von GitHub, nach 5 Versuchen Abbruch), lädt ein nackter Neustart alle rund 600 MB erneut. Stattdessen die eine fehlende Datei gezielt nachholen und dann aus dem Cache bauen:
+
+```bash
+curl -fSL --retry 10 --retry-all-errors --retry-delay 5 \
+  -o build/cache/python-windows-x64.tar.gz "<URL aus PYTHON_WINDOWS_URL>"
+bash tools/build-release.sh --skip-frontend --skip-download
+```
+
 **Frontend-Dep-Bumps — vite/plugin-react im Gleichschritt (1.8.9):** Ein Dependabot-`vite`-Major-Bump (z. B. 7→8) ohne passenden `@vitejs/plugin-react`-Bump bricht `npm ci` mit `ERESOLVE` — plugin-react **5.1.4** kennt als Peer nur `vite ≤7`, **5.2.0+** ergänzt `vite 8` (6.0+ ist vite-8-only). Beim vite-Major immer plugin-react mitziehen + `npm ci` lokal verifizieren. Frontend-`Dockerfile` nutzt jetzt `npm ci` (scheitert hart bei Lock-Drift, statt still abweichend zu bauen). `npm update` kann auf Windows am optionalen `@tailwindcss/oxide-wasm32-wasi` (ENOENT-Cleanup) hängen → `rm -rf node_modules && npm install` oder `--package-lock-only`.
 
 **Native-PG = `theseus-rs` 18.4.0** (ab 1.10.0; davor 16.13.0 — glibc-2.34-portabel: Ubuntu 22.04+/Debian 12+/RHEL·Rocky·Alma 9+/Fedora 35+; EDB-Quelle seit #125 raus, Build bricht bei glibc-Symbolen > 2.34 ab). **PG16→18-Major-Upgrade (nicht in-place):** `install.sh` dumpt vor dem Binary-Tausch mit den ALTEN Binaries, legt `data/db` als `data/db.pgXX-<ts>` zur Seite (nie gelöscht) + Marker `data/.pg-upgrade-restore`; `praxiszeit-server.py::_restore_pending_major_upgrade()` spielt den Dump in den frischen PG18-Cluster (`psql -f -v ON_ERROR_STOP=1`, streamend). Docker-Pendant: `tools/docker/update-pg-major.sh` (backup → nur `*_postgres_data`-Volume weg → frischer PG18 → restore). PG18-Docker-Image braucht `PGDATA=/var/lib/postgresql/data` (sonst Major-Unterordner). PG-Downloads SHA256-verifiziert, macOS zusätzlich per `file(1)` als Mach-O geprüft. ⚠️ `validate-macos.yml` läuft auf dem Privat-Repo **NIE** (Runs `queued`) → macOS-Release stützt sich auf die lokale Mach-O-Prüfung im Build, NICHT auf den GH-Workflow; echtes macOS-`initdb`-Smoke ggf. manuell auf einem Mac. `tools/validate-release.sh` (Linux) muss vor jedem Release grün sein. Hintergrund (EDB-403, 1.5.0-DMG-Pattern) → [docs/INSTALL-NATIVE.md](INSTALL-NATIVE.md).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -82,6 +82,21 @@ nano .env
 | `PRACTICE_NAME` / `PRACTICE_ADDRESS` | Erscheint in Excel-Exporten (DSGVO) |
 | `HOLIDAY_STATE` | Bundesland für Feiertage (z. B. `Bayern`) |
 | `CORS_ORIGINS` / `ALLOWED_HOSTS` | Eigene Domain statt `localhost` (bei Internet-Zugriff) |
+| `COOKIE_SECURE` | **Bei HTTP-Betrieb auf `false` setzen** (siehe Kasten unten) |
+
+> **Wichtig bei HTTP (Schritt 4 unten startet ohne HTTPS):** `generate-secrets.sh`
+> setzt `ENVIRONMENT=production`, und damit bleibt `COOKIE_SECURE` auf `true`.
+> Der Browser sendet ein `Secure`-Cookie über eine reine HTTP-Verbindung aber
+> nicht — das Refresh-Cookie kommt nie an, und jeder Seiten-Reload bzw.
+> spätestens der Ablauf nach 30 Minuten wirft alle Nutzer:innen auf die
+> Anmeldeseite zurück. Deshalb bei HTTP-Betrieb in die `.env` eintragen:
+>
+> ```
+> COOKIE_SECURE=false
+> ```
+>
+> Sobald Sie auf HTTPS umstellen (Abschnitt „HTTPS aktivieren"), gehört der Wert
+> wieder auf `true`.
 
 > **Wichtig (seit RLS-Umbau):** Die `.env` braucht zusätzlich
 > `APP_DB_USER`/`APP_DB_PASSWORD`, `ENVIRONMENT` und `CORS_ORIGINS`. Eine alte,
@@ -193,6 +208,9 @@ docker compose down
 docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d
 ```
 
+> Mit HTTPS gehört `COOKIE_SECURE` in der `.env` wieder auf `true` (Default) —
+> hatten Sie es für den HTTP-Betrieb auf `false` gesetzt, jetzt zurückstellen.
+
 ### Schritt 3: Firewall anpassen
 
 ```bash
@@ -218,6 +236,9 @@ Diese Warnung erscheint nur einmalig pro Browser/Geraet. Danach ist die Verbindu
 docker compose down
 docker compose up -d
 ```
+
+> Auch hier wieder `COOKIE_SECURE=false` in der `.env` — sonst bleibt der Login
+> über HTTP an der Anmeldeseite hängen.
 
 ---
 

--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -165,7 +165,7 @@ Klicken Sie auf **„Neuer Mitarbeiter:in"** und füllen Sie das Formular aus:
 | **Benutzername** | Eindeutiger Login-Name (z. B. `m.hoffmann`) |
 | **Passwort** | Initiales Passwort (mind. 10 Zeichen, Groß-/Kleinbuchstabe, Ziffer) |
 | **Rolle** | Mitarbeiter:in oder Admin |
-| **Wochenstunden** | Vertraglich vereinbarte Wochenstunden (Standard: 40), direkt eingegeben in halben Stunden. Bei individuellen Tagesstunden (Viertelstunden je Wochentag möglich) übernimmt das System die Wochenstunden automatisch als Summe der Tageswerte – der Eingabewert im Feld selbst spielt dann keine Rolle. |
+| **Wochenstunden** | Vertraglich vereinbarte Wochenstunden (Standard: 40), direkt eingegeben in Viertelstunden-Schritten (z. B. 20,25). Bei individuellen Tagesstunden (ebenfalls Viertelstunden je Wochentag) übernimmt das System die Wochenstunden automatisch als Summe der Tageswerte – der Eingabewert im Feld selbst spielt dann keine Rolle. |
 | **Arbeitstage pro Woche** | Anzahl der Arbeitstage 1–7 (Standard: 5). Bestimmt den anteiligen Urlaubsvorschlag. |
 | **Urlaubstage** | Jährlicher Urlaubsanspruch in **Tagen**. Vorschlag anteilig nach Arbeitstagen: `30 × Arbeitstage ÷ 5` (5 Tage → 30, 3 Tage → 18). Überschreibbar. |
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4309,9 +4309,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6523,6 +6523,16 @@
         "node": ">=20"
       }
     },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/jsdom/node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -7082,9 +7092,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -8690,16 +8700,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.18.1",
+  "version": "1.18.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "brace-expansion": ">=5.0.7",
     "lodash": ">=4.18.0",
     "follow-redirects": ">=1.16.0",
-    "undici": ">=8.10.0",
+    "undici": ">=7.29.0 <8",
     "js-yaml": ">=5.2.3",
     "fast-uri": ">=4.1.2"
   },

--- a/frontend/public/help/HANDBUCH-ADMIN.md
+++ b/frontend/public/help/HANDBUCH-ADMIN.md
@@ -165,7 +165,7 @@ Klicken Sie auf **„Neuer Mitarbeiter:in"** und füllen Sie das Formular aus:
 | **Benutzername** | Eindeutiger Login-Name (z. B. `m.hoffmann`) |
 | **Passwort** | Initiales Passwort (mind. 10 Zeichen, Groß-/Kleinbuchstabe, Ziffer) |
 | **Rolle** | Mitarbeiter:in oder Admin |
-| **Wochenstunden** | Vertraglich vereinbarte Wochenstunden (Standard: 40), direkt eingegeben in halben Stunden. Bei individuellen Tagesstunden (Viertelstunden je Wochentag möglich) übernimmt das System die Wochenstunden automatisch als Summe der Tageswerte – der Eingabewert im Feld selbst spielt dann keine Rolle. |
+| **Wochenstunden** | Vertraglich vereinbarte Wochenstunden (Standard: 40), direkt eingegeben in Viertelstunden-Schritten (z. B. 20,25). Bei individuellen Tagesstunden (ebenfalls Viertelstunden je Wochentag) übernimmt das System die Wochenstunden automatisch als Summe der Tageswerte – der Eingabewert im Feld selbst spielt dann keine Rolle. |
 | **Arbeitstage pro Woche** | Anzahl der Arbeitstage 1–7 (Standard: 5). Bestimmt den anteiligen Urlaubsvorschlag. |
 | **Urlaubstage** | Jährlicher Urlaubsanspruch in **Tagen**. Vorschlag anteilig nach Arbeitstagen: `30 × Arbeitstage ÷ 5` (5 Tage → 30, 3 Tage → 18). Überschreibbar. |
 

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.18.1"
+APP_VERSION="1.18.2"
 PYTHON_VERSION="3.13.13"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes


### PR DESCRIPTION
PATCH-Release 1.18.2. Enthält den Bug-Tracker-Nachzug aus 1.18.1 (bereits auf master), die Dependency-Sicherheitsfixes und fünf bestätigte Funde aus dem Release-Review.

## Abhängigkeiten

Der Dependabot-Override aus #446 (`undici: >=8.10.0`) zog undici 8 in den Baum. jsdom lädt undici beim Start und ruft dort `webidl.util.markAsUncloneable` — eine API, die Node 20 nicht hat. Folge: jeder vitest-Worker starb beim Hochfahren, die Suite meldete „Test Files no tests" bei 30 unhandled errors und lief als grün durch, **ohne eine einzige Zusicherung zu prüfen**. undici ist hier reine Test-/Build-Abhängigkeit (jsdom), kein Bestandteil des ausgelieferten Bundles; die Advisories sind ab 7.29.0 behoben → Override auf `>=7.29.0 <8`. Dazu brace-expansion 5.0.9 und nanoid 3.3.18 (beide Build-Zeit).

`npm audit`: 0 Schwachstellen. `pip-audit` (Backend): keine bekannten Lücken.

## Review-Funde (5-Lane-Review, jeder Fund adversarisch gegengeprüft)

**M1 — Betriebsferien-Neuspeichern löschte Schließtage mit Arbeitszeit ersatzlos.** Der Löschzweig des #314-Re-Splits klärte, WEN der Create-Helper wieder bucht (Teilnehmermenge, Release-Review 1.16.0), nicht WELCHE TAGE er überspringt: er lässt jeden Tag mit vorhandenem Zeiteintrag aus (#290, „Arbeit gewinnt"). Ein reines Umbenennen genügte, um den Urlaubstag verschwinden zu lassen — protokolliert als „werden neu gebucht". Betroffene Zeilen bleiben jetzt stehen und werden nur in-place synchronisiert.

**M2 — Reine Datumsänderung durch den Admin überschrieb den Rohstempel.** `clamp` bekam die bereits gekappte Zeit als Eingabe → zweite Kappung, und `raw_start_time`/`raw_end_time` wurden mit dem gekappten Wert überschrieben. Der Rohstempel ist der §16-Nachweis der tatsächlichen Anwesenheit und die Grundlage der §5-Ruhezeitprüfung — danach rechnete §5 gegen die geschönte Zeit und ein echter Verstoß blieb unentdeckt. Rückfallwert ist jetzt der Rohwert.

**M3 — `half_day` fehlte in `VacationRequestUpdate`.** Ein Halbtags-Antrag ließ sich im Bearbeiten-Dialog zum Zeitraum umbauen, die Flagge blieb still gesetzt, und die Genehmigung halbierte JEDEN Werktag: fünf freie Tage für 2,5 Urlaubstage, an jedem Tag ein halbes Tagessoll unabgedeckt. Feld jetzt führbar, Einzeltag-Invariante gegen den effektiven Zustand geprüft.

**M4 — Betriebsferien waren der einzige Spannen-Pfad ohne Obergrenze**, dabei der destruktivste (löschen beim Anlegen die Zeiteinträge aller Teilnehmenden pro Werktag). Jetzt dieselben 366 Tage wie im Urlaubsantrag.

**M5 — INSTALLATION.md** führte durch eine reine HTTP-Installation ohne `COOKIE_SECURE=false`. Das Secure-Cookie kommt über HTTP nie an → jeder Reload landet auf /login. Hinweis an drei Stellen ergänzt.

**L1 — ODS-Export** verschluckte am Wochenende die MA-Bemerkung, sobald ein §10-Ausnahmegrund erfasst war (`elif` statt `if`); XLSX und PDF zeigten beides.
**L2 — Admin-Handbuch** beschrieb die Wochenstunden-Eingabe als Halbstunden-Schritt — genau das hat dieser Release auf Viertelstunden umgestellt. Datei + `public/help`-Mirror nachgezogen.

Bewusst offen (LOW, als Issues nachgezogen): N+1 beim Vertrags-Snapshot in Export-Tagesschleifen, Enroll-Pfad ohne Kalender-Re-Split, 500-statt-409 bei einem Qualifikations-Rennen, fehlende `max_length` in Schichtplanungs-Schemas.

## Prüfung

| Gate | Ergebnis |
|---|---|
| Backend-Suite (SQLite) | 2051 passed, 49 skipped |
| Postgres-Integration | 44 passed (RLS 20 + Concurrency 12 + Art.-17-Purge 12) |
| Frontend | tsc sauber, vitest 323/30, eslint 0, vite build ok |
| Artefakte | 6/6, SHA256SUMS ok, Windows-ZIP ohne `setup.exe`, PG-Installer-SHA == Pin (18.4), gebündelte `updater.py` = 1.18.2 |
| validate-release | 5/5 Distros (Ubuntu 22/24, Debian 12, Rocky 9, Arch), postgres+initdb 18.4 |
| Docker-Update lokal | 1.18.1 → 1.18.2, Health 200, Alembic head, **DB über 26 Tabellen identisch**, Login + Exporte 200 |
| .131 nativ (Update) | Dienst aktiv, 1.18.2, HTTPS-Login 200, **DB identisch** |
| .131 Docker (Update) | 1.18.2, Alembic head, Login 200, **DB identisch** |
| Windows-Emulator | Install grün, HEALTH/LOGIN 200, nach Neustart erneut 200, Alembic head, psql 18.4, ACL-Härtung inkl. Selbstreparatur |
| Browser-Smoke gegen das Release-Bundle | Login, Farbkacheln ohne Überlappung (per boundingBox), `step=0.25` |

Keine neuen Alembic-Migrationen (head bleibt `069_weekly_hours_precision`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
