### PR TITLE
release: 1.19.0

### DIFF
--- a/backend/app/cli/reset_admin_password.py
+++ b/backend/app/cli/reset_admin_password.py
@@ -13,7 +13,13 @@ Dieses Modul ist er.
 
 Aufruf ueber den Prozessmanager::
 
-    sudo praxiszeit-server.py reset-admin-password [--username admin] [--disable-2fa]
+    # nativ (der volle Pfad ist noetig: nicht im PATH, und die App-Abhaengigkeiten
+    # liegen nur im mitgelieferten Interpreter):
+    sudo -u praxiszeit /opt/praxiszeit/bin/python/bin/python3 \\
+         /opt/praxiszeit/praxiszeit-server.py reset-admin-password [--username admin] [--disable-2fa]
+
+    # unter Docker steckt dasselbe Werkzeug im Backend-Abbild:
+    docker compose exec backend python -m app.cli.reset_admin_password [--disable-2fa]
 
 Eigenschaften:
 

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -32,7 +32,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.18.2"
+APP_VERSION = "1.19.0"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/routers/admin_users.py
+++ b/backend/app/routers/admin_users.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 from app.services.timezone_service import today_local
 from app.database import get_db
 from app.models import User, TimeEntry, Absence, AbsenceReason, WorkingHoursChange, ChangeRequest, VacationRequest, TimeEntryAuditLog, UserRole, PublicHoliday
+from app.models.security_event import SecurityEvent
 from app.services.date_filters import date_in_year
 from app.middleware.auth import require_admin
 from app.schemas.user import UserCreate, UserUpdate, UserResponse, UserCreateResponse, AdminSetPassword, UserListResponse
@@ -738,6 +739,17 @@ def anonymize_user(
         WorkingHoursChange.note.isnot(None),
     ).update({WorkingHoursChange.note: None}, synchronize_session=False)
 
+    # Release-Review 1.19.0: ``security_events.detail`` nennt das Konto im
+    # Klartext ("... (Konto admin)"). Die ZEILE bleibt (Art.-5(2)-Nachweis, wer
+    # wann dieses Konto uebernommen hat), der Freitext geht — Ereignis,
+    # handelndes Betriebssystem-Konto und Zeitpunkt tragen den Nachweis auch
+    # ohne den Namen.
+    db.query(SecurityEvent).filter(
+        SecurityEvent.subject_user_id == user.id,
+        SecurityEvent.tenant_id == current_user.tenant_id,  # F-026
+        SecurityEvent.detail.isnot(None),
+    ).update({SecurityEvent.detail: None}, synchronize_session=False)
+
     # #440 A/B: Die Antraege dieser Person tragen ihre eigene Prosa —
     # ``change_requests.reason`` ist NOT NULL und regelmaessig gesundheits- oder
     # adressnah ("Arzttermin wegen ...", "Kind in der Kita abgeholt"), dazu die
@@ -897,6 +909,16 @@ def purge_user(
         ChangeRequest.reviewed_by == user.id,
         ChangeRequest.tenant_id == current_user.tenant_id,
     ).update({ChangeRequest.reviewed_by: None}, synchronize_session=False)
+    # Release-Review 1.19.0: ``security_events.subject_user_id`` ist ON DELETE
+    # SET NULL — die Zeile ueberlebt den Hard-Delete also (so gewollt: sie
+    # belegt, wer wann dieses Konto uebernommen hat). Ihr ``detail`` nennt aber
+    # den Benutzernamen im Klartext, und den soll die Endloeschung gerade
+    # entfernen. Vor dem Loeschen schrubben, solange die Zuordnung noch steht.
+    db.query(SecurityEvent).filter(
+        SecurityEvent.subject_user_id == user.id,
+        SecurityEvent.tenant_id == current_user.tenant_id,  # F-026
+        SecurityEvent.detail.isnot(None),
+    ).update({SecurityEvent.detail: None}, synchronize_session=False)
     db.query(TimeEntry).filter(TimeEntry.user_id == user.id, TimeEntry.tenant_id == current_user.tenant_id).delete(synchronize_session=False)
     db.query(Absence).filter(Absence.user_id == user.id, Absence.tenant_id == current_user.tenant_id).delete(synchronize_session=False)
     # #305 Schichtplanung: shift_plans.created_by is NOT NULL with no ON DELETE

--- a/backend/app/routers/shift_planning.py
+++ b/backend/app/routers/shift_planning.py
@@ -89,14 +89,28 @@ class LocationIn(BaseModel):
     # varchar-Längen und fängt das nie — dasselbe Muster wie bei
     # time_entry_audit_logs.source.
     name: str = Field(..., min_length=1, max_length=255)
-    sort_order: int = 0
+    # Release-Review 1.19.0: Obergrenze noetig. Die Spalte ist ``integer``; ein
+    # Wert jenseits von 2^31 bricht erst beim COMMIT ab (psycopg2
+    # NumericValueOutOfRange) — ``_commit_or_conflict`` faengt nur
+    # IntegrityError, es gibt keinen DataError-Handler, also HTTP 500 statt
+    # 422. Dieselbe Fehlerklasse, die #450 fuer die Namensfelder geschlossen
+    # hat; die Zahlenfelder blieben ungebunden. SQLite ignoriert das und faengt
+    # es nie.
+    sort_order: int = Field(0, ge=0, le=100000)
 
 
 class WorkstationIn(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)  # #450
     location_id: Optional[UUID] = None
     color: Optional[str] = None
-    sort_order: int = 0
+    # Release-Review 1.19.0: Obergrenze noetig. Die Spalte ist ``integer``; ein
+    # Wert jenseits von 2^31 bricht erst beim COMMIT ab (psycopg2
+    # NumericValueOutOfRange) — ``_commit_or_conflict`` faengt nur
+    # IntegrityError, es gibt keinen DataError-Handler, also HTTP 500 statt
+    # 422. Dieselbe Fehlerklasse, die #450 fuer die Namensfelder geschlossen
+    # hat; die Zahlenfelder blieben ungebunden. SQLite ignoriert das und faengt
+    # es nie.
+    sort_order: int = Field(0, ge=0, le=100000)
 
     @field_validator("color")
     @classmethod
@@ -129,7 +143,10 @@ class SlotIn(BaseModel):
     weekday: int
     start_time: time
     end_time: time
-    min_staff: int = 0
+    # Release-Review 1.19.0: ``shift_slots.min_staff`` ist auf PostgreSQL
+    # ``smallint`` — 99999 bricht beim COMMIT ab und ergab HTTP 500 (live
+    # nachgestellt). Die Obergrenze ersetzt den reinen Negativ-Validator unten.
+    min_staff: int = Field(0, ge=0, le=999)
     # #443: freier Hinweis je Einteilung ("Einarbeitung Azubi"). Die Spalte ist
     # TEXT, die Grenze steht am Rand — 500 Zeichen sind reichlich für einen
     # Hinweis und halten Zelle und PDF lesbar.
@@ -140,13 +157,6 @@ class SlotIn(BaseModel):
     def _weekday_range(cls, v: int) -> int:
         if not 0 <= v <= 6:
             raise ValueError("weekday muss zwischen 0 (Montag) und 6 (Sonntag) liegen")
-        return v
-
-    @field_validator("min_staff")
-    @classmethod
-    def _min_staff_nonneg(cls, v: int) -> int:
-        if v < 0:
-            raise ValueError("Mindestbesetzung darf nicht negativ sein")
         return v
 
     @field_validator("note")

--- a/backend/app/services/lifecycle_service.py
+++ b/backend/app/services/lifecycle_service.py
@@ -45,6 +45,7 @@ from app.models import (
     VacationRequest,
     WorkingHoursChange,
 )
+from app.models.security_event import SecurityEvent
 from app.models.shift_planning import ShiftPlan, ShiftSlot
 from app.models.tenant import Tenant
 
@@ -242,6 +243,9 @@ def anonymize_tenant(db: Session, tenant: Tenant, *, commit: bool = True) -> Non
     - ``vacation_requests``: ``note``/``rejection_reason`` -> NULL (#440 B).
     - ``absences``: ``note`` -> NULL (#440 D). Nur hier — der Einzel-Nutzer-Pfad
       loescht die Abwesenheiten vollstaendig.
+    - ``security_events``: ``detail`` -> NULL (Release-Review 1.19.0; der
+      Freitext nennt das Konto im Klartext, die Zeile selbst bleibt als
+      Art.-5(2)-Nachweis stehen).
 
     **Bewusst NICHT geleert (#440 C):** ``time_entries.note``,
     ``sunday_exception_reason`` und ``break_waiver_reason`` auf dem Zeiteintrag.
@@ -295,6 +299,19 @@ def anonymize_tenant(db: Session, tenant: Tenant, *, commit: bool = True) -> Non
         ShiftSlot.tenant_id == tenant.id,  # F-026
         ShiftSlot.note.isnot(None),
     ).update({ShiftSlot.note: None}, synchronize_session=False)
+
+    # Release-Review 1.19.0: ``security_events.detail`` nennt das betroffene Konto
+    # im Klartext ("... (Konto admin)"). Die ZEILE muss bleiben — sie ist der
+    # Nachweis nach Art. 5 Abs. 2, wer wann ein Konto uebernommen hat —, ihr
+    # Freitext nicht: Ereignis, handelndes Betriebssystem-Konto und Zeitpunkt
+    # tragen den Nachweis auch ohne den Namen, und ``subject_user_id`` verweist
+    # ohnehin auf die (dann anonymisierte) Zeile. Ohne diesen Schritt ueberlebt
+    # der Benutzername die Loeschung — genau die Klasse Rest, die #440 fuer die
+    # Antraege geschlossen hat.
+    db.query(SecurityEvent).filter(
+        SecurityEvent.tenant_id == tenant.id,  # F-026
+        SecurityEvent.detail.isnot(None),
+    ).update({SecurityEvent.detail: None}, synchronize_session=False)
 
     # #440 A/B/D: Freitext der Antraege. ``change_requests.reason`` ist Prosa der
     # Beschaeftigten und regelmaessig gesundheits- oder adressnah ("Arzttermin

--- a/backend/tests/test_425_reset_admin_password.py
+++ b/backend/tests/test_425_reset_admin_password.py
@@ -159,3 +159,28 @@ def test_mehrdeutiger_name_bricht_ab(run_cli, db):
     with pytest.raises(SystemExit) as exc:
         run_cli(["--username", "admin"])
     assert exc.value.code == 1
+
+
+# ── Release-Review 1.19.0 ────────────────────────────────────────────────────
+
+
+def test_protokollzeile_verliert_den_kontonamen_bei_der_anonymisierung(run_cli, db):
+    """Art. 17: ``security_events.detail`` nennt das Konto im Klartext. Die
+    ZEILE muss den Vorgang weiter belegen (Art. 5 Abs. 2), der Name nicht."""
+    from app.routers import admin_users
+    from app.services import lifecycle_service  # noqa: F401 — Doku des Zwillingspfads
+
+    u = _user(db)
+    run_cli(["--username", "admin"])
+    assert db.query(SecurityEvent).filter(SecurityEvent.detail.isnot(None)).count() == 1
+
+    u.is_active = False
+    u.deactivated_at = None
+    db.commit()
+    admin = _user(db, username="chefin", role=UserRole.ADMIN)
+    admin_users.anonymize_user(str(u.id), db=db, current_user=admin)
+
+    zeile = db.query(SecurityEvent).filter(SecurityEvent.subject_user_id == u.id).one()
+    assert zeile.detail is None          # Klarname weg
+    assert zeile.event == EVENT_ADMIN_PASSWORD_RESET  # Vorgang bleibt belegt
+    assert zeile.actor.startswith("cli:")

--- a/backend/tests/test_shift_planning_limits.py
+++ b/backend/tests/test_shift_planning_limits.py
@@ -11,7 +11,15 @@
 import pytest
 from pydantic import ValidationError
 
-from app.routers.shift_planning import LocationIn, PlanDuplicateIn, PlanIn, WorkstationIn
+from app.routers.shift_planning import (
+    LocationIn,
+    PlanDuplicateIn,
+    PlanIn,
+    SlotIn,
+    WorkstationIn,
+)
+
+_WS = "11111111-2222-4333-8444-555555555555"
 
 _TOO_LONG = "x" * 256
 
@@ -86,3 +94,42 @@ def test_qualification_conflict_becomes_409(db, default_tenant, monkeypatch):
             target.id, sp.QualificationsIn(workstation_ids=[]), db=db, current_user=admin,
         )
     assert exc.value.status_code == 409
+
+
+# ── Release-Review 1.19.0: dieselbe Klasse, aber die ZAHLENfelder ───────────
+# #450 hat die Namensfelder gebunden und die Zahlen uebersehen. Beides bricht
+# auf PostgreSQL erst beim COMMIT ab: ``_commit_or_conflict`` faengt nur
+# IntegrityError, einen DataError-Handler gibt es nicht — also HTTP 500 statt
+# 422. Live nachgestellt mit min_staff=99999 und sort_order=3000000000.
+
+
+def test_min_staff_ist_nach_oben_gebunden():
+    """``shift_slots.min_staff`` ist auf PostgreSQL ``smallint``."""
+    SlotIn(workstation_id=_WS, weekday=0, start_time="08:00", end_time="12:00", min_staff=999)
+    with pytest.raises(ValidationError):
+        SlotIn(workstation_id=_WS, weekday=0, start_time="08:00", end_time="12:00",
+               min_staff=99999)
+
+
+def test_min_staff_bleibt_nach_unten_gebunden():
+    """Der frühere Negativ-Validator ist durch ge=0 ersetzt — die Regel bleibt."""
+    with pytest.raises(ValidationError):
+        SlotIn(workstation_id=_WS, weekday=0, start_time="08:00", end_time="12:00",
+               min_staff=-1)
+
+
+@pytest.mark.parametrize("model", [LocationIn, WorkstationIn])
+def test_sort_order_ist_gebunden(model):
+    """``sort_order`` ist ``integer`` (2^31)."""
+    model(name="ok", sort_order=100000)
+    with pytest.raises(ValidationError):
+        model(name="ok", sort_order=3000000000)
+    with pytest.raises(ValidationError):
+        model(name="ok", sort_order=-1)
+
+
+def test_uebliche_werte_bleiben_erlaubt():
+    """Kontrolle: die Grenzen duerfen den Normalbetrieb nicht einengen."""
+    SlotIn(workstation_id=_WS, weekday=1, start_time="08:00", end_time="12:00", min_staff=3)
+    LocationIn(name="Hauptstelle", sort_order=10)
+    WorkstationIn(name="Tresen", sort_order=0)

--- a/backend/tests/test_tenant_anonymization.py
+++ b/backend/tests/test_tenant_anonymization.py
@@ -68,6 +68,7 @@ from app.models import (
     VacationRequest,
     WorkingHoursChange,
 )
+from app.models.security_event import SecurityEvent
 from app.models.shift_planning import ShiftPlan, ShiftSlot, Workstation
 from app.models.tenant import Tenant
 from app.services import auth_service, lifecycle_service, signup_service
@@ -131,6 +132,8 @@ PII = {
     "vr_note": "PIIURLAUBSNOTIZAAA",
     "vr_rejection": "PIIURLAUBSABLEHNUNGAAA",
     "absence_note": "PIIABWESENHEITSNOTIZAAA",
+    # Release-Review 1.19.0: security_events.detail nennt das Konto im Klartext.
+    "security_detail": "PIISICHERHEITSDETAILAAA",
 }
 
 # Diese bleiben absichtlich stehen und duerfen die Suche nicht ausloesen.
@@ -217,6 +220,10 @@ def mandant(_db_session):
     _db_session.add(Absence(
         user_id=user.id, tenant_id=TID, date=date(2026, 3, 3),
         type=AbsenceType.VACATION, hours=8.0, note=PII["absence_note"],
+    ))
+    _db_session.add(SecurityEvent(
+        tenant_id=TID, event="admin_password_reset_cli", subject_user_id=user.id,
+        actor="cli:root@testhost", detail=PII["security_detail"],
     ))
     _db_session.add(ChangeRequest(
         user_id=user.id, tenant_id=TID,

--- a/docs/NATIVE-BETRIEB.md
+++ b/docs/NATIVE-BETRIEB.md
@@ -36,8 +36,11 @@ Tests: `test_native_pg_lifecycle.py::TestGesundheitspruefungGehoertZumEigenenKin
 ## Kontoübernahme bei verlorenem Admin-Passwort (#425)
 
 ```
-sudo praxiszeit-server.py reset-admin-password [--username admin] [--disable-2fa]
+sudo -u praxiszeit /opt/praxiszeit/bin/python/bin/python3 \
+     /opt/praxiszeit/praxiszeit-server.py reset-admin-password [--username admin] [--disable-2fa]
 ```
+
+⚠️ **Die vollständige Form ist nicht Zierde, sondern nötig** (Release-Review 1.19.0): `praxiszeit-server.py` liegt weder im `PATH` noch wird es vom Installer ausführbar gemacht — `sudo praxiszeit-server.py …` scheitert schon an der Shell. Und die Abhängigkeiten der Anwendung liegen ausschließlich im **mitgelieferten** Interpreter unter `bin/python`; mit dem System-Python stirbt der Unterprozess an `ModuleNotFoundError: No module named 'sqlalchemy'`. Das Kommando löst den gebündelten Interpreter inzwischen selbst auf (`bundled_python()`), aber der Aufruf muss ihn trotzdem finden. `sudo -u praxiszeit` statt reinem `sudo`, weil `pg_ctl` den Start als root ablehnt — läuft die Datenbank bereits, geht auch root, andernfalls bricht das Kommando jetzt mit einem Hinweis auf genau diese Zeile ab statt mit einem Traceback.
 
 - Fragt das neue Passwort **interaktiv** ab (zweimal, gegen dieselbe Komplexitätsregel wie die Anwendung). **Bewusst kein Argument dafür** — es stünde in der Shell-History und in der Prozessliste.
 - Erhöht `token_version` → alle bestehenden Sitzungen des Kontos werden ungültig.

--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -1028,7 +1028,7 @@ Betrifft es ein anderes Konto als `admin`, geben Sie den Benutzernamen mit an: `
 
 **Was dabei protokolliert wird:** Jeder solche Vorgang wird mit Zeitpunkt, betroffenem Konto und dem Betriebssystem-Konto, das ihn ausgelöst hat, dauerhaft festgehalten (Nachweispflicht nach Art. 5 Abs. 2 DSGVO). Ein Passwort-Reset ist also kein stiller Vorgang.
 
-> **Docker-Installation:** Dort gibt es dieses Kommando nicht — die Zugangsdaten stehen in der `.env`, der Weg führt über `docker compose exec db psql`. Siehe [`docs/DEPLOYMENT.md`](../DEPLOYMENT.md).
+> **Docker-Installation:** Dasselbe Werkzeug steckt auch im Backend-Abbild — dort lautet der Befehl `docker compose exec backend python -m app.cli.reset_admin_password` (mit `--username <name>` bzw. `--disable-2fa` wie oben). Ein Eingriff von Hand in die Datenbank ist weder nötig noch empfohlen: dabei entfiele die Protokollzeile.
 
 > **Der Eintrag `[admin] password` in `config/praxiszeit.conf` ist keine Antwort auf die Frage:** er ist nur der Startwert der Erstinstallation und wird bei einer späteren Passwortänderung nicht nachgeführt. Nach einem Reset überschreibt ihn das Kommando mit einem Zufallswert — er steht dann nur noch da, weil die Anwendung das Feld beim Start voraussetzt.
 

--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -199,7 +199,15 @@ Das Backend prüft:
 - **nicht** in der Liste typischer Default-/Beispielpasswörter (z. B. `change`, `secret`, `password`, `12345`, `BITTE_AENDERN…`)
 - praktisch **min. 12 Zeichen** — kürzere Passwörter lösen einen Sicherheitshinweis im Log aus
 
-Das `[admin].password` wird **nur beim Erststart** gelesen, sofort gehasht in die Datenbank geschrieben und nie wieder genutzt. Spätere Passwortänderungen erfolgen über das Frontend (Profil → Passwort ändern). Den Klartextwert in der Datei sollte man danach durch einen Platzhalter (z. B. `password = "set-via-ui"`) ersetzen, damit niemand mehr das Initialpasswort aus der Datei lesen kann.
+Das `[admin].password` wird beim Start gelesen, um das Admin-Konto anzulegen, **falls es fehlt**; existiert es bereits, bleibt es unberührt. Spätere Passwortänderungen erfolgen über das Frontend (Profil → Passwort ändern) — der Wert in der Datei wird dabei **nicht** nachgeführt und ist danach falsch.
+
+Den Klartextwert sollte man deshalb entwerten. ⚠️ **Nicht durch einen festen Platzhalter** wie `set-via-ui`: fehlt das Admin-Konto irgendwann (Benutzername umgestellt, Konto nach Art. 17 endgültig gelöscht), legt der nächste Start es mit genau diesem Wert neu an — und ein in der Projektdokumentation veröffentlichter Wert ist dann das Passwort. Die Schwachpasswort-Prüfung greift dabei nicht: sie bricht den Start nur bei `ENVIRONMENT=production` ab, und der native Standard ist `development`.
+
+Stattdessen einen **zufälligen** Ersatzwert eintragen — oder einfacher das mitgelieferte Kommando nutzen, das den Eintrag selbst mit einem Zufallswert überschreibt (siehe Admin-Handbuch, „Admin-Passwort verloren"):
+
+```
+bin\python\python.exe praxiszeit-server.py reset-admin-password
+```
 
 ### Optional, aber empfohlen: Produktiv-Modus erzwingen
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.18.2",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.18.2",
+      "version": "1.19.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.18.2",
+  "version": "1.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/public/help/HANDBUCH-ADMIN.md
+++ b/frontend/public/help/HANDBUCH-ADMIN.md
@@ -1028,7 +1028,7 @@ Betrifft es ein anderes Konto als `admin`, geben Sie den Benutzernamen mit an: `
 
 **Was dabei protokolliert wird:** Jeder solche Vorgang wird mit Zeitpunkt, betroffenem Konto und dem Betriebssystem-Konto, das ihn ausgelöst hat, dauerhaft festgehalten (Nachweispflicht nach Art. 5 Abs. 2 DSGVO). Ein Passwort-Reset ist also kein stiller Vorgang.
 
-> **Docker-Installation:** Dort gibt es dieses Kommando nicht — die Zugangsdaten stehen in der `.env`, der Weg führt über `docker compose exec db psql`. Siehe [`docs/DEPLOYMENT.md`](../DEPLOYMENT.md).
+> **Docker-Installation:** Dasselbe Werkzeug steckt auch im Backend-Abbild — dort lautet der Befehl `docker compose exec backend python -m app.cli.reset_admin_password` (mit `--username <name>` bzw. `--disable-2fa` wie oben). Ein Eingriff von Hand in die Datenbank ist weder nötig noch empfohlen: dabei entfiele die Protokollzeile.
 
 > **Der Eintrag `[admin] password` in `config/praxiszeit.conf` ist keine Antwort auf die Frage:** er ist nur der Startwert der Erstinstallation und wird bei einer späteren Passwortänderung nicht nachgeführt. Nach einem Reset überschreibt ihn das Kommando mit einem Zufallswert — er steht dann nur noch da, weil die Anwendung das Feld beim Start voraussetzt.
 

--- a/frontend/src/components/DocViewer.tsx
+++ b/frontend/src/components/DocViewer.tsx
@@ -566,11 +566,12 @@ export const handbuchAdminSections: AccordionItem[] = [
     content: (
       <div className="space-y-2">
         <p>Kommt niemand mehr mit einem Administrator-Konto in die Anwendung, hilft ein Kommando <strong>auf dem Server selbst</strong> — es setzt das Passwort direkt in der Datenbank neu und braucht dafür keine Anmeldung:</p>
-        <p><code>sudo praxiszeit-server.py reset-admin-password</code></p>
+        <p><code>sudo -u praxiszeit /opt/praxiszeit/bin/python/bin/python3 /opt/praxiszeit/praxiszeit-server.py reset-admin-password</code></p>
+        <p className="text-gray-500">Der lange Pfad ist nötig: das Programm braucht den mitgelieferten Python-Interpreter und liegt nicht als normaler Befehl im Systempfad. Weicht Ihr Installationsverzeichnis von <code>/opt/praxiszeit</code> ab, ersetzen Sie es entsprechend.</p>
         <p>Das neue Passwort wird zweimal abgefragt (nicht mit eingetippt, damit es nicht in der Befehls-Historie landet) und gegen dieselben Regeln geprüft wie in der Anwendung. Danach sind <strong>alle laufenden Sitzungen dieses Kontos ungültig</strong>.</p>
         <p>Ist auch das Handy mit der <strong>Zwei-Faktor-Anmeldung</strong> weg, reicht das neue Passwort nicht — der Login fragt weiter nach einem Code. Dann <code>--disable-2fa</code> ergänzen und die Zwei-Faktor-Anmeldung anschließend im Profil neu einrichten. Betrifft es ein anderes Konto als <code>admin</code>: <code>--username &lt;name&gt;</code>.</p>
         <p>Jeder solche Vorgang wird mit Zeitpunkt, betroffenem Konto und dem auslösenden Betriebssystem-Konto dauerhaft festgehalten (Nachweispflicht nach Art. 5 Abs. 2 DSGVO) — ein Passwort-Reset ist kein stiller Vorgang.</p>
-        <p className="text-gray-500">In der <strong>Docker</strong>-Installation gibt es dieses Kommando nicht; dort führt der Weg über <code>docker compose exec db psql</code>. Der Eintrag <code>[admin] password</code> in <code>config/praxiszeit.conf</code> ist <strong>keine</strong> Antwort auf die Frage — er ist nur der Startwert der Erstinstallation und nach der ersten Änderung falsch; das Kommando überschreibt ihn anschließend mit einem Zufallswert.</p>
+        <p className="text-gray-500">In der <strong>Docker</strong>-Installation steckt dasselbe Werkzeug im Backend-Abbild: <code>docker compose exec backend python -m app.cli.reset_admin_password</code>. Der Eintrag <code>[admin] password</code> in <code>config/praxiszeit.conf</code> ist <strong>keine</strong> Antwort auf die Frage — er ist nur der Startwert der Erstinstallation und nach der ersten Änderung falsch; das Kommando überschreibt ihn anschließend mit einem Zufallswert.</p>
       </div>
     ),
   },

--- a/frontend/src/components/shiftplanning/SlotDialog.tsx
+++ b/frontend/src/components/shiftplanning/SlotDialog.tsx
@@ -196,8 +196,9 @@ export default function SlotDialog({
               label="Mindestbesetzung"
               type="number"
               min={0}
+              max={999}  /* Release-Review 1.19.0: Server-Grenze (smallint) */
               value={minStaff}
-              onChange={(e) => setMinStaff(Math.max(0, Number(e.target.value)))}
+              onChange={(e) => setMinStaff(Math.min(999, Math.max(0, Number(e.target.value))))}
               helperText="0 = keine Mindestbesetzung; sonst wird der Slot bei Unterbesetzung markiert."
             />
 

--- a/praxiszeit-server.py
+++ b/praxiszeit-server.py
@@ -1914,6 +1914,46 @@ def cmd_backup(args):
     create_backup(config)
 
 
+def bundled_python() -> str:
+    """Pfad zum MITGELIEFERTEN Interpreter (Release-Review 1.19.0).
+
+    Die Abhaengigkeiten der Anwendung (sqlalchemy, passlib, pydantic-settings)
+    liegen bei einer nativen Installation ausschliesslich unter
+    ``bin/python`` — der System-Python kennt sie nicht. systemd und launchd
+    rufen den gebuendelten Interpreter mit vollem Pfad auf, ein von Hand
+    gestartetes Kommando aber nicht zwangslaeufig: ``sys.executable`` ist dann
+    ``/usr/bin/python3`` und der Unterprozess stirbt an
+    ``ModuleNotFoundError: No module named 'sqlalchemy'``.
+
+    Faellt auf ``sys.executable`` zurueck, wenn kein gebuendelter Interpreter
+    daneben liegt (Entwicklungsumgebung, install-local.sh mit venv).
+    """
+    candidates = [
+        BIN_DIR / "python" / "bin" / "python3",   # Linux/macOS-Bundle
+        BIN_DIR / "python" / "python.exe",        # Windows-Bundle
+        BASE_DIR / "venv" / "bin" / "python3",    # install-local.sh
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    return sys.executable
+
+
+def _install_owner() -> str:
+    """Das Konto, dem die Installation gehoert — der richtige Aufrufer, wenn die
+    Datenbank noch hochgefahren werden muss (Release-Review 1.19.0)."""
+    try:
+        import pwd
+        return pwd.getpwuid(BASE_DIR.stat().st_uid).pw_name
+    except Exception:  # noqa: BLE001 — Windows/unbekannte UID: der Hinweis bleibt brauchbar
+        return "praxiszeit"
+
+
+def _running_as_root() -> bool:
+    """Unter Windows gibt es ``geteuid`` nicht — dort ist die Frage bedeutungslos."""
+    return hasattr(os, "geteuid") and os.geteuid() == 0
+
+
 def cmd_reset_admin_password(args):
     """#425: Passwort eines Kontos lokal auf der Maschine neu setzen.
 
@@ -1939,6 +1979,21 @@ def cmd_reset_admin_password(args):
 
     started_here = False
     if not pg_is_running():
+        # Release-Review 1.19.0: ``pg_ctl`` verweigert den Start als root
+        # ("cannot be run as root") — mit ``check=True`` schlaegt das als roher
+        # Traceback durch, und das Passwort bleibt unveraendert. Laeuft die
+        # Datenbank dagegen bereits (der Regelfall), ist root voellig in
+        # Ordnung; deshalb steht der Guard genau hier und nicht am Anfang.
+        if _running_as_root():
+            logger.error(
+                "PostgreSQL laeuft nicht, und als root darf es nicht gestartet werden "
+                "(pg_ctl lehnt das ab). Zwei Wege: entweder den Dienst starten "
+                "(systemctl start praxiszeit) und das Kommando erneut aufrufen, oder "
+                "es als Dienstkonto ausfuehren:\n"
+                "  sudo -u %s %s %s reset-admin-password",
+                _install_owner(), bundled_python(), Path(__file__).resolve(),
+            )
+            sys.exit(1)
         logger.info("PostgreSQL ist nicht gestartet — wird fuer den Vorgang kurz hochgefahren.")
         pg_start()
         started_here = True
@@ -1960,7 +2015,8 @@ def cmd_reset_admin_password(args):
         apply_config_env(config, env)
         env.setdefault("SECRET_KEY", resolve_secret_key(config, persist=False))
 
-        cmd = [sys.executable, "-m", "app.cli.reset_admin_password"]
+        # Release-Review 1.19.0: NICHT ``sys.executable`` — siehe bundled_python().
+        cmd = [bundled_python(), "-m", "app.cli.reset_admin_password"]
         if args.username:
             cmd += ["--username", args.username]
         if args.disable_2fa:

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,12 +15,19 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.18.2"
-PYTHON_VERSION="3.13.13"
+APP_VERSION="1.19.0"
+PYTHON_VERSION="3.13.15"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
-# 20260510 buendelt CPython 3.13.13 — enthaelt die tarfile-Fixes
-# (CVE-2025-4517 u.a.) gegenueber dem alten 3.13.3 (Tag 20250529).
-PYTHON_STANDALONE_TAG="20260510"
+# 20260825 buendelt CPython 3.13.15 mit OpenSSL 3.5.8, SQLite 3.53.1 und
+# expat 2.8.3 (am Artefakt nachgemessen). Der vorherige Stand 3.13.13 /
+# Tag 20260510 lieferte OpenSSL 3.5.6 — zwei Sicherheitsrunden aelter.
+# Der Interpreter gehoert zu ALLEN vier nativen Kundenpaketen, das ist also
+# ausgelieferte Angriffsflaeche, nicht nur Bauwerkzeug (Release-Review 1.19.0).
+# Beim Anheben: die vier Assets vorher auf HTTP 200 pruefen (nicht jede
+# CPython-Punktversion hat ein python-build-standalone-Release) und danach am
+# gebauten Artefakt gegenmessen:
+#   build/release-<ver>/linux/bin/python/bin/python3 -c "import ssl; print(ssl.OPENSSL_VERSION)"
+PYTHON_STANDALONE_TAG="20260825"
 # theseus-rs/postgresql-binaries — manylinux-Build, portable bis glibc 2.34
 # (Ubuntu 22.04, Debian 12, RHEL 9 und neuer). Releases:
 #   https://github.com/theseus-rs/postgresql-binaries/releases


### PR DESCRIPTION
Release 1.19.0. Enthält die bereits gemergten #461/#440/#425 (PR #464) und
#427/#463 (PR #465); dieser PR bringt die Funde der Release-Review und den
Versionssprung.

## Review-Funde (10 bestätigt, alle behoben)

**Hoch — das Notfall-Kommando aus #425 war so, wie dokumentiert, auf keiner Installation aufrufbar.** `praxiszeit-server.py` liegt nicht im PATH und wird vom Installer nicht ausführbar gemacht; wer stattdessen `python3 …` davorsetzt, landet im System-Python ohne die App-Abhängigkeiten. Dokumentiert war die nicht funktionierende Form auf fünf Flächen. `bundled_python()` löst jetzt den mitgelieferten Interpreter auf, die Doku zeigt den tatsächlich funktionierenden Aufruf. Mein eigener Test auf .131 hat das nicht gesehen, weil er den vollen Interpreter-Pfad benutzte — also gerade nicht die dokumentierte Form.

**Mittel** — als root scheitert das Hochfahren der Datenbank (`pg_ctl` lehnt root ab): jetzt ein Guard mit dem richtigen Aufruf statt eines Tracebacks · `security_events.detail` trug den Kontonamen und überlebte beide Anonymisierungspfade und den Hard-Delete · `min_staff`/`sort_order` waren nach oben ungebunden (HTTP 500 statt 422, live nachgestellt — dieselbe Lücke, die #450 für die Namensfelder schloss) · der Docker-Hinweis im Handbuch verwies auf eine Doku ohne Antwort, obwohl das Werkzeug im Backend-Abbild steckt · `setup-windows.md` empfahl genau den festen Platzhalter, den #425 als Risiko verworfen hat · der gebündelte Interpreter lag auf **OpenSSL 3.5.6**, jetzt **3.5.8** (CPython 3.13.13 → 3.13.15).

## Geprüft

- Backend 2187, Frontend 371, native Lebenszyklus 68, Postgres-only 44
- Migration 071 up→down→up auf frischem PG18
- Build: 6 Artefakte, SHA 6/6, Windows-ZIP ohne `setup.exe`, PG-SHA = Pin, OpenSSL am Artefakt nachgemessen
- validate-release 5/5 Distributionen
- **Lokal Docker**: Update ohne Datenänderung (27 Tabellen), alembic head, echter Login
- **Lokal nativ**: aus dem Tarball, Login 200, Reset **in der dokumentierten Form**, Dienst startet nach dem Config-Eingriff weiter
- **.131 nativ**: Update auf 1.19.0, Daten unverändert, Login 200, `StartLimitBurst=5` von systemd tatsächlich übernommen (in `[Service]` wäre es ignoriert worden), und **#427 im Betrieb nachgestellt**: belegter Port → klare Ursachenmeldung → nach fünf Versuchen ehrliches `failed` statt dauerhaft `active`
- **.131 docker**: Update über Migration 070+071 auf echten Daten, nur `security_events` neu, Login 200 nach Reset über den dokumentierten Docker-Weg
- UI-Smoke im Browser gegen 1.19.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJGXWtenCdKNspSMSfWQMB
