### PR TITLE
Release 1.19.1 — Kappungs-Meldung vollständig, Rohstempel-Schutz, Review-Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 ## [Unreleased]
 
+## [1.19.1] - 2026-09-05
+
+Patch-Release. Update aus jeder 1.19.x ohne Zwischenschritte; **keine neue
+Migration** (head bleibt `071_security_events`).
+
+### 🐞 Korrekturen
+- **Die Kappung auf das Arbeitszeit-Fenster passierte stumm** (aus dem
+  Bug-Tracker). Wer 07:37 eintrug, bekam bei hinterlegten Soll-Zeiten 07:45
+  gespeichert und erfuhr es nicht — bei einer Zeiterfassung ist die unbemerkte
+  Änderung fremder Arbeitszeit das eigentliche Problem, nicht die Kappung.
+  Jetzt erscheint beim Speichern ein Hinweis mit den konkreten Zeiten („Beginn
+  07:00 → 07:45; Puffer 15 Minuten"), an allen Wegen: Ausstempeln, manuelles
+  Anlegen und Bearbeiten in beiden Rollen, Genehmigung eines Änderungsantrags
+  und Excel-Import. Der Eintrag wird trotzdem gespeichert; der Hinweis
+  blockiert nichts. Eine Rundung auf Viertelstunden gibt es nach wie vor
+  nirgends — bei einem Soll-Beginn zur vollen Stunde landet jede zu frühe
+  Eingabe auf `hh:45`, was danach aussieht.
+- **Der Rohstempel ist jetzt auch im Admin-Dashboard sichtbar** („gestempelt
+  07:37 · angerechnet ab 07:45"). Er stand bisher nur im Monatsjournal und in
+  der Zeiterfassung — ausgerechnet nicht auf der Fläche, auf der die Meldung
+  entstanden ist.
+- **Erneutes Speichern eines gekappten Eintrags löschte den Rohstempel.** Das
+  Bearbeiten-Formular füllt sich mit der angerechneten Zeit; wer nur Notiz oder
+  Pause korrigierte, schickte sie unverändert mit, und die Anwendung sah darin
+  eine neue Eingabe. Der Nachweis der tatsächlichen Anwesenheit (§ 16 ArbZG)
+  und damit die Grundlage der Ruhezeitprüfung (§ 5) war danach weg. Betraf
+  beide Bearbeiten-Wege.
+- **Der Excel-Import prüfte die Zeiten nur in der Vorschau.** Der Bestätigen-
+  Schritt übernahm Zeiten und Rohstempel unverändert aus dem Aufruf; jetzt
+  rechnet der Server erneut, wo ein Arbeitszeit-Fenster hinterlegt ist.
+- **Ein Eintrag ganz außerhalb des Fensters** meldete „Beginn 05:00 → 05:00"
+  und verschwieg die Folge. Jetzt: „… liegt vollständig außerhalb … es werden 0
+  Stunden angerechnet."
+- **Weiche Warnungen des Admin-Dashboards erreichten niemanden.** Die Antwort
+  der Zeiteintrag-Endpunkte wurde nicht ausgewertet — betraf neben der neuen
+  Kappungs-Meldung auch die schon länger vorhandenen Hinweise zu
+  Tages-/Wochenarbeitszeit und Nachtarbeit. Im Monatsjournal galt dasselbe für
+  einen **neuen** Eintrag, während der bearbeitete längst meldete.
+- **`ALLOWED_HOSTS` wirkte im Docker-Betrieb nicht.** Die Einstellung stand in
+  `.env.example` und in der Sicherheitsdokumentation, wurde dem Container aber
+  nie übergeben — der Host-Header-Schutz blieb damit abgeschaltet, unabhängig
+  vom Eintrag in der `.env`. Voreinstellung `*` hält Bestandsinstallationen
+  unverändert.
+
+### 📦 Dependencies
+- Sicherheitsaktualisierungen für `fast-uri`, `browserslist` und `@humanfs/node`
+  (Build- und Lint-Kette des Frontends, nicht Teil der ausgelieferten
+  Anwendung). `npm audit`: 0 Schwachstellen.
+
+### 📖 Dokumentation
+- Admin- und Mitarbeiter-Handbuch (Datei, Download-Spiegel und In-App-Hilfe)
+  beschreiben den neuen Hinweis, die Rohstempel-Zeile und das umbenannte
+  Vorschau-Label des Excel-Imports („Hinweise" statt „ArbZG-Warnungen", weil
+  dort jetzt auch die Kappung erscheint).
+
 ## [1.19.0] - 2026-08-29
 
 Minor-Release. Notfall-Zugang bei verlorenem Admin-Passwort (#425), ehrlicher

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **Repo:** https://github.com/phash/praxiszeit
 **Stack:** React 18 + TypeScript + Tailwind / FastAPI (Python 3.12) + PostgreSQL 16
 **Deployment:** Docker Compose (Entwicklung/Prod) ODER Native Installer (Kundenserver)
-**Aktuelle Version:** 1.19.0 (Stand 2026-08-29)
+**Aktuelle Version:** 1.19.1 (Stand 2026-09-05)
 **Lizenz/Updates:** ausgeliefert über [pzweb](https://github.com/phash/pzweb) — `praxiszeit.mr-development.de` (Shop) + `updates.mr-development.de` (Update-Server)
 
 ---

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -32,7 +32,7 @@ from app.core.license import _PUBLIC_KEY_PEM  # reuse the same trust root
 logger = logging.getLogger(__name__)
 
 # Current application version
-APP_VERSION = "1.19.0"
+APP_VERSION = "1.19.1"
 
 # F-036: Allowed update-server host prefixes. The download URL returned by
 # the server is refused unless its host matches one of these. Prevents a

--- a/backend/app/routers/admin_time_entries.py
+++ b/backend/app/routers/admin_time_entries.py
@@ -270,6 +270,20 @@ def admin_update_time_entry(
             detail="Endzeit muss nach Startzeit liegen",
         )
 
+    # Release-Review 1.19.1: Schickt das Formular die ANGERECHNETE Zeit unveraendert
+    # zurueck (es fuellt sich damit), ist das keine Eingabe — sondern derselbe
+    # Eintrag. Ohne diese Ruecksetzung sah ``clamp`` darin eine neue,
+    # fensterkonforme Zeit und setzte raw_* auf None: der §16-Rohstempel war nach
+    # einer blossen Notiz- oder Pausenkorrektur weg (und mit ihm die Grundlage der
+    # §5-Ruhezeitpruefung). Derselbe Schaden wie beim Datums-Edit aus 1.18.2, nur
+    # ueber den zweiten Weg.
+    update_start_time = work_window_service.unclamp_input(
+        update_start_time, entry.start_time, entry.raw_start_time,
+    )
+    update_end_time = work_window_service.unclamp_input(
+        update_end_time, entry.end_time, entry.raw_end_time,
+    )
+
     # #201: Clamp start/end to the affected employee's soll window.
     # Use `affected_user` (the employee whose entry this is), NOT current_user (admin).
     _grace = work_window_service.get_grace_minutes(db, current_user.tenant_id)
@@ -303,11 +317,18 @@ def admin_update_time_entry(
     # gekappte Zeit auch tatsaechlich geschrieben wird: eine reine
     # Notiz-Aenderung fasst start/end nicht an (Fix #2 weiter unten) und darf
     # deshalb auch nicht ueber eine Kappung berichten.
+    # Release-Review 1.19.1: Massstab ist nicht "war ein Zeitfeld im Payload",
+    # sondern "hat sich die eingereichte Zeit gegenueber der gespeicherten
+    # geaendert". Das Formular schickt die angerechnete Zeit immer mit; ohne
+    # diesen Vergleich meldete jede Notiz- oder Pausenkorrektur erneut eine
+    # Kappung, die laengst passiert ist — derselbe Laerm, den der Notiz-Gate
+    # vermeiden sollte. ``entry.*`` traegt an dieser Stelle noch den gespeicherten
+    # Stand (geschrieben wird weiter unten).
     _times_written = (
         entry_data.date is not None
-        or entry_data.start_time is not None
-        or entry_data.end_time is not None
-    )
+        and entry_data.date != entry.date
+    ) or update_start_time != (entry.raw_start_time or entry.start_time) \
+      or update_end_time != (entry.raw_end_time or entry.end_time)
     if _times_written:
         _clamp_warn = work_window_service.clamp_warning(
             raw_start, raw_end, eff_start, eff_end, _grace,

--- a/backend/app/routers/time_entries.py
+++ b/backend/app/routers/time_entries.py
@@ -972,8 +972,21 @@ def update_time_entry(
         ).first() or current_user
     )
     _grace = work_window_service.get_grace_minutes(db, current_user.tenant_id)
+    # Release-Review 1.19.1: wie im Admin-Pfad — kommt die bereits gekappte Zeit
+    # unveraendert zurueck, mit dem Rohwert weiterrechnen, statt raw_* zu loeschen.
+    # ``entry.start_time`` traegt hier bereits den Wert aus ``update_data``; der
+    # zuvor gespeicherte Stand steckt in ``orig_snapshot``. Fuer ein Feld, das gar
+    # nicht Teil des Updates war, liefert die Ruecksetzung den Rohwert und die
+    # Kappung daraus wieder exakt dieselbe angerechnete Zeit — §3/§4 pruefen also
+    # unveraendert gegen die angerechnete Zeit.
+    _clamp_start = work_window_service.unclamp_input(
+        entry.start_time, orig_snapshot["start_time"], orig_snapshot["raw_start_time"],
+    )
+    _clamp_end = work_window_service.unclamp_input(
+        entry.end_time, orig_snapshot["end_time"], orig_snapshot["raw_end_time"],
+    )
     _eff_start, _eff_end, _raw_start, _raw_end = work_window_service.clamp(
-        _entry_owner, entry.date, entry.start_time, entry.end_time, _grace,
+        _entry_owner, entry.date, _clamp_start, _clamp_end, _grace,
     )
     # Fix #2: only overwrite start/end + raw_* when the respective time was
     # actually part of this partial update — mirrors the admin path
@@ -1096,7 +1109,14 @@ def update_time_entry(
     update_warnings: list[str] = []
     # #462: nur wenn die gekappte Zeit auch geschrieben wird — eine reine
     # Notiz-Aenderung fasst start/end nicht an (Fix #2) und darf nichts melden.
-    if "start_time" in update_data or "end_time" in update_data:
+    # Release-Review 1.19.1: zusaetzlich muss sich die eingereichte Zeit von der
+    # gespeicherten unterscheiden — das Formular schickt die angerechnete Zeit
+    # immer mit, und eine erneute Meldung derselben alten Kappung ist Laerm.
+    _resubmitted_unchanged = (
+        _clamp_start == (orig_snapshot["raw_start_time"] or orig_snapshot["start_time"])
+        and _clamp_end == (orig_snapshot["raw_end_time"] or orig_snapshot["end_time"])
+    )
+    if ("start_time" in update_data or "end_time" in update_data) and not _resubmitted_unchanged:
         _clamp_warn = work_window_service.clamp_warning(
             _raw_start, _raw_end, _eff_start, _eff_end, _grace,
         )

--- a/backend/app/services/work_window_service.py
+++ b/backend/app/services/work_window_service.py
@@ -85,10 +85,29 @@ def clamp_warning_text(
     sichtbar. Fuer die API-Warnungen setzt ``clamp_warning`` den Code davor.
     """
     teile = []
-    if raw_start is not None and eff_start is not None:
+    # Nur Seiten nennen, die sich tatsaechlich verschoben haben. Im Kollaps-Fall
+    # (Eintrag ganz ausserhalb des Fensters) gibt ``clamp`` (start, start, start, end)
+    # zurueck — raw_start IST dort eff_start, und "Beginn 05:00 -> 05:00" waere eine
+    # Kappung, die es nicht gab (Release-Review 1.19.1).
+    if raw_start is not None and eff_start is not None and raw_start != eff_start:
         teile.append(f"Beginn {_hhmm(raw_start)} \u2192 {_hhmm(eff_start)}")
-    if raw_end is not None and eff_end is not None:
+    if raw_end is not None and eff_end is not None and raw_end != eff_end:
         teile.append(f"Ende {_hhmm(raw_end)} \u2192 {_hhmm(eff_end)}")
+
+    # Kollaps: angerechnet werden 0 Stunden. Das ist die eigentliche Folge und
+    # stand vorher nirgends — der Text nannte nur Zeitpunkte.
+    collapsed = (
+        eff_start is not None and eff_end is not None and eff_start == eff_end
+    )
+    if collapsed:
+        roh_start = raw_start or eff_start
+        roh_end = raw_end or eff_end
+        return (
+            f"Die eingetragene Zeit ({_hhmm(roh_start)}\u2013{_hhmm(roh_end)}) liegt "
+            f"vollstaendig ausserhalb des hinterlegten Arbeitszeit-Fensters "
+            f"(Puffer {grace_minutes} Minuten) — angerechnet werden 0 Stunden. "
+            f"Die urspruengliche Eingabe bleibt als Rohstempel gespeichert."
+        )
     if not teile:
         return None
     return (
@@ -97,6 +116,26 @@ def clamp_warning_text(
         f"Angerechnet wird die gekappte Zeit; die urspruengliche Eingabe bleibt "
         f"als Rohstempel gespeichert."
     )
+
+
+def unclamp_input(
+    incoming: Optional[time], prev_eff: Optional[time], prev_raw: Optional[time],
+) -> Optional[time]:
+    """Schickt ein Formular die zuvor GEKAPPTE Zeit unveraendert zurueck, ist das
+    keine Eingabe — sondern derselbe Eintrag. Dann mit dem Rohwert weiterrechnen.
+
+    Release-Review 1.19.1: Das Bearbeiten-Formular im Admin-Dashboard fuellt sich
+    mit der angerechneten Zeit (07:45). Wer nur die Notiz oder die Pause aendert
+    und speichert, schickt 07:45 als ``start_time`` mit; ``clamp`` sah darin eine
+    neue, bereits fensterkonforme Eingabe und setzte ``raw_start_time`` auf None —
+    der echte Stempel (07:37) war weg. Das ist derselbe Schaden wie beim
+    Datums-Edit aus 1.18.2, nur ueber den zweiten Weg: der Rohstempel ist der
+    §16-Nachweis der Anwesenheit UND die Grundlage der §5-Ruhezeitpruefung.
+
+    Ein echter Wechsel auf eine andere Uhrzeit laeuft unveraendert durch."""
+    if incoming is not None and prev_raw is not None and incoming == prev_eff:
+        return prev_raw
+    return incoming
 
 
 def clamp_warning(

--- a/backend/app/services/xls_import_service.py
+++ b/backend/app/services/xls_import_service.py
@@ -374,6 +374,11 @@ def _execute_import_inner(
     overwritten = 0
     all_warnings: list[str] = []
 
+    # Einmal fuer die Schleife: Ziel-Person (fuer die Kappung unten und die
+    # Zusammenfassung am Ende) und der Tenant-Puffer.
+    target_user = db.query(User).filter(User.id == user_id).first()
+    grace = work_window_service.get_grace_minutes(db, tenant_id)
+
     for entry in entries:
         # Invariant end_time > start_time. net_hours floors a negative duration
         # to 0, so an end<=start row (over-midnight shift, or corrupt/forged
@@ -390,6 +395,37 @@ def _execute_import_inner(
                 f"Über-Mitternacht-Schichten als zwei Einträge erfassen."
             )
             continue
+
+        # Release-Review 1.19.1: NICHT den Client-Zeiten vertrauen. /confirm nimmt
+        # die Eintraege aus dem Request-Body entgegen; gekappt wurde bisher nur in
+        # der Vorschau (parse_xls). Wer den Aufruf nachbaut, schrieb damit Zeiten
+        # am Arbeitszeit-Fenster vorbei — und setzte obendrein raw_start_time/
+        # raw_end_time frei, also genau den Wert, der als §16-Anwesenheitsnachweis
+        # und als Grundlage der §5-Ruhezeitpruefung gilt. Gerechnet wird deshalb
+        # hier erneut, und zwar aus dem Rohwert: fuer eine unveraenderte Vorschau
+        # ist das Ergebnis identisch (die Kappung ist in sich idempotent).
+        # Nur wo an diesem Wochentag ueberhaupt ein Fenster hinterlegt ist. Ohne
+        # Fenster gibt es nichts zu umgehen — und ein mitgeliefertes raw_* (etwa
+        # aus einer Vorschau, die unter einem frueheren Fenster entstand) bleibt
+        # als §16-Nachweis stehen, statt von einer Kappung geloescht zu werden,
+        # die gar nicht stattfindet.
+        _hat_fenster = target_user is not None and work_window_service.get_scheduled_window(
+            target_user, entry.date,
+        ) != (None, None)
+        if _hat_fenster:
+            _eff_start, _eff_end, _raw_start, _raw_end = work_window_service.clamp(
+                target_user,
+                entry.date,
+                entry.raw_start_time or entry.start_time,
+                entry.raw_end_time or entry.end_time,
+                grace,
+            )
+            entry = entry.model_copy(update={
+                "start_time": _eff_start,
+                "end_time": _eff_end,
+                "raw_start_time": _raw_start,
+                "raw_end_time": _raw_end,
+            })
 
         for w in entry.arbzg_warnings:
             all_warnings.append(f"{entry.date.strftime('%d.%m.%Y')}: {w}")
@@ -473,7 +509,6 @@ def _execute_import_inner(
             imported += 1
 
     # Zusammenfassungs-Eintrag im Audit-Log (action="import", time_entry_id=None)
-    target_user = db.query(User).filter(User.id == user_id).first()
     username = f"{target_user.first_name} {target_user.last_name}" if target_user else str(user_id)
     summary = (
         f"XLS-Import: {imported} neu, {overwritten} überschrieben, {skipped} übersprungen "

--- a/backend/tests/test_release_1_19_1_review.py
+++ b/backend/tests/test_release_1_19_1_review.py
@@ -1,0 +1,64 @@
+"""Release-Review 1.19.1 — Funde 1-3: Rohstempel-Erhalt beim Re-Speichern + Kollaps-Text."""
+from datetime import time
+
+import pytest
+
+from app.services import work_window_service
+
+
+class TestUnclampInput:
+    """Fund: das Formular schickt die GEKAPPTE Zeit zurueck; ohne Ruecksetzung
+    rechnet clamp() sie als neue Eingabe und wirft den Rohstempel weg (§16)."""
+
+    def test_returns_raw_when_incoming_equals_previous_effective(self):
+        assert work_window_service.unclamp_input(
+            time(7, 45), prev_eff=time(7, 45), prev_raw=time(7, 37)
+        ) == time(7, 37)
+
+    def test_returns_incoming_on_a_real_change(self):
+        assert work_window_service.unclamp_input(
+            time(9, 0), prev_eff=time(7, 45), prev_raw=time(7, 37)
+        ) == time(9, 0)
+
+    def test_passes_through_when_nothing_was_clamped_before(self):
+        assert work_window_service.unclamp_input(
+            time(8, 0), prev_eff=time(8, 0), prev_raw=None
+        ) == time(8, 0)
+
+    def test_passes_through_none(self):
+        assert work_window_service.unclamp_input(
+            None, prev_eff=time(7, 45), prev_raw=time(7, 37)
+        ) is None
+
+
+class TestClampWarningCollapse:
+    """Fund: liegt ein Eintrag ganz ausserhalb des Fensters, kollabiert clamp()
+    auf einen Punkt und gab (start, start, start, end) zurueck — der Text las
+    sich dann als 'Beginn 05:00 -> 05:00' und verschwieg die eigentliche Folge."""
+
+    def test_no_part_for_an_unchanged_side(self):
+        text = work_window_service.clamp_warning_text(
+            raw_start=time(5, 0), raw_end=time(6, 0),
+            eff_start=time(5, 0), eff_end=time(5, 0),
+            grace_minutes=15,
+        )
+        assert text is not None
+        assert "05:00 → 05:00" not in text, text
+
+    def test_names_the_zero_hours_consequence(self):
+        text = work_window_service.clamp_warning_text(
+            raw_start=time(5, 0), raw_end=time(6, 0),
+            eff_start=time(5, 0), eff_end=time(5, 0),
+            grace_minutes=15,
+        )
+        assert "0 Stunden" in text, text
+
+    def test_normal_clamp_text_unchanged(self):
+        text = work_window_service.clamp_warning_text(
+            raw_start=time(7, 0), raw_end=None,
+            eff_start=time(7, 45), eff_end=time(16, 0),
+            grace_minutes=15,
+        )
+        assert "Beginn 07:00 → 07:45" in text
+        assert "0 Stunden" not in text
+        assert "Puffer 15 Minuten" in text

--- a/backend/tests/test_work_window_integration.py
+++ b/backend/tests/test_work_window_integration.py
@@ -510,3 +510,78 @@ def test_zeitaenderung_meldet_die_kappung(db, employee, admin_client):
                             json={"start_time": "06:30"})
     assert resp.status_code == 200, resp.text
     assert _clamp_warnings(resp), resp.json().get("warnings")
+
+
+# ── Release-Review 1.19.1: erneutes Speichern darf den Rohstempel nicht loeschen ──
+# Das Bearbeiten-Formular fuellt sich mit der ANGERECHNETEN Zeit (07:45). Wer nur
+# Notiz oder Pause aendert, schickt sie unveraendert mit — clamp() sah darin eine
+# neue, fensterkonforme Eingabe und setzte raw_start_time auf None. Der echte
+# Stempel (§16-Nachweis, Grundlage der §5-Ruhezeitpruefung) war damit weg, und die
+# seit 1.19.1 sichtbare Rohstempel-Zeile verschwand aus der Liste.
+
+def _angelegt_mit_kappung(admin_client, employee_id):
+    resp = admin_client.post(
+        f"/api/admin/users/{employee_id}/time-entries",
+        json={"date": "2026-06-01", "start_time": "07:00", "end_time": "16:00",
+              "break_minutes": 30},
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()["id"]
+
+
+def test_admin_resave_der_gekappten_zeit_bewahrt_den_rohstempel(db, employee, admin_client):
+    employee.scheduled_start_monday = dt.time(8, 0)
+    db.commit()
+    entry_id = _angelegt_mit_kappung(admin_client, employee.id)
+
+    resp = admin_client.put(
+        f"/api/admin/time-entries/{entry_id}",
+        json={"date": "2026-06-01", "start_time": "07:45", "end_time": "16:00",
+              "break_minutes": 30, "note": "Pause korrigiert"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    entry = db.query(TimeEntry).filter(TimeEntry.id == entry_id).one()
+    assert entry.start_time == dt.time(7, 45)
+    assert entry.raw_start_time == dt.time(7, 0), (
+        f"Rohstempel verloren: {entry.raw_start_time}"
+    )
+    # Es wurde nichts neu gekappt — also auch nichts zu melden.
+    assert not _clamp_warnings(resp), resp.json().get("warnings")
+
+
+def test_admin_echte_zeitaenderung_setzt_den_rohstempel_neu(db, employee, admin_client):
+    """Gegenprobe: eine andere Uhrzeit ist eine echte Eingabe und laeuft unveraendert
+    durch die Kappung — der neue Rohwert ersetzt den alten."""
+    employee.scheduled_start_monday = dt.time(8, 0)
+    db.commit()
+    entry_id = _angelegt_mit_kappung(admin_client, employee.id)
+
+    resp = admin_client.put(
+        f"/api/admin/time-entries/{entry_id}", json={"start_time": "06:30"},
+    )
+    assert resp.status_code == 200, resp.text
+    entry = db.query(TimeEntry).filter(TimeEntry.id == entry_id).one()
+    assert entry.start_time == dt.time(7, 45)
+    assert entry.raw_start_time == dt.time(6, 30)
+
+
+def test_zweiter_schreibpfad_bewahrt_den_rohstempel_ebenfalls(db, employee, admin_client):
+    """Derselbe Fall ueber ``PUT /api/time-entries/{id}`` — den zweiten Bearbeiten-Pfad,
+    ueber den Admins fremde Eintraege aendern. Beide Pfade kappen, also muessen beide
+    den Rohstempel bewahren; genau solche Parallelpfade sind in diesem Projekt schon
+    mehrfach auseinandergelaufen."""
+    employee.scheduled_start_monday = dt.time(8, 0)
+    db.commit()
+    entry_id = _angelegt_mit_kappung(admin_client, employee.id)
+
+    resp = admin_client.put(
+        f"/api/time-entries/{entry_id}",
+        json={"start_time": "07:45", "end_time": "16:00", "break_minutes": 30},
+    )
+    assert resp.status_code == 200, resp.text
+    entry = db.query(TimeEntry).filter(TimeEntry.id == entry_id).one()
+    assert entry.start_time == dt.time(7, 45)
+    assert entry.raw_start_time == dt.time(7, 0), (
+        f"Rohstempel verloren: {entry.raw_start_time}"
+    )

--- a/backend/tests/test_xls_import_service.py
+++ b/backend/tests/test_xls_import_service.py
@@ -609,3 +609,49 @@ def test_parse_xls_without_soll_window_has_no_clamp_warning(db, test_user):
     assert entries[0].start_time == time(7, 0)
     assert entries[0].raw_start_time is None
     assert not [w for w in entries[0].arbzg_warnings if "Arbeitszeit-Fenster" in w]
+
+
+def test_execute_import_kappt_selbst_und_traut_dem_client_nicht(db, test_user, test_admin):
+    """Release-Review 1.19.1: /confirm bekam Zeiten UND §16-Rohstempel unveraendert
+    aus dem Request-Body — geklammert wurde nur in der Vorschau. Wer den Aufruf
+    nachbaut, schreibt damit Zeiten am Arbeitszeit-Fenster vorbei und faelscht
+    obendrein den Rohstempel, der als Anwesenheitsnachweis gilt."""
+    test_user.scheduled_start_monday = time(8, 0)
+    test_user.scheduled_end_monday = time(17, 0)
+    db.commit()
+
+    manipuliert = [ImportedEntry(
+        date=date(2026, 1, 12), start_time=time(6, 0), end_time=time(16, 0),
+        break_minutes=30, note=None, has_conflict=False, arbzg_warnings=[],
+        raw_start_time=None, raw_end_time=None,
+    )]
+    execute_import(
+        test_user.id, manipuliert, overwrite=False, db=db,
+        changed_by_id=test_admin.id, filename="manipuliert.xls",
+        tenant_id=DEFAULT_TENANT_ID,
+    )
+    db_entry = db.query(TimeEntry).filter(TimeEntry.user_id == test_user.id).one()
+    assert db_entry.start_time == time(7, 45), f"nicht gekappt: {db_entry.start_time}"
+    assert db_entry.raw_start_time == time(6, 0), f"Rohstempel falsch: {db_entry.raw_start_time}"
+
+
+def test_execute_import_ist_idempotent_zur_vorschau(db, test_user, test_admin):
+    """Gegenprobe: die unveraenderte Vorschau darf durch die zweite Kappung nicht
+    ihren Rohstempel verlieren (die Vorschau liefert bereits gekappte Zeiten)."""
+    test_user.scheduled_start_monday = time(8, 0)
+    test_user.scheduled_end_monday = time(17, 0)
+    db.commit()
+
+    rows = [
+        ["Datum", "Tag", "Total", "Ein", "Aus", "Tagesnotiz"],
+        _make_data_row(_dt(2026, 1, 12, 7, 0), _dt(2026, 1, 12, 16, 0)),
+    ]
+    entries = parse_xls(_make_xls_bytes(rows), test_user.id, db)
+    execute_import(
+        test_user.id, entries, overwrite=False, db=db,
+        changed_by_id=test_admin.id, filename="test.xls",
+        tenant_id=DEFAULT_TENANT_ID,
+    )
+    db_entry = db.query(TimeEntry).filter(TimeEntry.user_id == test_user.id).one()
+    assert db_entry.start_time == time(7, 45)
+    assert db_entry.raw_start_time == time(7, 0)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,11 @@ services:
       ACCESS_TOKEN_EXPIRE_MINUTES: ${ACCESS_TOKEN_EXPIRE_MINUTES:-30}
       REFRESH_TOKEN_EXPIRE_DAYS: ${REFRESH_TOKEN_EXPIRE_DAYS:-7}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost,http://localhost:5173}
+      # Release-Review 1.19.1: ALLOWED_HOSTS stand in .env.example und in der
+      # Sicherheitsdoku, wurde aber nie durchgereicht — im Docker-Betrieb blieb
+      # der Host-Header-Schutz (TrustedHostMiddleware) damit wirkungslos, egal
+      # was in der .env stand. Default '*' haelt Bestandsinstallationen gleich.
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-*}
       LOGIN_RATE_LIMIT: ${LOGIN_RATE_LIMIT:-5/minute}
       REFRESH_RATE_LIMIT: ${REFRESH_RATE_LIMIT:-10/minute}
       DATA_EXPORT_RATE_LIMIT: ${DATA_EXPORT_RATE_LIMIT:-5/day}

--- a/docs/handbuch/HANDBUCH-ADMIN.md
+++ b/docs/handbuch/HANDBUCH-ADMIN.md
@@ -548,7 +548,7 @@ Unter **Import** übernehmen Sie historische **Zeiteinträge** aus einer **TimeR
 **Vorgehensweise (Assistent in drei Schritten):**
 
 1. **Hochladen:** Wählen Sie den/die **Mitarbeiter:in** aus, dem/der die Einträge zugeordnet werden, und laden Sie die `.xls`-Datei hoch (Drag & Drop oder Klick). Klicken Sie auf **„Datei analysieren"**.
-2. **Vorschau:** Das System zeigt alle gefundenen Einträge in einer Tabelle mit Datum, Von/Bis, Pause und Netto-Stunden. **Konflikte** (bereits vorhandene Einträge am selben Tag) werden rot, **ArbZG-Warnungen** (z. B. Ruhezeit, Höchstarbeitszeit) gelb markiert. Über die Option **„Konflikte überschreiben"** entscheiden Sie, ob vorhandene Einträge ersetzt werden – andernfalls werden sie übersprungen. Klicken Sie auf **„Import bestätigen"**.
+2. **Vorschau:** Das System zeigt alle gefundenen Einträge in einer Tabelle mit Datum, Von/Bis, Pause und Netto-Stunden. **Konflikte** (bereits vorhandene Einträge am selben Tag) werden rot, **Hinweise** gelb markiert — das sind ArbZG-Warnungen (z. B. Ruhezeit, Höchstarbeitszeit) und, wenn ein Arbeitszeit-Fenster hinterlegt ist, die Kappung der importierten Zeit auf dieses Fenster. Den genauen Text zeigt das Zeilen-Symbol als Kurzinfo. Über die Option **„Konflikte überschreiben"** entscheiden Sie, ob vorhandene Einträge ersetzt werden – andernfalls werden sie übersprungen. Klicken Sie auf **„Import bestätigen"**.
 3. **Ergebnis:** Sie sehen, wie viele Einträge importiert, überschrieben oder übersprungen wurden sowie die ArbZG-Warnungen. Der Import wird im **Änderungsprotokoll** dokumentiert.
 
 ---

--- a/docs/handbuch/HANDBUCH-MITARBEITER.md
+++ b/docs/handbuch/HANDBUCH-MITARBEITER.md
@@ -190,6 +190,7 @@ Manche Praxen hinterlegen für einzelne Wochentage **feste Soll-Arbeitszeiten** 
 - **Zu früh eingestempelt:** Stempeln Sie deutlich **vor Ihrem Soll-Beginn** ein, wird die Zeit davor nicht als Arbeitszeit angerechnet. Ein kleiner **Puffer** (Standard 15 Minuten) ist erlaubt. Sie sehen dann den Hinweis: *„Du hast vor deinem Soll-Beginn eingestempelt – die Anrechnung beginnt ab dem frühestmöglichen Zeitpunkt."*
 - **Zu spät ausgestempelt:** Bleiben Sie nach Ihrem **Soll-Ende** noch deutlich länger (über den Puffer hinaus), wird die Zeit danach ebenfalls nicht mitgezählt.
 - In der Eintragsliste erkennen Sie das an einer kleinen Zusatzzeile unter der Uhrzeit, z. B. *„gestempelt 07:30 · angerechnet ab 07:45"*.
+- **Beim Ausstempeln und beim Speichern eines eigenen Eintrags** erscheint ein Hinweis mit den konkreten Zeiten, sobald gekappt wurde (z. B. *„… gekappt (Beginn 07:00 → 07:45; Puffer 15 Minuten)"*). Der Eintrag wird dabei **trotzdem gespeichert** — der Hinweis blockiert nichts.
 
 > **Ihre echte Stempelzeit geht nicht verloren:** Der Zeitpunkt, zu dem Sie tatsächlich gestempelt haben, bleibt immer gespeichert (gesetzlich vorgeschrieben, § 16 ArbZG). Für Ihr Stundenkonto wird nur die **angerechnete** Zeit verwendet.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "praxiszeit-frontend",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "praxiszeit-frontend",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2142,25 +2142,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -4286,9 +4300,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4322,9 +4336,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -4342,11 +4356,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4422,9 +4436,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001770",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
-      "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -4858,9 +4872,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.302",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "version": "1.5.422",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+      "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7118,11 +7132,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -8781,9 +8798,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praxiszeit-frontend",
   "private": true,
-  "version": "1.19.0",
+  "version": "1.19.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/public/help/HANDBUCH-ADMIN.md
+++ b/frontend/public/help/HANDBUCH-ADMIN.md
@@ -548,7 +548,7 @@ Unter **Import** übernehmen Sie historische **Zeiteinträge** aus einer **TimeR
 **Vorgehensweise (Assistent in drei Schritten):**
 
 1. **Hochladen:** Wählen Sie den/die **Mitarbeiter:in** aus, dem/der die Einträge zugeordnet werden, und laden Sie die `.xls`-Datei hoch (Drag & Drop oder Klick). Klicken Sie auf **„Datei analysieren"**.
-2. **Vorschau:** Das System zeigt alle gefundenen Einträge in einer Tabelle mit Datum, Von/Bis, Pause und Netto-Stunden. **Konflikte** (bereits vorhandene Einträge am selben Tag) werden rot, **ArbZG-Warnungen** (z. B. Ruhezeit, Höchstarbeitszeit) gelb markiert. Über die Option **„Konflikte überschreiben"** entscheiden Sie, ob vorhandene Einträge ersetzt werden – andernfalls werden sie übersprungen. Klicken Sie auf **„Import bestätigen"**.
+2. **Vorschau:** Das System zeigt alle gefundenen Einträge in einer Tabelle mit Datum, Von/Bis, Pause und Netto-Stunden. **Konflikte** (bereits vorhandene Einträge am selben Tag) werden rot, **Hinweise** gelb markiert — das sind ArbZG-Warnungen (z. B. Ruhezeit, Höchstarbeitszeit) und, wenn ein Arbeitszeit-Fenster hinterlegt ist, die Kappung der importierten Zeit auf dieses Fenster. Den genauen Text zeigt das Zeilen-Symbol als Kurzinfo. Über die Option **„Konflikte überschreiben"** entscheiden Sie, ob vorhandene Einträge ersetzt werden – andernfalls werden sie übersprungen. Klicken Sie auf **„Import bestätigen"**.
 3. **Ergebnis:** Sie sehen, wie viele Einträge importiert, überschrieben oder übersprungen wurden sowie die ArbZG-Warnungen. Der Import wird im **Änderungsprotokoll** dokumentiert.
 
 ---

--- a/frontend/public/help/HANDBUCH-MITARBEITER.md
+++ b/frontend/public/help/HANDBUCH-MITARBEITER.md
@@ -190,6 +190,7 @@ Manche Praxen hinterlegen für einzelne Wochentage **feste Soll-Arbeitszeiten** 
 - **Zu früh eingestempelt:** Stempeln Sie deutlich **vor Ihrem Soll-Beginn** ein, wird die Zeit davor nicht als Arbeitszeit angerechnet. Ein kleiner **Puffer** (Standard 15 Minuten) ist erlaubt. Sie sehen dann den Hinweis: *„Du hast vor deinem Soll-Beginn eingestempelt – die Anrechnung beginnt ab dem frühestmöglichen Zeitpunkt."*
 - **Zu spät ausgestempelt:** Bleiben Sie nach Ihrem **Soll-Ende** noch deutlich länger (über den Puffer hinaus), wird die Zeit danach ebenfalls nicht mitgezählt.
 - In der Eintragsliste erkennen Sie das an einer kleinen Zusatzzeile unter der Uhrzeit, z. B. *„gestempelt 07:30 · angerechnet ab 07:45"*.
+- **Beim Ausstempeln und beim Speichern eines eigenen Eintrags** erscheint ein Hinweis mit den konkreten Zeiten, sobald gekappt wurde (z. B. *„… gekappt (Beginn 07:00 → 07:45; Puffer 15 Minuten)"*). Der Eintrag wird dabei **trotzdem gespeichert** — der Hinweis blockiert nichts.
 
 > **Ihre echte Stempelzeit geht nicht verloren:** Der Zeitpunkt, zu dem Sie tatsächlich gestempelt haben, bleibt immer gespeichert (gesetzlich vorgeschrieben, § 16 ArbZG). Für Ihr Stundenkonto wird nur die **angerechnete** Zeit verwendet.
 

--- a/frontend/src/components/DocViewer.tsx
+++ b/frontend/src/components/DocViewer.tsx
@@ -317,6 +317,7 @@ export const handbuchMitarbeiterSections: AccordionItem[] = [
       <div className="space-y-2">
         <p>Hat Ihre Praxis für einen Wochentag eine <strong>Soll-Arbeitszeit</strong> hinterlegt, wird Zeit deutlich vor dem Soll-Beginn bzw. nach dem Soll-Ende <strong>nicht angerechnet</strong>. Ein kleiner Puffer (Standard 15 Min.) ist erlaubt.</p>
         <p>Stempeln Sie z. B. zu früh ein, sehen Sie den Hinweis: <em>„Du hast vor deinem Soll-Beginn eingestempelt – die Anrechnung beginnt ab dem frühestmöglichen Zeitpunkt."</em> In der Eintragsliste steht dann z. B. <em>„gestempelt 07:30 · angerechnet ab 07:45"</em>.</p>
+        <p>Beim <strong>Ausstempeln</strong> und beim Speichern eines eigenen Eintrags erscheint zusätzlich ein Hinweis mit den konkreten Zeiten, sobald gekappt wurde (z. B. <em>„… gekappt (Beginn 07:00 → 07:45; Puffer 15 Minuten)"</em>). Der Eintrag wird trotzdem gespeichert — der Hinweis blockiert nichts.</p>
         <p className="text-gray-700">Ihre <strong>echte Stempelzeit geht nicht verloren</strong> (gesetzlich vorgeschrieben, §16 ArbZG) – fürs Stundenkonto zählt nur die angerechnete Zeit.</p>
       </div>
     ),

--- a/frontend/src/components/MonthlyJournal.tsx
+++ b/frontend/src/components/MonthlyJournal.tsx
@@ -290,12 +290,17 @@ export default function MonthlyJournal({ userId, isAdminView }: MonthlyJournalPr
           setSaving(false);
           return;
         }
-        await apiClient.post(`/admin/users/${userId}/time-entries`, {
+        // Release-Review 1.19.1: Antwort auswerten wie im Bearbeiten-Pfad
+        // (handleAdminSave). Vorher meldete dieselbe Kappung auf demselben
+        // Bildschirm je nach Aktion mal etwas und mal nichts: ein NEUER Eintrag
+        // wurde stumm gekappt, erst die spätere Korrektur sagte es.
+        const res = await apiClient.post(`/admin/users/${userId}/time-entries`, {
           date: dateStr,
           start_time: editState.startTime,
           end_time: editState.endTime,
           break_minutes: Math.min(parseInt(editState.breakMinutes, 10) || 0, 480),
         });
+        showArbzgWarnings(toast, res.data?.warnings);
       } else {
         const hasExistingEntries = day && day.time_entries.length > 0;
         const res = await apiClient.post('/absences', {

--- a/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/frontend/src/pages/admin/AdminDashboard.tsx
@@ -13,6 +13,7 @@ import { getErrorMessage } from '../../utils/errorMessage';
 import { formatHoursHM, parseHours, formatClockTime, formatWeeklyHoursChanges } from '../../utils/formatters';
 import type { WeeklyHoursChangeInPeriod } from '../../utils/formatters';
 import { submitWithBreakWaiver } from '../../utils/breakWaiverRetry';
+import { showArbzgWarnings } from '../../utils/arbzgWarnings';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import UpdateBanner from '../../components/UpdateBanner';
 // Geteilt mit dem Änderungsprotokoll (`admin/AuditLog.tsx`) — dieselben
@@ -365,14 +366,20 @@ export default function AdminDashboard() {
           break_minutes: entryForm.break_minutes,
           note: entryForm.note,
         };
-        await submitWithBreakWaiver(async (extra) => {
+        // Release-Review 1.19.1: die Antwort BINDEN. Der Callback gab bisher
+        // nichts zurück, und der äußere Aufruf wertete nichts aus — die weichen
+        // Warnungen dieser beiden Endpunkte (§3-Tagesgrenze, §6-Nachtarbeit,
+        // dokumentierte §4-Ausnahme und seit #462 die Fenster-Kappung) wurden
+        // erzeugt, ausgeliefert und im Browser weggeworfen. Genau auf dieser
+        // Fläche hatte der Melder die stille Änderung bemerkt.
+        const res = await submitWithBreakWaiver(async (extra) => {
           if (editingEntryId) {
-            await apiClient.put(`/admin/time-entries/${editingEntryId}`, { ...base, ...extra });
-          } else {
-            await apiClient.post(`/admin/users/${selectedEmployee.user_id}/time-entries`, { ...base, ...extra });
+            return apiClient.put(`/admin/time-entries/${editingEntryId}`, { ...base, ...extra });
           }
+          return apiClient.post(`/admin/users/${selectedEmployee.user_id}/time-entries`, { ...base, ...extra });
         });
         toast.success(editingEntryId ? 'Eintrag aktualisiert' : 'Eintrag erstellt');
+        showArbzgWarnings(toast, res?.data?.warnings);
       } else {
         // Absence entry (sick, training, overtime comp, other)
         await apiClient.post('/absences', {

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Konfiguration — Versionen der gebuendelten Binaries
 # =============================================================================
 
-APP_VERSION="1.19.0"
+APP_VERSION="1.19.1"
 PYTHON_VERSION="3.13.15"
 # python-build-standalone Release-Tag (Format: YYYYMMDD)
 # 20260825 buendelt CPython 3.13.15 mit OpenSSL 3.5.8, SQLite 3.53.1 und


### PR DESCRIPTION
Patch-Release. Kein Migrationsschritt (head bleibt `071_security_events`).

## Inhalt

**#462 abgeschlossen.** Der Hinweis bei einer Kappung auf das Arbeitszeit-Fenster erreicht jetzt alle Schreibwege (Ausstempeln, manuelles Anlegen/Bearbeiten in beiden Rollen, Genehmigung eines Änderungsantrags, Excel-Import), und der Rohstempel steht auch im Admin-Dashboard unter der Uhrzeit.

**Sieben Funde aus dem Release-Review** (5 Lanes, 20 Agenten, jeder Fund adversarisch gegengeprüft — 14 bestätigt, 1 widerlegt):

- **Rohstempel überlebt ein erneutes Speichern.** Das Formular füllt sich mit der angerechneten Zeit (07:45); wer nur Notiz oder Pause korrigierte, schickte sie zurück, und `clamp` sah darin eine neue Eingabe → `raw_start_time = None`. Der §16-Nachweis der Anwesenheit und die Grundlage der §5-Ruhezeitprüfung waren weg. `unclamp_input()` ist die eine Antwort für beide Bearbeiten-Pfade.
- **Warn-Maßstab korrigiert:** nicht „war ein Zeitfeld im Payload", sondern „hat sich die eingereichte Zeit geändert" — sonst meldete jede Notizkorrektur eine längst passierte Kappung erneut.
- **Import traut dem Aufrufer nicht mehr:** `/confirm` übernahm Zeiten und Rohstempel ungeprüft aus dem Body; gekappt wurde nur in der Vorschau.
- **Kollaps-Fall** (Eintrag ganz außerhalb des Fensters) sagte „Beginn 05:00 → 05:00" statt „0 Stunden angerechnet".
- **Weiche Warnungen erreichten das Admin-Dashboard nie** (Antwort wurde nicht ausgewertet) — betraf neben der Kappung auch §3, §6 und die dokumentierte §4-Ausnahme. Im Monatsjournal meldete der bearbeitete Eintrag, der neue nicht.
- **`ALLOWED_HOSTS` wirkte im Docker-Betrieb nicht** — dokumentiert, aber nie an den Container übergeben.
- Doku: XLS-Vorschau-Label, Mitarbeiter-Handbuch, In-App-Hilfe, Spiegel byte-identisch, CHANGELOG.

Bewusst offen (LOW, Altlast): die Sammel-Genehmigung von Änderungsanträgen trägt kein `warnings`-Feld.

## Prüfungen

- Backend 2206 passed / 68 skipped · Postgres-Integration 50 (RLS, Nebenläufigkeit, Mandantentrennung) · Frontend 377 · tsc + eslint sauber
- `validate-release`: 5/5 Distributionen (Ubuntu 22/24, Debian 12, Rocky 9, Arch), PostgreSQL 18.4
- Artefakte: 6/6, SHA256 geprüft; Windows-ZIP ohne `setup.exe`, PG-Installer-SHA = Pin 18.4, Bundle-Version 1.19.1, `.bat` CRLF
- Docker-Update lokal: 27 Tabellen inhaltsgleich, alembic head, echter Login über nginx, beide Fixes live nachgestellt
- Native: Erstinstallation (gebündeltes PG + Python) sowie Update 1.19.0 → 1.19.1 mit inhaltsgleicher Datenbank; auf 1.19.0 dieselbe Eingabe stumm gekappt, nach dem Update mit Hinweis
- Windows-11-Emulator läuft noch (Ergebnis wird nachgetragen); `.131` ist nicht erreichbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019618QdcojcuHyhTW8YQjAE
