### PR TITLE
docs: Versionsstand auf 1.19.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.18.2 (Stand 2026-08-13)
+**Aktuelle Version:** 1.19.0 (Stand 2026-08-29)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---


### PR DESCRIPTION
Nachtrag zum Release: `CLAUDE.md` führte noch 1.18.2 als aktuellen Stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJGXWtenCdKNspSMSfWQMB